### PR TITLE
Fix auth session bootstrap and origin handling

### DIFF
--- a/apps/api/src/lib/auth-origins.test.ts
+++ b/apps/api/src/lib/auth-origins.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getAppBaseUrl, getCorsOrigins, getTrustedOrigins } from './auth-origins.js';
+
+test('auth origin helpers merge defaults with configured origins', () => {
+  process.env['APP_BASE_URL'] = 'https://api.example.com';
+  process.env['TRUSTED_ORIGINS'] = 'https://app.example.com, https://admin.example.com';
+  process.env['CORS_ORIGIN'] = 'https://admin.example.com, https://marketing.example.com';
+
+  assert.equal(getAppBaseUrl(), 'https://api.example.com');
+  assert.deepEqual(getTrustedOrigins(), [
+    'http://localhost:4200',
+    'http://127.0.0.1:4200',
+    'https://app.example.com',
+    'https://admin.example.com',
+  ]);
+  assert.deepEqual(getCorsOrigins(), [
+    'http://localhost:4200',
+    'http://127.0.0.1:4200',
+    'https://app.example.com',
+    'https://admin.example.com',
+    'https://marketing.example.com',
+  ]);
+});

--- a/apps/api/src/lib/auth-origins.ts
+++ b/apps/api/src/lib/auth-origins.ts
@@ -1,0 +1,26 @@
+function parseOriginList(value: string | undefined) {
+    return value
+        ?.split(",")
+        .map((origin) => origin.trim())
+        .filter(Boolean) ?? [];
+}
+
+export function getAppBaseUrl() {
+    return process.env["APP_BASE_URL"] ?? "http://localhost:3000";
+}
+
+export function getTrustedOrigins() {
+    const configuredOrigins = parseOriginList(process.env["TRUSTED_ORIGINS"]);
+    const defaultOrigins = [
+        "http://localhost:4200",
+        "http://127.0.0.1:4200",
+    ];
+
+    return Array.from(new Set([...defaultOrigins, ...configuredOrigins]));
+}
+
+export function getCorsOrigins() {
+    const configuredOrigins = parseOriginList(process.env["CORS_ORIGIN"]);
+
+    return Array.from(new Set([...getTrustedOrigins(), ...configuredOrigins]));
+}

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -1,13 +1,30 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { db } from "../db/client.js";
+import { getAppBaseUrl, getTrustedOrigins } from "./auth-origins.js";
+
+const appBaseUrl = getAppBaseUrl();
+const trustedOrigins = getTrustedOrigins();
+const useSecureCookies =
+    process.env["NODE_ENV"] === "production" ||
+    appBaseUrl.startsWith("https://");
 
 export const auth = betterAuth({
+    baseURL: appBaseUrl,
+    trustedOrigins,
     database: drizzleAdapter(db, {
         provider: "sqlite",
     }),
     emailAndPassword: {
         enabled: true,
         requireEmailVerification: false,
+    },
+    advanced: {
+        defaultCookieAttributes: {
+            httpOnly: true,
+            sameSite: "lax",
+            secure: useSecureCookies,
+        },
+        useSecureCookies,
     },
 });

--- a/apps/api/src/plugins/cors.test.ts
+++ b/apps/api/src/plugins/cors.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import Fastify from 'fastify';
+import corsPlugin from './cors.js';
+
+test('cors plugin allows configured auth origins with credentials', async () => {
+  process.env['TRUSTED_ORIGINS'] = 'https://app.example.com';
+  process.env['CORS_ORIGIN'] = 'https://docs.example.com';
+
+  const app = Fastify();
+
+  await app.register(corsPlugin);
+
+  try {
+    const response = await app.inject({
+      method: 'OPTIONS',
+      url: '/auth/session',
+      headers: {
+        origin: 'https://app.example.com',
+        'access-control-request-method': 'GET',
+      },
+    });
+
+    assert.equal(response.statusCode, 204);
+    assert.equal(response.headers['access-control-allow-origin'], 'https://app.example.com');
+    assert.equal(response.headers['access-control-allow-credentials'], 'true');
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/api/src/plugins/cors.ts
+++ b/apps/api/src/plugins/cors.ts
@@ -1,16 +1,17 @@
 import cors from '@fastify/cors';
 import type { FastifyInstance } from 'fastify';
+import { getCorsOrigins } from '../lib/auth-origins.js';
 
 /**
  * CORS plugin — allows the Angular dev server (localhost:4200) in development
  * and the configured origin in production.
  */
 export default async function corsPlugin(fastify: FastifyInstance) {
-    const isProd = process.env['NODE_ENV'] === 'production';
-    const origin = process.env['CORS_ORIGIN'] ?? (isProd ? false : 'http://localhost:4200');
+    const origins = getCorsOrigins();
 
     await fastify.register(cors, {
-        origin,
+        origin: origins,
+        credentials: true,
         methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
     });
 }

--- a/apps/frontend/src/app/app.config.ts
+++ b/apps/frontend/src/app/app.config.ts
@@ -1,13 +1,22 @@
 import { provideHttpClient, withFetch, withInterceptors } from '@angular/common/http';
-import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { APP_INITIALIZER, ApplicationConfig, inject, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { routes } from './app.routes';
 import { apiPrefixInterceptor } from './core/interceptors/api-prefix.interceptor';
+import { AuthStateService } from './core/services/auth-state.service';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
     provideHttpClient(withFetch(), withInterceptors([apiPrefixInterceptor])),
+    {
+      provide: APP_INITIALIZER,
+      multi: true,
+      useFactory: () => {
+        const authState = inject(AuthStateService);
+        return () => authState.initialize();
+      },
+    },
   ]
 };

--- a/apps/frontend/src/app/core/guards/auth.guard.ts
+++ b/apps/frontend/src/app/core/guards/auth.guard.ts
@@ -1,17 +1,20 @@
 import { inject } from '@angular/core';
 import { Router, CanActivateFn } from '@angular/router';
-import { AuthService } from '@yotara/shared';
+import { AuthStateService } from '../services/auth-state.service';
 
 export const authGuard: CanActivateFn = async () => {
     const router = inject(Router);
+    const authState = inject(AuthStateService);
 
     try {
-        const session = await AuthService.getSession();
-        if (session?.data?.session) {
+        await authState.initialize();
+
+        if (authState.isAuthenticated()) {
             return true;
         }
     } catch (error) {
         console.error('Session validation error', error);
+        return router.parseUrl('/login');
     }
 
     return router.parseUrl('/login');

--- a/apps/frontend/src/app/core/services/auth-state.service.spec.ts
+++ b/apps/frontend/src/app/core/services/auth-state.service.spec.ts
@@ -1,0 +1,29 @@
+import { TestBed } from '@angular/core/testing';
+import { AuthService } from '@yotara/shared';
+import { AuthStateService } from './auth-state.service';
+
+describe('AuthStateService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('falls back to unauthenticated state when initial session refresh fails', async () => {
+    spyOn(console, 'error');
+    spyOn(AuthService, 'getSession').and.rejectWith(new Error('network down'));
+
+    const service = TestBed.inject(AuthStateService);
+
+    await expectAsync(service.initialize()).toBeResolvedTo(null);
+
+    expect(service.initialized()).toBeTrue();
+    expect(service.isAuthenticated()).toBeFalse();
+    expect(service.session()).toBeNull();
+    expect(service.user()).toBeNull();
+    expect(AuthService.getSession).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/app/core/services/auth-state.service.ts
+++ b/apps/frontend/src/app/core/services/auth-state.service.ts
@@ -1,0 +1,105 @@
+import { Injectable, computed, signal } from '@angular/core';
+import { AuthService } from '@yotara/shared';
+
+type SessionResponse = Awaited<ReturnType<typeof AuthService.getSession>>;
+type SessionData = NonNullable<SessionResponse['data']>;
+
+@Injectable({ providedIn: 'root' })
+export class AuthStateService {
+  private sessionState = signal<SessionData['session'] | null>(null);
+  private userState = signal<SessionData['user'] | null>(null);
+  private initializedState = signal(false);
+  private loadingState = signal(false);
+  private initPromise: Promise<SessionResponse> | null = null;
+
+  readonly session = this.sessionState.asReadonly();
+  readonly user = this.userState.asReadonly();
+  readonly initialized = this.initializedState.asReadonly();
+  readonly loading = this.loadingState.asReadonly();
+  readonly isAuthenticated = computed(() => !!this.sessionState());
+
+  async initialize() {
+    if (this.initializedState()) {
+      return;
+    }
+
+    if (this.initPromise) {
+      return this.initPromise;
+    }
+
+    this.initPromise = this.refreshSession().finally(() => {
+      this.initPromise = null;
+    });
+
+    try {
+      return await this.initPromise;
+    } catch (error) {
+      console.error('Initial session refresh failed', error);
+      this.sessionState.set(null);
+      this.userState.set(null);
+      return null;
+    }
+  }
+
+  async refreshSession() {
+    this.loadingState.set(true);
+
+    try {
+      const result = await AuthService.getSession();
+      this.applySessionResult(result);
+      return result;
+    } finally {
+      this.initializedState.set(true);
+      this.loadingState.set(false);
+    }
+  }
+
+  async signIn(email: string, password: string) {
+    this.loadingState.set(true);
+
+    try {
+      const result = await AuthService.signIn(email, password);
+      if (!result.error) {
+        await this.refreshSession();
+      }
+      return result;
+    } finally {
+      this.loadingState.set(false);
+    }
+  }
+
+  async signUp(email: string, password: string, name: string) {
+    this.loadingState.set(true);
+
+    try {
+      const result = await AuthService.signUp(email, password, name);
+      if (!result.error) {
+        await this.refreshSession();
+      }
+      return result;
+    } finally {
+      this.loadingState.set(false);
+    }
+  }
+
+  async signOut() {
+    this.loadingState.set(true);
+
+    try {
+      const result = await AuthService.signOut();
+      this.sessionState.set(null);
+      this.userState.set(null);
+      this.initializedState.set(true);
+      return result;
+    } finally {
+      this.loadingState.set(false);
+    }
+  }
+
+  private applySessionResult(result: SessionResponse | null | undefined) {
+    const session = result?.data?.session ?? null;
+    const user = result?.data?.user ?? null;
+    this.sessionState.set(session);
+    this.userState.set(user);
+  }
+}

--- a/apps/frontend/src/app/features/auth/login.component.ts
+++ b/apps/frontend/src/app/features/auth/login.component.ts
@@ -1,7 +1,7 @@
 import { Component, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { AuthService } from '@yotara/shared';
+import { AuthStateService } from '../../core/services/auth-state.service';
 
 @Component({
   selector: 'app-login',
@@ -342,7 +342,10 @@ export class LoginComponent {
     loading = signal(false);
     error = signal('');
 
-    constructor(private router: Router) { }
+    constructor(
+        private router: Router,
+        private authState: AuthStateService,
+    ) { }
 
     toggleMode() {
         this.isLogin.set(!this.isLogin());
@@ -438,9 +441,9 @@ export class LoginComponent {
         try {
             let res;
             if (this.isLogin()) {
-                res = await AuthService.signIn(this.email().trim(), this.password());
+                res = await this.authState.signIn(this.email().trim(), this.password());
             } else {
-                res = await AuthService.signUp(this.email().trim(), this.password(), this.name().trim());
+                res = await this.authState.signUp(this.email().trim(), this.password(), this.name().trim());
             }
 
             if (res.error) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,5 @@
 // ─── Primitives ─────────────────────────────────────────────────────────────
-export * from './auth.js';
+export * from './auth';
 
 export type Priority = 'low' | 'medium' | 'high';
 export type TaskStatus = 'inbox' | 'today' | 'upcoming' | 'done' | 'archived';


### PR DESCRIPTION
## Summary
- add an auth state service and app initialization path that tolerates session refresh failures
- align Better Auth trusted origins and Fastify CORS configuration, including credentialed requests
- add targeted API and frontend tests for origin handling and auth bootstrap fallback

## Testing
- pnpm --filter @yotara/api test
- pnpm --filter @yotara/frontend ng test --watch=false --browsers=ChromeHeadless --include='src/app/core/services/auth-state.service.spec.ts'
- pnpm --filter @yotara/frontend typecheck
- pnpm --filter @yotara/shared typecheck