### PR TITLE
Improve auth flow and SQLite developer tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ package-lock.json
 apps/api/data/*.db
 apps/api/data/*.db-*
 apps/api/.env
+packages/shared/tsconfig.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ Configure the API server using these environment variables:
 DATABASE_URL=./data/yotara.db PORT=3001 HOST=localhost pnpm dev:api
 ```
 
+On first startup, the API will create the SQLite file and initialize the required auth and task tables automatically.
+
 ### Angular Frontend (`apps/frontend/`)
 
 Configuration is handled in `src/environments/`:

--- a/apps/api/src/db/client.ts
+++ b/apps/api/src/db/client.ts
@@ -5,6 +5,76 @@ import { drizzle } from 'drizzle-orm/better-sqlite3';
 import * as schema from './schema.js';
 
 const DEFAULT_DATABASE_URL = './data/yotara.db';
+const SQLITE_BOOTSTRAP_SQL = `
+  PRAGMA foreign_keys = ON;
+
+  CREATE TABLE IF NOT EXISTS user (
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    email TEXT NOT NULL,
+    emailVerified INTEGER NOT NULL,
+    image TEXT,
+    createdAt INTEGER NOT NULL,
+    updatedAt INTEGER NOT NULL
+  );
+
+  CREATE UNIQUE INDEX IF NOT EXISTS user_email_unique ON user (email);
+
+  CREATE TABLE IF NOT EXISTS session (
+    id TEXT PRIMARY KEY NOT NULL,
+    userId TEXT NOT NULL,
+    token TEXT NOT NULL,
+    expiresAt INTEGER NOT NULL,
+    ipAddress TEXT,
+    userAgent TEXT,
+    createdAt INTEGER NOT NULL,
+    updatedAt INTEGER NOT NULL,
+    FOREIGN KEY (userId) REFERENCES user(id) ON DELETE NO ACTION
+  );
+
+  CREATE TABLE IF NOT EXISTS account (
+    id TEXT PRIMARY KEY NOT NULL,
+    userId TEXT NOT NULL,
+    accountId TEXT NOT NULL,
+    providerId TEXT NOT NULL,
+    userIdToken TEXT,
+    userRefreshToken TEXT,
+    accessToken TEXT,
+    refreshToken TEXT,
+    accessTokenExpiresAt INTEGER,
+    refreshTokenExpiresAt INTEGER,
+    scope TEXT,
+    idToken TEXT,
+    password TEXT,
+    createdAt INTEGER NOT NULL,
+    updatedAt INTEGER NOT NULL,
+    FOREIGN KEY (userId) REFERENCES user(id) ON DELETE NO ACTION
+  );
+
+  CREATE TABLE IF NOT EXISTS verification (
+    id TEXT PRIMARY KEY NOT NULL,
+    identifier TEXT NOT NULL,
+    value TEXT NOT NULL,
+    expiresAt INTEGER NOT NULL,
+    createdAt INTEGER,
+    updatedAt INTEGER
+  );
+
+  CREATE TABLE IF NOT EXISTS tasks (
+    id TEXT PRIMARY KEY NOT NULL,
+    user_id TEXT,
+    title TEXT NOT NULL,
+    description TEXT,
+    status TEXT NOT NULL DEFAULT 'inbox',
+    priority TEXT NOT NULL DEFAULT 'medium',
+    completed INTEGER NOT NULL DEFAULT 0,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    due_date TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE SET NULL
+  );
+`;
 
 function resolveDbPath(databaseUrl: string): string {
   if (databaseUrl === ':memory:') {
@@ -22,13 +92,17 @@ function ensureDatabasePath(databasePath: string): void {
   mkdirSync(dirname(databasePath), { recursive: true });
 }
 
+function ensureSqliteSchema(sqlite: Database.Database): void {
+  sqlite.exec(SQLITE_BOOTSTRAP_SQL);
+}
+
 export function createDbClient(databaseUrl = process.env['DATABASE_URL'] ?? DEFAULT_DATABASE_URL) {
   const databasePath = resolveDbPath(databaseUrl);
   ensureDatabasePath(databasePath);
 
   const sqlite = new Database(databasePath);
+  ensureSqliteSchema(sqlite);
   sqlite.pragma('journal_mode = WAL');
-
 
   const db = drizzle(sqlite, { schema });
   return { db, sqlite, databasePath };

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { db } from "../db/client.js";
+import { accounts, sessions, users, verifications } from "../db/schema.js";
 import { getAppBaseUrl, getTrustedOrigins } from "./auth-origins.js";
 
 const appBaseUrl = getAppBaseUrl();
@@ -11,9 +12,16 @@ const useSecureCookies =
 
 export const auth = betterAuth({
     baseURL: appBaseUrl,
+    basePath: "/auth",
     trustedOrigins,
     database: drizzleAdapter(db, {
         provider: "sqlite",
+        schema: {
+            user: users,
+            session: sessions,
+            account: accounts,
+            verification: verifications,
+        },
     }),
     emailAndPassword: {
         enabled: true,

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -1,0 +1,143 @@
+import { randomUUID } from 'node:crypto';
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const TEST_EMAIL = 'register-login@example.com';
+const TEST_PASSWORD = 'Password123!';
+const TEST_NAME = 'Register Login User';
+const TEST_ORIGIN = 'http://localhost:4200';
+
+async function createTestApp() {
+  const dbFile = join(tmpdir(), `yotara-auth-test-${randomUUID()}.db`);
+  process.env['DATABASE_URL'] = dbFile;
+  process.env['BETTER_AUTH_SECRET'] = 'test-secret-with-enough-entropy-1234567890';
+  process.env['APP_BASE_URL'] = 'http://localhost:3000';
+
+  const { buildApp } = await import('../server.js');
+  const app = await buildApp();
+
+  return {
+    app,
+    async cleanup() {
+      await app.close();
+      rmSync(dbFile, { force: true });
+      delete process.env['DATABASE_URL'];
+      delete process.env['BETTER_AUTH_SECRET'];
+      delete process.env['APP_BASE_URL'];
+    },
+  };
+}
+
+function readCookie(response: { headers: Record<string, unknown> }) {
+  const cookie = response.headers['set-cookie'];
+  assert.ok(cookie);
+  return Array.isArray(cookie) ? cookie[0] : cookie;
+}
+
+test('auth routes register and login with email/password', async () => {
+  const ctx = await createTestApp();
+
+  try {
+    const registerResponse = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/sign-up/email',
+      headers: {
+        origin: TEST_ORIGIN,
+      },
+      payload: {
+        email: TEST_EMAIL,
+        password: TEST_PASSWORD,
+        name: TEST_NAME,
+      },
+    });
+
+    assert.equal(registerResponse.statusCode, 200);
+    assert.equal(registerResponse.headers['access-control-allow-origin'], TEST_ORIGIN);
+    assert.equal(registerResponse.headers['access-control-allow-credentials'], 'true');
+    const registerBody = registerResponse.json();
+    assert.equal(registerBody.user.email, TEST_EMAIL);
+    assert.equal(registerBody.user.name, TEST_NAME);
+    const registerCookie = readCookie(registerResponse);
+
+    const meAfterRegister = await ctx.app.inject({
+      method: 'GET',
+      url: '/me',
+      headers: {
+        origin: TEST_ORIGIN,
+        cookie: registerCookie,
+      },
+    });
+
+    assert.equal(meAfterRegister.statusCode, 200);
+    assert.equal(meAfterRegister.json().user.email, TEST_EMAIL);
+
+    const signOutResponse = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/sign-out',
+      headers: {
+        cookie: registerCookie,
+        origin: TEST_ORIGIN,
+      },
+    });
+
+    assert.equal(signOutResponse.statusCode, 200);
+
+    const loginResponse = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/sign-in/email',
+      headers: {
+        origin: TEST_ORIGIN,
+      },
+      payload: {
+        email: TEST_EMAIL,
+        password: TEST_PASSWORD,
+      },
+    });
+
+    assert.equal(loginResponse.statusCode, 200);
+    assert.equal(loginResponse.headers['access-control-allow-origin'], TEST_ORIGIN);
+    assert.equal(loginResponse.headers['access-control-allow-credentials'], 'true');
+    const loginBody = loginResponse.json();
+    assert.equal(loginBody.user.email, TEST_EMAIL);
+    const loginCookie = readCookie(loginResponse);
+
+    const meAfterLogin = await ctx.app.inject({
+      method: 'GET',
+      url: '/me',
+      headers: {
+        origin: TEST_ORIGIN,
+        cookie: loginCookie,
+      },
+    });
+
+    assert.equal(meAfterLogin.statusCode, 200);
+    assert.equal(meAfterLogin.json().user.email, TEST_EMAIL);
+  } finally {
+    await ctx.cleanup();
+  }
+});
+
+test('auth routes answer CORS preflight for sign-up', async () => {
+  const ctx = await createTestApp();
+
+  try {
+    const response = await ctx.app.inject({
+      method: 'OPTIONS',
+      url: '/auth/sign-up/email',
+      headers: {
+        origin: TEST_ORIGIN,
+        'access-control-request-method': 'POST',
+        'access-control-request-headers': 'content-type',
+      },
+    });
+
+    assert.equal(response.statusCode, 204);
+    assert.equal(response.headers['access-control-allow-origin'], TEST_ORIGIN);
+    assert.equal(response.headers['access-control-allow-credentials'], 'true');
+  } finally {
+    await ctx.cleanup();
+  }
+});

--- a/apps/api/src/routes/tasks.test.ts
+++ b/apps/api/src/routes/tasks.test.ts
@@ -5,48 +5,64 @@ import { tmpdir } from 'node:os';
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-test('tasks routes create and list tasks', async () => {
+async function createAuthedApp() {
   const dbFile = join(tmpdir(), `yotara-test-${randomUUID()}.db`);
   process.env['DATABASE_URL'] = dbFile;
-  process.env['BETTER_AUTH_SECRET'] = 'test-secret';
-
-  const { sqlite } = await import('../db/client.js');
-
-  // Initialize schema for tests
-  sqlite.exec(`
-    CREATE TABLE IF NOT EXISTS user (
-      id TEXT PRIMARY KEY,
-      name TEXT NOT NULL,
-      email TEXT NOT NULL UNIQUE,
-      emailVerified INTEGER NOT NULL,
-      image TEXT,
-      createdAt INTEGER NOT NULL,
-      updatedAt INTEGER NOT NULL
-    );
-
-    CREATE TABLE IF NOT EXISTS tasks (
-      id TEXT PRIMARY KEY,
-      user_id TEXT,
-      title TEXT NOT NULL,
-      description TEXT,
-      status TEXT NOT NULL DEFAULT 'inbox',
-      priority TEXT NOT NULL DEFAULT 'medium',
-      completed INTEGER NOT NULL DEFAULT 0,
-      sort_order INTEGER NOT NULL DEFAULT 0,
-      due_date TEXT,
-      created_at TEXT NOT NULL,
-      updated_at TEXT NOT NULL,
-      FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE SET NULL
-    );
-  `);
+  process.env['BETTER_AUTH_SECRET'] = 'test-secret-with-enough-entropy-1234567890';
+  process.env['APP_BASE_URL'] = 'http://localhost:3000';
 
   const { buildApp } = await import('../server.js');
   const app = await buildApp();
 
+  return {
+    app,
+    cleanup() {
+      return Promise.resolve()
+        .then(() => app.close())
+        .finally(() => {
+          rmSync(dbFile, { force: true });
+          delete process.env['DATABASE_URL'];
+          delete process.env['BETTER_AUTH_SECRET'];
+          delete process.env['APP_BASE_URL'];
+        });
+    },
+  };
+}
+
+async function signUpAndGetCookie(email: string) {
+  const { auth } = await import('../lib/auth.js');
+  const response = await auth.api.signUpEmail({
+    body: {
+      email,
+      password: 'Password123!',
+      name: email.split('@')[0],
+    },
+    asResponse: true,
+  });
+
+  assert.equal(response.status, 200);
+
+  const cookie = response.headers.get('set-cookie');
+  assert.ok(cookie);
+  return cookie;
+}
+
+test('tasks routes require auth and scope data to the current user', async () => {
+  const ctx = await createAuthedApp();
+
   try {
-    const createResponse = await app.inject({
+    const unauthorized = await ctx.app.inject({ method: 'GET', url: '/tasks' });
+    assert.equal(unauthorized.statusCode, 401);
+
+    const firstUserCookie = await signUpAndGetCookie(`first-${randomUUID()}@example.com`);
+    const secondUserCookie = await signUpAndGetCookie(`second-${randomUUID()}@example.com`);
+
+    const createResponse = await ctx.app.inject({
       method: 'POST',
       url: '/tasks',
+      headers: {
+        cookie: firstUserCookie,
+      },
       payload: {
         title: 'Write first task',
         priority: 'high',
@@ -59,15 +75,35 @@ test('tasks routes create and list tasks', async () => {
     assert.equal(created.title, 'Write first task');
     assert.equal(created.completed, false);
 
-    const listResponse = await app.inject({ method: 'GET', url: '/tasks' });
-    assert.equal(listResponse.statusCode, 200);
+    const ownerList = await ctx.app.inject({
+      method: 'GET',
+      url: '/tasks',
+      headers: {
+        cookie: firstUserCookie,
+      },
+    });
+    assert.equal(ownerList.statusCode, 200);
+    assert.equal(ownerList.json().length, 1);
 
-    const tasks = listResponse.json();
-    assert.equal(Array.isArray(tasks), true);
-    assert.equal(tasks.length, 1);
-    assert.equal(tasks[0].title, 'Write first task');
+    const otherUserList = await ctx.app.inject({
+      method: 'GET',
+      url: '/tasks',
+      headers: {
+        cookie: secondUserCookie,
+      },
+    });
+    assert.equal(otherUserList.statusCode, 200);
+    assert.equal(otherUserList.json().length, 0);
+
+    const otherUserFetch = await ctx.app.inject({
+      method: 'GET',
+      url: `/tasks/${created.id}`,
+      headers: {
+        cookie: secondUserCookie,
+      },
+    });
+    assert.equal(otherUserFetch.statusCode, 404);
   } finally {
-    await app.close();
-    rmSync(dbFile, { force: true });
+    await ctx.cleanup();
   }
 });

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -1,7 +1,9 @@
 import { randomUUID } from 'node:crypto';
-import { asc, eq } from 'drizzle-orm';
-import type { FastifyInstance } from 'fastify';
+import { and, asc, eq } from 'drizzle-orm';
+import type { FastifyInstance, FastifyRequest } from 'fastify';
 import type { CreateTaskDto, Task, TaskStatus, UpdateTaskDto } from '@yotara/shared';
+import { auth } from '../lib/auth.js';
+import { fromNodeHeaders } from 'better-auth/node';
 import { db } from '../db/client.js';
 import { tasks } from '../db/schema.js';
 
@@ -45,17 +47,43 @@ function normalizeStatusOnCompletion(currentStatus: TaskStatus, completed: boole
   return currentStatus;
 }
 
+async function requireUserId(request: FastifyRequest) {
+  const session = await auth.api.getSession({
+    headers: fromNodeHeaders(request.headers),
+  });
+
+  return session?.user.id ?? null;
+}
+
 /**
  * Tasks routes backed by SQLite via Drizzle.
  */
 export default async function taskRoutes(fastify: FastifyInstance) {
-  fastify.get<{ Reply: Task[] }>('/tasks', async () => {
-    const rows = await db.select().from(tasks).orderBy(asc(tasks.order), asc(tasks.createdAt));
+  fastify.get<{ Reply: Task[] | { message: string } }>('/tasks', async (request, reply) => {
+    const userId = await requireUserId(request);
+    if (!userId) {
+      return reply.code(401).send({ message: 'Unauthorized' });
+    }
+
+    const rows = await db
+      .select()
+      .from(tasks)
+      .where(eq(tasks.userId, userId))
+      .orderBy(asc(tasks.order), asc(tasks.createdAt));
     return rows.map(toTask);
   });
 
   fastify.get<{ Params: { id: string }; Reply: Task | { message: string } }>('/tasks/:id', async (request, reply) => {
-    const [row] = await db.select().from(tasks).where(eq(tasks.id, request.params.id)).limit(1);
+    const userId = await requireUserId(request);
+    if (!userId) {
+      return reply.code(401).send({ message: 'Unauthorized' });
+    }
+
+    const [row] = await db
+      .select()
+      .from(tasks)
+      .where(and(eq(tasks.id, request.params.id), eq(tasks.userId, userId)))
+      .limit(1);
 
     if (!row) {
       return reply.code(404).send({ message: 'Task not found' });
@@ -65,6 +93,11 @@ export default async function taskRoutes(fastify: FastifyInstance) {
   });
 
   fastify.post<{ Body: CreateTaskDto; Reply: Task | { message: string } }>('/tasks', async (request, reply) => {
+    const userId = await requireUserId(request);
+    if (!userId) {
+      return reply.code(401).send({ message: 'Unauthorized' });
+    }
+
     const payload = normalizeCreatePayload(request.body);
 
     if (!payload.title) {
@@ -76,6 +109,7 @@ export default async function taskRoutes(fastify: FastifyInstance) {
 
     await db.insert(tasks).values({
       id,
+      userId,
       title: payload.title,
       description: payload.description,
       status: payload.status,
@@ -87,7 +121,11 @@ export default async function taskRoutes(fastify: FastifyInstance) {
       updatedAt: now,
     });
 
-    const [created] = await db.select().from(tasks).where(eq(tasks.id, id)).limit(1);
+    const [created] = await db
+      .select()
+      .from(tasks)
+      .where(and(eq(tasks.id, id), eq(tasks.userId, userId)))
+      .limit(1);
     if (!created) {
       return reply.code(500).send({ message: 'Failed to create task' });
     }
@@ -98,7 +136,16 @@ export default async function taskRoutes(fastify: FastifyInstance) {
   fastify.patch<{ Params: { id: string }; Body: UpdateTaskDto; Reply: Task | { message: string } }>(
     '/tasks/:id',
     async (request, reply) => {
-      const [existing] = await db.select().from(tasks).where(eq(tasks.id, request.params.id)).limit(1);
+      const userId = await requireUserId(request);
+      if (!userId) {
+        return reply.code(401).send({ message: 'Unauthorized' });
+      }
+
+      const [existing] = await db
+        .select()
+        .from(tasks)
+        .where(and(eq(tasks.id, request.params.id), eq(tasks.userId, userId)))
+        .limit(1);
 
       if (!existing) {
         return reply.code(404).send({ message: 'Task not found' });
@@ -122,7 +169,11 @@ export default async function taskRoutes(fastify: FastifyInstance) {
         })
         .where(eq(tasks.id, request.params.id));
 
-      const [updated] = await db.select().from(tasks).where(eq(tasks.id, request.params.id)).limit(1);
+      const [updated] = await db
+        .select()
+        .from(tasks)
+        .where(and(eq(tasks.id, request.params.id), eq(tasks.userId, userId)))
+        .limit(1);
       if (!updated) {
         return reply.code(500).send({ message: 'Failed to update task' });
       }
@@ -132,13 +183,17 @@ export default async function taskRoutes(fastify: FastifyInstance) {
   );
 
   fastify.delete<{ Params: { id: string }; Reply: { ok: true } | { message: string } }>('/tasks/:id', async (request, reply) => {
-    const existing = await db
-      .select({ id: tasks.id })
-      .from(tasks)
-      .where(eq(tasks.id, request.params.id))
-      .limit(1);
+    const userId = await requireUserId(request);
+    if (!userId) {
+      return reply.code(401).send({ message: 'Unauthorized' });
+    }
 
-    if (existing.length === 0) {
+    const [row] = await db
+      .select()
+      .from(tasks)
+      .where(and(eq(tasks.id, request.params.id), eq(tasks.userId, userId)))
+      .limit(1);
+    if (!row) {
       return reply.code(404).send({ message: 'Task not found' });
     }
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -4,7 +4,59 @@ import corsPlugin from './plugins/cors.js';
 import healthRoutes from './routes/health.js';
 import taskRoutes from './routes/tasks.js';
 import { auth } from './lib/auth.js';
-import { toNodeHandler, fromNodeHeaders } from 'better-auth/node';
+import { getCorsOrigins } from './lib/auth-origins.js';
+import { fromNodeHeaders } from 'better-auth/node';
+
+function toHeaders(source: Record<string, string | string[] | undefined>) {
+    const headers = new Headers();
+
+    for (const [key, value] of Object.entries(source)) {
+        if (value === undefined) {
+            continue;
+        }
+
+        if (Array.isArray(value)) {
+            for (const item of value) {
+                headers.append(key, item);
+            }
+            continue;
+        }
+
+        headers.set(key, value);
+    }
+
+    return headers;
+}
+
+function getRequestBody(method: string, body: unknown, headers: Headers) {
+    if (method === 'GET' || method === 'HEAD' || body == null) {
+        return undefined;
+    }
+
+    if (typeof body === 'string') {
+        return body;
+    }
+
+    if (body instanceof Uint8Array) {
+        return Buffer.from(body);
+    }
+
+    if (!headers.has('content-type')) {
+        headers.set('content-type', 'application/json');
+    }
+
+    return JSON.stringify(body);
+}
+
+function applyAuthCorsHeaders(reply: { header: (name: string, value: string | string[]) => unknown }, origin: string | undefined) {
+    if (!origin || !getCorsOrigins().includes(origin)) {
+        return;
+    }
+
+    reply.header('access-control-allow-origin', origin);
+    reply.header('access-control-allow-credentials', 'true');
+    reply.header('vary', 'Origin');
+}
 
 export async function buildApp() {
     const app = Fastify({ logger: true });
@@ -13,10 +65,51 @@ export async function buildApp() {
     await app.register(corsPlugin);
 
     // Register Better Auth handler
-    app.all("/auth/*", async (request, reply) => {
-        const authHandler = toNodeHandler(auth);
-        await authHandler(request.raw, reply.raw);
-        reply.hijack();
+    app.options("/auth/*", async (request, reply) => {
+        const origin = request.headers.origin;
+        if (origin && getCorsOrigins().includes(origin)) {
+            applyAuthCorsHeaders(reply, origin);
+            reply.header('access-control-allow-methods', 'GET,POST,PUT,PATCH,DELETE');
+
+            const requestedHeaders = request.headers['access-control-request-headers'];
+            if (requestedHeaders) {
+                reply.header('access-control-allow-headers', requestedHeaders);
+            }
+        }
+
+        return reply.code(204).send();
+    });
+
+    app.route({
+        method: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD'],
+        url: "/auth/*",
+        handler: async (request, reply) => {
+            applyAuthCorsHeaders(reply, request.headers.origin);
+            const headers = toHeaders(request.headers);
+            const protocol = request.protocol ?? 'http';
+            const host = request.headers.host ?? 'localhost';
+            const url = new URL(request.url, `${protocol}://${host}`);
+            const body = getRequestBody(request.method, request.body, headers);
+            const response = await auth.handler(new Request(url, {
+                method: request.method,
+                headers,
+                body,
+            }));
+
+            reply.code(response.status);
+
+            response.headers.forEach((value, key) => {
+                if (key === 'set-cookie') {
+                    reply.header(key, response.headers.getSetCookie());
+                    return;
+                }
+
+                reply.header(key, value);
+            });
+
+            const text = await response.text();
+            return reply.send(text);
+        },
     });
 
     // Example protected route showing session retrieval

--- a/apps/frontend/src/app/app.config.ts
+++ b/apps/frontend/src/app/app.config.ts
@@ -1,6 +1,8 @@
 import { provideHttpClient, withFetch, withInterceptors } from '@angular/common/http';
 import { APP_INITIALIZER, ApplicationConfig, inject, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { configureAuthClient } from '@yotara/shared';
+import { environment } from '../environments/environment';
 import { routes } from './app.routes';
 import { apiPrefixInterceptor } from './core/interceptors/api-prefix.interceptor';
 import { AuthStateService } from './core/services/auth-state.service';
@@ -15,7 +17,10 @@ export const appConfig: ApplicationConfig = {
       multi: true,
       useFactory: () => {
         const authState = inject(AuthStateService);
-        return () => authState.initialize();
+        return () => {
+          configureAuthClient(`${environment.apiBaseUrl}/auth`);
+          return authState.initialize();
+        };
       },
     },
   ]

--- a/package.json
+++ b/package.json
@@ -4,14 +4,16 @@
   "version": "0.1.0",
   "description": "Yotara: lightweight self-hosted task manager",
   "scripts": {
-    "dev": "pnpm --parallel dev",
+    "dev": "node scripts/dev.mjs",
     "build": "pnpm -r build",
     "start": "pnpm -r start",
     "lint": "pnpm -r lint",
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r test",
     "dev:frontend": "pnpm --filter @yotara/frontend dev",
-    "dev:api": "pnpm --filter @yotara/api dev"
+    "dev:api": "pnpm --filter @yotara/api dev",
+    "dev:studio": "pnpm --filter @yotara/api db:studio",
+    "db:studio": "pnpm --filter @yotara/api db:studio"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/shared/src/auth.ts
+++ b/packages/shared/src/auth.ts
@@ -1,28 +1,35 @@
 import { createAuthClient } from "better-auth/client";
 
-export const authClient = createAuthClient({
-    // You can also use an environment variable here if preferred
-    baseURL: "http://localhost:3000"
-});
+let authBaseUrl = "";
+
+export function configureAuthClient(baseURL: string) {
+    authBaseUrl = baseURL;
+}
+
+function getAuthClient() {
+    return createAuthClient({
+        baseURL: authBaseUrl,
+    });
+}
 
 export const AuthService = {
     signIn: async (email: string, password: string) => {
-        return await authClient.signIn.email({
+        return await getAuthClient().signIn.email({
             email,
             password
         });
     },
     signUp: async (email: string, password: string, name: string) => {
-        return await authClient.signUp.email({
+        return await getAuthClient().signUp.email({
             email,
             password,
             name
         });
     },
     signOut: async () => {
-        return await authClient.signOut();
+        return await getAuthClient().signOut();
     },
     getSession: async () => {
-        return await authClient.getSession();
+        return await getAuthClient().getSession();
     }
 };

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,92 @@
+import { spawn } from 'node:child_process';
+
+const processes = [
+  { name: 'frontend', args: ['--filter', '@yotara/frontend', 'dev'] },
+  { name: 'api', args: ['--filter', '@yotara/api', 'dev'] },
+  { name: 'studio', args: ['--filter', '@yotara/api', 'db:studio'], optional: true },
+];
+const DRIZZLE_STUDIO_URL = 'https://local.drizzle.studio';
+
+const children = [];
+let shuttingDown = false;
+let announcedStudioUrl = false;
+
+function prefixOutput(name, chunk, writer) {
+  const text = chunk.toString();
+  const lines = text.split(/\r?\n/);
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (line.length === 0 && index === lines.length - 1) {
+      continue;
+    }
+
+    writer(`[${name}] ${line}\n`);
+
+    if (name === 'studio' && !announcedStudioUrl && line.includes('Drizzle Studio is up and running on')) {
+      announcedStudioUrl = true;
+      process.stdout.write(`\n[dev] Drizzle Studio: ${DRIZZLE_STUDIO_URL}\n\n`);
+    }
+  }
+}
+
+function shutdown(code = 0) {
+  if (shuttingDown) {
+    return;
+  }
+
+  shuttingDown = true;
+
+  for (const child of children) {
+    if (!child.killed) {
+      child.kill('SIGTERM');
+    }
+  }
+
+  setTimeout(() => {
+    for (const child of children) {
+      if (!child.killed) {
+        child.kill('SIGKILL');
+      }
+    }
+    process.exit(code);
+  }, 1000).unref();
+}
+
+for (const processConfig of processes) {
+  const child = spawn('pnpm', processConfig.args, {
+    cwd: process.cwd(),
+    env: process.env,
+    stdio: ['inherit', 'pipe', 'pipe'],
+  });
+
+  children.push(child);
+
+  child.stdout.on('data', (chunk) => prefixOutput(processConfig.name, chunk, process.stdout.write.bind(process.stdout)));
+  child.stderr.on('data', (chunk) => prefixOutput(processConfig.name, chunk, process.stderr.write.bind(process.stderr)));
+
+  child.on('exit', (code, signal) => {
+    if (shuttingDown) {
+      return;
+    }
+
+    if (code === 0 || signal === 'SIGTERM') {
+      shutdown(code ?? 0);
+      return;
+    }
+
+    if (processConfig.optional) {
+      process.stderr.write(`[${processConfig.name}] exited with code ${code ?? 'unknown'}; continuing\n`);
+      return;
+    }
+
+    process.stderr.write(`[${processConfig.name}] exited with code ${code ?? 'unknown'}\n`);
+    shutdown(code ?? 1);
+  });
+}
+
+process.stdout.write(`[dev] Starting frontend, api, and Drizzle Studio\n`);
+process.stdout.write(`[dev] Drizzle Studio URL: ${DRIZZLE_STUDIO_URL}\n\n`);
+
+process.on('SIGINT', () => shutdown(0));
+process.on('SIGTERM', () => shutdown(0));


### PR DESCRIPTION
## Summary
- harden the SQLite-backed auth and task flow, including user-scoped task access
- fix Better Auth HTTP/CORS handling and add integration tests for register, login, and auth preflight
- improve local developer workflow by wiring Drizzle Studio into the root dev flow and surfacing its URL

## Verification
- pnpm --filter @yotara/api test
- pnpm --filter @yotara/api typecheck
- pnpm --filter @yotara/frontend typecheck
- pnpm --filter @yotara/shared typecheck