### PR TITLE
Add generated OpenAPI docs for API

### DIFF
--- a/PROJECT_README.md
+++ b/PROJECT_README.md
@@ -169,6 +169,7 @@ pnpm start
 pnpm lint
 pnpm typecheck
 pnpm test
+pnpm docs:check
 pnpm db:generate
 pnpm db:push
 pnpm db:studio
@@ -302,36 +303,27 @@ That production setting assumes the frontend and API are served behind the same 
 
 ## API Surface
 
-### Public endpoints
+Interactive API documentation is now served by the API itself:
+
+- Swagger UI: `http://localhost:3000/docs`
+- OpenAPI JSON: `http://localhost:3000/docs/openapi.json`
+
+The generated spec includes app-owned routes plus the configured Better Auth endpoints:
 
 - `GET /`
 - `GET /health`
-
-### Auth endpoints
-
-Mounted under:
-
-```text
-/auth/*
-```
-
-These are handled by Better Auth. Common flows include sign-up, sign-in, session retrieval, and sign-out.
-
-### Session endpoint
-
 - `GET /me`
-
-Returns the authenticated user session or `401`.
-
-### Task endpoints
-
 - `GET /tasks`
 - `GET /tasks/:id`
 - `POST /tasks`
 - `PATCH /tasks/:id`
 - `DELETE /tasks/:id`
+- `POST /auth/sign-up/email`
+- `POST /auth/sign-in/email`
+- `POST /auth/sign-out`
+- `GET /auth/session`
 
-All task routes require authentication and are scoped to the current user.
+Use the generated docs as the source of truth for request/response shapes and examples. Keep this README limited to high-level notes that are not duplicated in OpenAPI.
 
 ## Database And Drizzle
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,12 +10,16 @@
     "lint": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test src/**/*.test.ts",
+    "docs:check": "tsx --test src/docs/openapi.test.ts",
+    "docs:export": "tsx src/scripts/export-openapi.ts",
     "db:generate": "drizzle-kit generate",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
     "@fastify/cors": "^11.2.0",
+    "@fastify/swagger": "^9.5.1",
+    "@fastify/swagger-ui": "^5.2.3",
     "@yotara/shared": "workspace:*",
     "better-auth": "^1.5.4",
     "better-sqlite3": "^12.6.2",

--- a/apps/api/src/docs/openapi.test.ts
+++ b/apps/api/src/docs/openapi.test.ts
@@ -1,0 +1,143 @@
+import { randomUUID } from 'node:crypto';
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getOpenApiJson } from '../scripts/export-openapi.js';
+
+async function createTestApp() {
+  const dbFile = join(tmpdir(), `yotara-openapi-test-${randomUUID()}.db`);
+  process.env['DATABASE_URL'] = dbFile;
+  process.env['BETTER_AUTH_SECRET'] = 'test-secret-with-enough-entropy-1234567890';
+  process.env['APP_BASE_URL'] = 'http://localhost:3000';
+
+  const { buildApp } = await import('../server.js');
+  const app = await buildApp();
+
+  return {
+    app,
+    async cleanup() {
+      await app.close();
+      rmSync(dbFile, { force: true });
+      delete process.env['DATABASE_URL'];
+      delete process.env['BETTER_AUTH_SECRET'];
+      delete process.env['APP_BASE_URL'];
+    },
+  };
+}
+
+test('openapi endpoint exposes documented app and auth routes', async () => {
+  const ctx = await createTestApp();
+
+  try {
+    const response = await ctx.app.inject({
+      method: 'GET',
+      url: '/docs/openapi.json',
+    });
+
+    assert.equal(response.statusCode, 200);
+    const spec = response.json();
+
+    assert.equal(spec.info.title, 'Yotara API');
+    assert.equal(spec.openapi, '3.1.0');
+
+    assert.ok(spec.paths['/']);
+    assert.ok(spec.paths['/health']);
+    assert.ok(spec.paths['/me']);
+    assert.ok(spec.paths['/tasks']);
+    assert.ok(spec.paths['/tasks/{id}']);
+    assert.ok(spec.paths['/auth/sign-up/email']);
+    assert.ok(spec.paths['/auth/sign-in/email']);
+    assert.ok(spec.paths['/auth/sign-out']);
+    assert.ok(spec.paths['/auth/session']);
+
+    assert.deepEqual(spec.paths['/tasks'].get.security, [{ cookieAuth: [] }]);
+    assert.ok(spec.components.securitySchemes.cookieAuth);
+  } finally {
+    await ctx.cleanup();
+  }
+});
+
+test('docs ui is served from the api and export helper returns valid json', async () => {
+  const ctx = await createTestApp();
+
+  try {
+    const docsResponse = await ctx.app.inject({
+      method: 'GET',
+      url: '/docs',
+    });
+
+    assert.equal(docsResponse.statusCode, 200);
+    assert.match(String(docsResponse.headers['content-type']), /text\/html/);
+    assert.match(docsResponse.body, /Swagger UI/i);
+
+    const exported = await getOpenApiJson();
+    const spec = JSON.parse(exported);
+
+    assert.equal(spec.info.title, 'Yotara API');
+    assert.ok(spec.paths['/docs/openapi.json'] === undefined);
+  } finally {
+    await ctx.cleanup();
+  }
+});
+
+test('openapi spec includes representative response contracts and examples', async () => {
+  const ctx = await createTestApp();
+
+  try {
+    const response = await ctx.app.inject({
+      method: 'GET',
+      url: '/docs/openapi.json',
+    });
+
+    assert.equal(response.statusCode, 200);
+    const spec = response.json();
+
+    assert.ok(spec.paths['/tasks'].get.responses['200']);
+    assert.ok(spec.paths['/tasks'].get.responses['401']);
+    assert.ok(spec.paths['/tasks'].post.responses['201']);
+    assert.ok(spec.paths['/tasks'].post.responses['400']);
+    assert.ok(spec.paths['/tasks'].post.responses['500']);
+    assert.ok(spec.paths['/tasks/{id}'].patch.responses['404']);
+    assert.ok(spec.paths['/tasks/{id}'].delete.responses['404']);
+    assert.ok(spec.paths['/auth/sign-in/email'].post.responses['401']);
+    assert.ok(spec.paths['/auth/session'].get.responses['200']);
+
+    assert.equal(
+      spec.paths['/tasks'].post.responses['400'].content['application/json'].example.message,
+      'Task title is required',
+    );
+    assert.equal(
+      spec.paths['/auth/sign-in/email'].post.responses['401'].content['application/json'].example
+        .code,
+      'INVALID_CREDENTIALS',
+    );
+  } finally {
+    await ctx.cleanup();
+  }
+});
+
+test('protected endpoints use the normalized unauthorized error shape', async () => {
+  const ctx = await createTestApp();
+
+  try {
+    const meResponse = await ctx.app.inject({
+      method: 'GET',
+      url: '/me',
+    });
+
+    assert.equal(meResponse.statusCode, 401);
+    assert.deepEqual(meResponse.json(), { message: 'Unauthorized' });
+
+    const tasksResponse = await ctx.app.inject({
+      method: 'GET',
+      url: '/tasks',
+    });
+
+    assert.equal(tasksResponse.statusCode, 401);
+    assert.deepEqual(tasksResponse.json(), { message: 'Unauthorized' });
+  } finally {
+    await ctx.cleanup();
+  }
+});

--- a/apps/api/src/docs/openapi.ts
+++ b/apps/api/src/docs/openapi.ts
@@ -1,0 +1,663 @@
+import swagger from '@fastify/swagger';
+import swaggerUi from '@fastify/swagger-ui';
+import type { FastifyInstance, FastifySchema, RouteOptions } from 'fastify';
+
+type OpenApiJsonContent = {
+  example?: unknown;
+};
+
+type OpenApiResponse = {
+  content?: Record<string, OpenApiJsonContent>;
+};
+
+type OpenApiOperation = {
+  responses?: Record<string, OpenApiResponse>;
+  requestBody?: {
+    content?: Record<string, OpenApiJsonContent>;
+  };
+};
+
+type OpenApiPathRecord = Record<
+  string,
+  Partial<Record<'get' | 'post' | 'patch' | 'delete', OpenApiOperation>>
+>;
+
+const taskSchema = {
+  $id: 'Task',
+  type: 'object',
+  required: ['id', 'title', 'status', 'priority', 'completed', 'order', 'createdAt', 'updatedAt'],
+  properties: {
+    id: { type: 'string', format: 'uuid' },
+    title: { type: 'string' },
+    description: { type: 'string' },
+    status: {
+      type: 'string',
+      enum: ['inbox', 'today', 'upcoming', 'done', 'archived'],
+    },
+    priority: {
+      type: 'string',
+      enum: ['low', 'medium', 'high'],
+    },
+    completed: { type: 'boolean' },
+    dueDate: { type: 'string', format: 'date' },
+    projectId: { type: 'string' },
+    assigneeId: { type: 'string' },
+    parentTaskId: { type: 'string' },
+    labels: {
+      type: 'array',
+      items: { type: 'string' },
+    },
+    order: { type: 'integer' },
+    createdAt: { type: 'string', format: 'date-time' },
+    updatedAt: { type: 'string', format: 'date-time' },
+  },
+} as const;
+
+const createTaskSchema = {
+  $id: 'CreateTaskDto',
+  type: 'object',
+  required: ['title'],
+  properties: {
+    title: { type: 'string' },
+    description: { type: 'string' },
+    status: {
+      type: 'string',
+      enum: ['inbox', 'today', 'upcoming', 'done', 'archived'],
+    },
+    priority: {
+      type: 'string',
+      enum: ['low', 'medium', 'high'],
+    },
+    dueDate: { type: 'string', format: 'date' },
+    projectId: { type: 'string' },
+    parentTaskId: { type: 'string' },
+    labels: {
+      type: 'array',
+      items: { type: 'string' },
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+const updateTaskSchema = {
+  $id: 'UpdateTaskDto',
+  type: 'object',
+  properties: {
+    title: { type: 'string' },
+    description: { type: 'string' },
+    status: {
+      type: 'string',
+      enum: ['inbox', 'today', 'upcoming', 'done', 'archived'],
+    },
+    priority: {
+      type: 'string',
+      enum: ['low', 'medium', 'high'],
+    },
+    dueDate: { type: 'string', format: 'date' },
+    projectId: { type: 'string' },
+    parentTaskId: { type: 'string' },
+    labels: {
+      type: 'array',
+      items: { type: 'string' },
+    },
+    completed: { type: 'boolean' },
+    order: { type: 'integer' },
+  },
+  additionalProperties: false,
+} as const;
+
+const userSchema = {
+  $id: 'User',
+  type: 'object',
+  required: ['id', 'email', 'name', 'createdAt'],
+  properties: {
+    id: { type: 'string' },
+    email: { type: 'string', format: 'email' },
+    name: { type: 'string' },
+    avatarUrl: { type: 'string', format: 'uri' },
+    image: { anyOf: [{ type: 'string', format: 'uri' }, { type: 'null' }] },
+    emailVerified: { type: 'boolean' },
+    createdAt: {
+      anyOf: [{ type: 'string', format: 'date-time' }, { type: 'integer' }],
+    },
+    updatedAt: {
+      anyOf: [{ type: 'string', format: 'date-time' }, { type: 'integer' }],
+    },
+  },
+} as const;
+
+const apiErrorSchema = {
+  $id: 'ApiError',
+  type: 'object',
+  required: ['message'],
+  properties: {
+    message: { type: 'string' },
+  },
+} as const;
+
+const sessionSchema = {
+  $id: 'Session',
+  type: 'object',
+  required: ['id', 'userId', 'expiresAt', 'createdAt', 'updatedAt'],
+  properties: {
+    id: { type: 'string' },
+    userId: { type: 'string' },
+    expiresAt: {
+      anyOf: [{ type: 'string', format: 'date-time' }, { type: 'integer' }],
+    },
+    createdAt: {
+      anyOf: [{ type: 'string', format: 'date-time' }, { type: 'integer' }],
+    },
+    updatedAt: {
+      anyOf: [{ type: 'string', format: 'date-time' }, { type: 'integer' }],
+    },
+    token: { type: 'string' },
+    ipAddress: { type: 'string' },
+    userAgent: { type: 'string' },
+  },
+} as const;
+
+const meResponseSchema = {
+  $id: 'MeResponse',
+  type: 'object',
+  required: ['user'],
+  properties: {
+    user: { $ref: 'User#' },
+  },
+} as const;
+
+const authSessionResponseSchema = {
+  $id: 'AuthSessionResponse',
+  type: 'object',
+  required: ['session', 'user'],
+  properties: {
+    session: {
+      anyOf: [{ $ref: 'Session#' }, { type: 'null' }],
+    },
+    user: {
+      anyOf: [{ $ref: 'User#' }, { type: 'null' }],
+    },
+  },
+} as const;
+
+const authCredentialsSchema = {
+  $id: 'AuthCredentials',
+  type: 'object',
+  required: ['email', 'password'],
+  properties: {
+    email: { type: 'string', format: 'email' },
+    password: { type: 'string' },
+  },
+  additionalProperties: false,
+} as const;
+
+const authSignUpSchema = {
+  $id: 'AuthSignUp',
+  type: 'object',
+  required: ['email', 'password', 'name'],
+  properties: {
+    email: { type: 'string', format: 'email' },
+    password: { type: 'string' },
+    name: { type: 'string' },
+  },
+  additionalProperties: false,
+} as const;
+
+const authUserResponseSchema = {
+  $id: 'AuthUserResponse',
+  type: 'object',
+  required: ['user'],
+  properties: {
+    user: { $ref: 'User#' },
+  },
+} as const;
+
+const authSignOutResponseSchema = {
+  $id: 'AuthSignOutResponse',
+  type: 'object',
+  properties: {
+    success: { type: 'boolean' },
+  },
+  additionalProperties: true,
+} as const;
+
+const authErrorSchema = {
+  $id: 'AuthError',
+  type: 'object',
+  required: ['message'],
+  properties: {
+    message: { type: 'string' },
+    code: { type: 'string' },
+    status: { type: 'integer' },
+  },
+  additionalProperties: true,
+} as const;
+
+const sharedSchemas = [
+  taskSchema,
+  createTaskSchema,
+  updateTaskSchema,
+  userSchema,
+  apiErrorSchema,
+  sessionSchema,
+  meResponseSchema,
+  authSessionResponseSchema,
+  authCredentialsSchema,
+  authSignUpSchema,
+  authUserResponseSchema,
+  authSignOutResponseSchema,
+  authErrorSchema,
+] as const;
+
+export const examples = {
+  apiInfo: {
+    name: 'Yotara API',
+    version: '0.1.0',
+  },
+  health: {
+    status: 'ok',
+    timestamp: '2026-03-16T12:00:00.000Z',
+  },
+  task: {
+    id: '9fd8141d-e282-43b8-96d5-a19e6b6f0c8f',
+    title: 'Write API docs',
+    description: 'Document every route with OpenAPI',
+    status: 'today',
+    priority: 'high',
+    completed: false,
+    dueDate: '2026-03-18',
+    order: 0,
+    createdAt: '2026-03-16T12:00:00.000Z',
+    updatedAt: '2026-03-16T12:00:00.000Z',
+  },
+  createTask: {
+    title: 'Write API docs',
+    description: 'Document every route with OpenAPI',
+    status: 'today',
+    priority: 'high',
+    dueDate: '2026-03-18',
+  },
+  updateTask: {
+    completed: true,
+    status: 'done',
+  },
+  me: {
+    user: {
+      id: 'user_123',
+      email: 'demo@example.com',
+      name: 'Demo User',
+      createdAt: '2026-03-16T12:00:00.000Z',
+    },
+  },
+  apiError: (message: string) => ({ message }),
+  authSignUp: {
+    email: 'demo@example.com',
+    password: 'Password123!',
+    name: 'Demo User',
+  },
+  authSignIn: {
+    email: 'demo@example.com',
+    password: 'Password123!',
+  },
+  authUser: {
+    user: {
+      id: 'user_123',
+      email: 'demo@example.com',
+      name: 'Demo User',
+      emailVerified: false,
+      image: null,
+      createdAt: 1773652800000,
+      updatedAt: 1773652800000,
+    },
+  },
+  authSession: {
+    session: {
+      id: 'session_123',
+      userId: 'user_123',
+      expiresAt: 1774257600000,
+      createdAt: 1773652800000,
+      updatedAt: 1773652800000,
+      ipAddress: '127.0.0.1',
+      userAgent: 'Mozilla/5.0',
+    },
+    user: {
+      id: 'user_123',
+      email: 'demo@example.com',
+      name: 'Demo User',
+      emailVerified: false,
+      image: null,
+      createdAt: 1773652800000,
+      updatedAt: 1773652800000,
+    },
+  },
+  authSignOut: {
+    success: true,
+  },
+  authError: {
+    message: 'Invalid email or password',
+    code: 'INVALID_CREDENTIALS',
+    status: 401,
+  },
+} as const;
+
+export const authCookieSecurity = [{ cookieAuth: [] }] as const;
+
+export function errorResponseSchema(
+  description: string,
+  message: string,
+): {
+  description: string;
+  content: { 'application/json': { schema: { $ref: string }; example: { message: string } } };
+} {
+  return {
+    description,
+    content: {
+      'application/json': {
+        schema: { $ref: 'ApiError#' },
+        example: examples.apiError(message),
+      },
+    },
+  };
+}
+
+export function idParamSchema(description = 'Task identifier'): FastifySchema['params'] {
+  return {
+    type: 'object',
+    required: ['id'],
+    properties: {
+      id: { type: 'string', description },
+    },
+  };
+}
+
+function ensureJsonContent(operation: OpenApiOperation, statusCode: string) {
+  const response = (operation.responses ?? {})[statusCode] ?? {};
+  response.content ??= {};
+  response.content['application/json'] ??= {};
+  operation.responses ??= {};
+  operation.responses[statusCode] = response;
+  return response.content['application/json'];
+}
+
+function addOpenApiExamples(paths: OpenApiPathRecord) {
+  const rootGet = paths['/']?.get;
+  if (rootGet) {
+    ensureJsonContent(rootGet, '200').example = examples.apiInfo;
+  }
+
+  const healthGet = paths['/health']?.get;
+  if (healthGet) {
+    ensureJsonContent(healthGet, '200').example = examples.health;
+  }
+
+  const meGet = paths['/me']?.get;
+  if (meGet) {
+    ensureJsonContent(meGet, '200').example = examples.me;
+    ensureJsonContent(meGet, '401').example = examples.apiError('Unauthorized');
+  }
+
+  const tasksListGet = paths['/tasks']?.get;
+  if (tasksListGet) {
+    ensureJsonContent(tasksListGet, '200').example = [examples.task];
+    ensureJsonContent(tasksListGet, '401').example = examples.apiError('Unauthorized');
+  }
+
+  const tasksPost = paths['/tasks']?.post;
+  if (tasksPost) {
+    tasksPost.requestBody ??= { content: { 'application/json': {} } };
+    tasksPost.requestBody.content ??= {};
+    tasksPost.requestBody.content['application/json'] ??= {};
+    tasksPost.requestBody.content['application/json'].example = examples.createTask;
+    ensureJsonContent(tasksPost, '201').example = examples.task;
+    ensureJsonContent(tasksPost, '400').example = examples.apiError('Task title is required');
+    ensureJsonContent(tasksPost, '401').example = examples.apiError('Unauthorized');
+    ensureJsonContent(tasksPost, '500').example = examples.apiError('Failed to create task');
+  }
+
+  const taskByIdGet = paths['/tasks/{id}']?.get;
+  if (taskByIdGet) {
+    ensureJsonContent(taskByIdGet, '200').example = examples.task;
+    ensureJsonContent(taskByIdGet, '401').example = examples.apiError('Unauthorized');
+    ensureJsonContent(taskByIdGet, '404').example = examples.apiError('Task not found');
+  }
+
+  const taskByIdPatch = paths['/tasks/{id}']?.patch;
+  if (taskByIdPatch) {
+    taskByIdPatch.requestBody ??= { content: { 'application/json': {} } };
+    taskByIdPatch.requestBody.content ??= {};
+    taskByIdPatch.requestBody.content['application/json'] ??= {};
+    taskByIdPatch.requestBody.content['application/json'].example = examples.updateTask;
+    ensureJsonContent(taskByIdPatch, '200').example = {
+      ...examples.task,
+      completed: true,
+      status: 'done',
+    };
+    ensureJsonContent(taskByIdPatch, '401').example = examples.apiError('Unauthorized');
+    ensureJsonContent(taskByIdPatch, '404').example = examples.apiError('Task not found');
+    ensureJsonContent(taskByIdPatch, '500').example = examples.apiError('Failed to update task');
+  }
+
+  const taskByIdDelete = paths['/tasks/{id}']?.delete;
+  if (taskByIdDelete) {
+    ensureJsonContent(taskByIdDelete, '200').example = { ok: true };
+    ensureJsonContent(taskByIdDelete, '401').example = examples.apiError('Unauthorized');
+    ensureJsonContent(taskByIdDelete, '404').example = examples.apiError('Task not found');
+  }
+}
+
+function authPaths() {
+  return {
+    '/auth/sign-up/email': {
+      post: {
+        tags: ['auth'],
+        summary: 'Register a user with email and password',
+        description: 'Creates a new user account and starts an authenticated session.',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: { $ref: 'AuthSignUp#' },
+              example: examples.authSignUp,
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: 'User registered',
+            content: {
+              'application/json': {
+                schema: { $ref: 'AuthUserResponse#' },
+                example: examples.authUser,
+              },
+            },
+          },
+          400: {
+            description: 'Invalid registration payload',
+            content: {
+              'application/json': {
+                schema: { $ref: 'AuthError#' },
+                example: {
+                  message: 'User already exists',
+                  code: 'USER_ALREADY_EXISTS',
+                  status: 400,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/auth/sign-in/email': {
+      post: {
+        tags: ['auth'],
+        summary: 'Sign in with email and password',
+        description:
+          'Authenticates a user and returns the user profile while setting the session cookie.',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: { $ref: 'AuthCredentials#' },
+              example: examples.authSignIn,
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: 'User authenticated',
+            content: {
+              'application/json': {
+                schema: { $ref: 'AuthUserResponse#' },
+                example: examples.authUser,
+              },
+            },
+          },
+          401: {
+            description: 'Invalid credentials',
+            content: {
+              'application/json': {
+                schema: { $ref: 'AuthError#' },
+                example: examples.authError,
+              },
+            },
+          },
+        },
+      },
+    },
+    '/auth/sign-out': {
+      post: {
+        tags: ['auth'],
+        summary: 'Sign out the current session',
+        description: 'Clears the session cookie for the authenticated user.',
+        security: authCookieSecurity,
+        responses: {
+          200: {
+            description: 'Session cleared',
+            content: {
+              'application/json': {
+                schema: { $ref: 'AuthSignOutResponse#' },
+                example: examples.authSignOut,
+              },
+            },
+          },
+          401: {
+            description: 'No active session',
+            content: {
+              'application/json': {
+                schema: { $ref: 'AuthError#' },
+                example: {
+                  message: 'Unauthorized',
+                  code: 'UNAUTHORIZED',
+                  status: 401,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/auth/session': {
+      get: {
+        tags: ['auth'],
+        summary: 'Fetch the current auth session',
+        description:
+          'Returns the Better Auth session and user. This endpoint is cookie-based; send the session cookie to retrieve an authenticated session.',
+        security: authCookieSecurity,
+        responses: {
+          200: {
+            description: 'Session response',
+            content: {
+              'application/json': {
+                schema: { $ref: 'AuthSessionResponse#' },
+                example: examples.authSession,
+              },
+            },
+          },
+        },
+      },
+    },
+  } as const;
+}
+
+export async function registerOpenApi(app: FastifyInstance) {
+  for (const schema of sharedSchemas) {
+    app.addSchema(schema);
+  }
+
+  await app.register(swagger, {
+    openapi: {
+      openapi: '3.1.0',
+      info: {
+        title: 'Yotara API',
+        version: '0.1.0',
+        description:
+          'Machine-readable API documentation for Yotara. Session-based endpoints use the Better Auth cookie.',
+      },
+      servers: [
+        {
+          url: 'http://localhost:3000',
+          description: 'Local development server',
+        },
+      ],
+      tags: [
+        { name: 'meta', description: 'Service metadata and health endpoints' },
+        { name: 'tasks', description: 'Authenticated task CRUD endpoints' },
+        { name: 'auth', description: 'Better Auth session and credential flows' },
+      ],
+      components: {
+        securitySchemes: {
+          cookieAuth: {
+            type: 'apiKey',
+            in: 'cookie',
+            name: 'better-auth.session_token',
+            description: 'Better Auth session cookie',
+          },
+        },
+      },
+    },
+    transformObject(documentObject) {
+      if (!('openapiObject' in documentObject)) {
+        return documentObject.swaggerObject;
+      }
+
+      const openapiObject = {
+        ...documentObject.openapiObject,
+        paths: {
+          ...(documentObject.openapiObject.paths ?? {}),
+          ...authPaths(),
+        },
+      };
+
+      addOpenApiExamples(openapiObject.paths as OpenApiPathRecord);
+
+      return openapiObject as never;
+    },
+  });
+
+  await app.register(swaggerUi, {
+    routePrefix: '/docs',
+    uiConfig: {
+      docExpansion: 'list',
+      deepLinking: false,
+    },
+    staticCSP: true,
+  });
+
+  app.get(
+    '/docs/openapi.json',
+    {
+      schema: {
+        hide: true,
+      } satisfies FastifySchema,
+    },
+    async () => app.swagger(),
+  );
+}
+
+export function withJsonResponse(schema: RouteOptions['schema']): RouteOptions['schema'] {
+  return {
+    ...schema,
+    consumes: ['application/json'],
+    produces: ['application/json'],
+  };
+}

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -5,7 +5,26 @@ import type { FastifyInstance } from 'fastify';
  * Used by Docker healthcheck and load balancers.
  */
 export default async function healthRoutes(fastify: FastifyInstance) {
-  fastify.get('/health', async () => {
-    return { status: 'ok', timestamp: new Date().toISOString() };
-  });
+  fastify.get(
+    '/health',
+    {
+      schema: {
+        tags: ['meta'],
+        summary: 'Health check',
+        response: {
+          200: {
+            type: 'object',
+            required: ['status', 'timestamp'],
+            properties: {
+              status: { type: 'string' },
+              timestamp: { type: 'string', format: 'date-time' },
+            },
+          },
+        },
+      },
+    },
+    async () => {
+      return { status: 'ok', timestamp: new Date().toISOString() };
+    },
+  );
 }

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -6,6 +6,12 @@ import { auth } from '../lib/auth.js';
 import { fromNodeHeaders } from 'better-auth/node';
 import { db } from '../db/client.js';
 import { tasks } from '../db/schema.js';
+import {
+  authCookieSecurity,
+  errorResponseSchema,
+  idParamSchema,
+  withJsonResponse,
+} from '../docs/openapi.js';
 
 function toTask(task: typeof tasks.$inferSelect): Task {
   return {
@@ -55,22 +61,56 @@ async function requireUserId(request: FastifyRequest) {
  * Tasks routes backed by SQLite via Drizzle.
  */
 export default async function taskRoutes(fastify: FastifyInstance) {
-  fastify.get<{ Reply: Task[] | { message: string } }>('/tasks', async (request, reply) => {
-    const userId = await requireUserId(request);
-    if (!userId) {
-      return reply.code(401).send({ message: 'Unauthorized' });
-    }
+  fastify.get<{ Reply: Task[] | { message: string } }>(
+    '/tasks',
+    {
+      schema: withJsonResponse({
+        tags: ['tasks'],
+        summary: 'List tasks',
+        security: authCookieSecurity,
+        response: {
+          200: {
+            description: 'Tasks for the authenticated user',
+            type: 'array',
+            items: { $ref: 'Task#' },
+          },
+          401: errorResponseSchema('Authentication required', 'Unauthorized'),
+        },
+      }),
+    },
+    async (request, reply) => {
+      const userId = await requireUserId(request);
+      if (!userId) {
+        return reply.code(401).send({ message: 'Unauthorized' });
+      }
 
-    const rows = await db
-      .select()
-      .from(tasks)
-      .where(eq(tasks.userId, userId))
-      .orderBy(asc(tasks.order), asc(tasks.createdAt));
-    return rows.map(toTask);
-  });
+      const rows = await db
+        .select()
+        .from(tasks)
+        .where(eq(tasks.userId, userId))
+        .orderBy(asc(tasks.order), asc(tasks.createdAt));
+      return rows.map(toTask);
+    },
+  );
 
   fastify.get<{ Params: { id: string }; Reply: Task | { message: string } }>(
     '/tasks/:id',
+    {
+      schema: withJsonResponse({
+        tags: ['tasks'],
+        summary: 'Fetch a single task',
+        security: authCookieSecurity,
+        params: idParamSchema(),
+        response: {
+          200: {
+            description: 'Task found',
+            $ref: 'Task#',
+          },
+          401: errorResponseSchema('Authentication required', 'Unauthorized'),
+          404: errorResponseSchema('Task was not found', 'Task not found'),
+        },
+      }),
+    },
     async (request, reply) => {
       const userId = await requireUserId(request);
       if (!userId) {
@@ -93,6 +133,25 @@ export default async function taskRoutes(fastify: FastifyInstance) {
 
   fastify.post<{ Body: CreateTaskDto; Reply: Task | { message: string } }>(
     '/tasks',
+    {
+      schema: withJsonResponse({
+        tags: ['tasks'],
+        summary: 'Create a task',
+        security: authCookieSecurity,
+        body: {
+          $ref: 'CreateTaskDto#',
+        },
+        response: {
+          201: {
+            description: 'Task created',
+            $ref: 'Task#',
+          },
+          400: errorResponseSchema('Invalid task payload', 'Task title is required'),
+          401: errorResponseSchema('Authentication required', 'Unauthorized'),
+          500: errorResponseSchema('Task could not be created', 'Failed to create task'),
+        },
+      }),
+    },
     async (request, reply) => {
       const userId = await requireUserId(request);
       if (!userId) {
@@ -137,6 +196,26 @@ export default async function taskRoutes(fastify: FastifyInstance) {
 
   fastify.patch<{ Params: { id: string }; Body: UpdateTaskDto; Reply: Task | { message: string } }>(
     '/tasks/:id',
+    {
+      schema: withJsonResponse({
+        tags: ['tasks'],
+        summary: 'Update a task',
+        security: authCookieSecurity,
+        params: idParamSchema(),
+        body: {
+          $ref: 'UpdateTaskDto#',
+        },
+        response: {
+          200: {
+            description: 'Task updated',
+            $ref: 'Task#',
+          },
+          401: errorResponseSchema('Authentication required', 'Unauthorized'),
+          404: errorResponseSchema('Task was not found', 'Task not found'),
+          500: errorResponseSchema('Task could not be updated', 'Failed to update task'),
+        },
+      }),
+    },
     async (request, reply) => {
       const userId = await requireUserId(request);
       if (!userId) {
@@ -186,6 +265,26 @@ export default async function taskRoutes(fastify: FastifyInstance) {
 
   fastify.delete<{ Params: { id: string }; Reply: { ok: true } | { message: string } }>(
     '/tasks/:id',
+    {
+      schema: withJsonResponse({
+        tags: ['tasks'],
+        summary: 'Delete a task',
+        security: authCookieSecurity,
+        params: idParamSchema(),
+        response: {
+          200: {
+            description: 'Task deleted',
+            type: 'object',
+            required: ['ok'],
+            properties: {
+              ok: { type: 'boolean' },
+            },
+          },
+          401: errorResponseSchema('Authentication required', 'Unauthorized'),
+          404: errorResponseSchema('Task was not found', 'Task not found'),
+        },
+      }),
+    },
     async (request, reply) => {
       const userId = await requireUserId(request);
       if (!userId) {

--- a/apps/api/src/scripts/export-openapi.ts
+++ b/apps/api/src/scripts/export-openapi.ts
@@ -1,0 +1,33 @@
+import { fileURLToPath } from 'node:url';
+import { writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { buildApp } from '../server.js';
+
+export async function getOpenApiJson() {
+  const app = await buildApp();
+
+  try {
+    await app.ready();
+    const spec = app.swagger();
+    return JSON.stringify(spec, null, 2);
+  } finally {
+    await app.close();
+  }
+}
+
+async function main() {
+  const output = await getOpenApiJson();
+  const target = process.argv[2];
+
+  if (target) {
+    await writeFile(resolve(process.cwd(), target), `${output}\n`, 'utf8');
+    return;
+  }
+
+  process.stdout.write(`${output}\n`);
+}
+
+const isEntryPoint = process.argv[1] === fileURLToPath(import.meta.url);
+if (isEntryPoint) {
+  await main();
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,6 +1,12 @@
 import Fastify from 'fastify';
 import { fileURLToPath } from 'node:url';
 import corsPlugin from './plugins/cors.js';
+import {
+  authCookieSecurity,
+  errorResponseSchema,
+  registerOpenApi,
+  withJsonResponse,
+} from './docs/openapi.js';
 import healthRoutes from './routes/health.js';
 import taskRoutes from './routes/tasks.js';
 import { auth } from './lib/auth.js';
@@ -65,6 +71,7 @@ export async function buildApp() {
   const app = Fastify({ logger: true });
 
   // ─── Plugins ──────────────────────────────────────────────────────────────
+  await registerOpenApi(app);
   await app.register(corsPlugin);
 
   // Register Better Auth handler
@@ -117,23 +124,58 @@ export async function buildApp() {
     },
   });
 
-  // Example protected route showing session retrieval
-  app.get('/me', async (request, reply) => {
-    const session = await auth.api.getSession({
-      headers: fromNodeHeaders(request.headers),
-    });
-    if (!session) return reply.code(401).send({ error: 'Unauthorized' });
-    return { user: session.user };
-  });
+  app.get(
+    '/me',
+    {
+      schema: withJsonResponse({
+        tags: ['auth'],
+        summary: 'Get the current authenticated user',
+        security: authCookieSecurity,
+        response: {
+          200: {
+            description: 'Authenticated user',
+            $ref: 'MeResponse#',
+          },
+          401: errorResponseSchema('Authentication required', 'Unauthorized'),
+        },
+      }),
+    },
+    async (request, reply) => {
+      const session = await auth.api.getSession({
+        headers: fromNodeHeaders(request.headers),
+      });
+      if (!session) return reply.code(401).send({ message: 'Unauthorized' });
+      return { user: session.user };
+    },
+  );
 
   // ─── Routes ───────────────────────────────────────────────────────────────
   await app.register(healthRoutes);
   await app.register(taskRoutes);
 
   // ─── Root ─────────────────────────────────────────────────────────────────
-  app.get('/', async () => {
-    return { name: 'Yotara API', version: '0.1.0' };
-  });
+  app.get(
+    '/',
+    {
+      schema: {
+        tags: ['meta'],
+        summary: 'Get API metadata',
+        response: {
+          200: {
+            type: 'object',
+            required: ['name', 'version'],
+            properties: {
+              name: { type: 'string' },
+              version: { type: 'string' },
+            },
+          },
+        },
+      },
+    },
+    async () => {
+      return { name: 'Yotara API', version: '0.1.0' };
+    },
+  );
 
   return app;
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "dev:frontend": "pnpm --filter @yotara/frontend dev",
     "dev:api": "pnpm --filter @yotara/api dev",
     "dev:studio": "pnpm --filter @yotara/api db:studio",
-    "db:studio": "pnpm --filter @yotara/api db:studio"
+    "db:studio": "pnpm --filter @yotara/api db:studio",
+    "docs:check": "pnpm --filter @yotara/api docs:check",
+    "docs:export": "pnpm --filter @yotara/api docs:export"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,12 @@ importers:
       '@fastify/cors':
         specifier: ^11.2.0
         version: 11.2.0
+      '@fastify/swagger':
+        specifier: ^9.5.1
+        version: 9.7.0
+      '@fastify/swagger-ui':
+        specifier: ^5.2.3
+        version: 5.2.5
       '@yotara/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -1621,6 +1627,9 @@ packages:
     resolution: {integrity: sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@fastify/accept-negotiator@2.0.1':
+    resolution: {integrity: sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==}
+
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
 
@@ -1641,6 +1650,18 @@ packages:
 
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
+  '@fastify/send@4.1.0':
+    resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
+
+  '@fastify/static@9.0.0':
+    resolution: {integrity: sha512-r64H8Woe/vfilg5RTy7lwWlE8ZZcTrc3kebYFMEUBrMqlydhQyoiExQXdYAy2REVpST/G35+stAM8WYp1WGmMA==}
+
+  '@fastify/swagger-ui@5.2.5':
+    resolution: {integrity: sha512-ky3I0LAkXKX/prwSDpoQ3kscBKsj2Ha6Gp1/JfgQSqyx0bm9F2bE//XmGVGj2cR9l5hUjZYn60/hqn7e+OLgWQ==}
+
+  '@fastify/swagger@9.7.0':
+    resolution: {integrity: sha512-Vp1SC1GC2Hrkd3faFILv86BzUNyFz5N4/xdExqtCgkGASOzn/x+eMe4qXIGq7cdT6wif/P/oa6r1Ruqx19paZA==}
 
   '@gar/promise-retry@1.0.2':
     resolution: {integrity: sha512-Lm/ZLhDZcBECta3TmCQSngiQykFdfw+QtI1/GYMsZd4l3nG+P8WLB16XuS7WaBGLQ+9E+cOcWQsth9cayuGt8g==}
@@ -2022,6 +2043,10 @@ packages:
     resolution: {integrity: sha512-qwosvPyl+zpUlp3gRb7UcJ3H8S28XHCzkv0Y0EgQToXjQP91ZD67EHSCDmaLjtKhe+GVIW5om1KUpzVLA0l6pg==}
     cpu: [x64]
     os: [win32]
+
+  '@lukeed/ms@2.0.2':
+    resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
+    engines: {node: '>=8'}
 
   '@modelcontextprotocol/sdk@1.26.0':
     resolution: {integrity: sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==}
@@ -5458,6 +5483,10 @@ packages:
   json-schema-ref-resolver@3.0.0:
     resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
 
+  json-schema-resolver@3.0.0:
+    resolution: {integrity: sha512-HqMnbz0tz2DaEJ3ntsqtx3ezzZyDE7G56A/pPY/NGmrPu76UzsWquOpHFRAf5beTNXoH2LU5cQePVvRli1nchA==}
+    engines: {node: '>=20'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -5873,6 +5902,11 @@ packages:
     engines: {node: '>=4.0.0'}
     hasBin: true
 
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -6227,6 +6261,9 @@ packages:
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
+
+  openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
   opener@1.5.2:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
@@ -9633,6 +9670,8 @@ snapshots:
       '@eslint/core': 1.1.1
       levn: 0.4.1
 
+  '@fastify/accept-negotiator@2.0.1': {}
+
   '@fastify/ajv-compiler@4.0.5':
     dependencies:
       ajv: 8.18.0
@@ -9660,6 +9699,41 @@ snapshots:
     dependencies:
       '@fastify/forwarded': 3.0.1
       ipaddr.js: 2.3.0
+
+  '@fastify/send@4.1.0':
+    dependencies:
+      '@lukeed/ms': 2.0.2
+      escape-html: 1.0.3
+      fast-decode-uri-component: 1.0.1
+      http-errors: 2.0.1
+      mime: 3.0.0
+
+  '@fastify/static@9.0.0':
+    dependencies:
+      '@fastify/accept-negotiator': 2.0.1
+      '@fastify/send': 4.1.0
+      content-disposition: 1.0.1
+      fastify-plugin: 5.1.0
+      fastq: 1.20.1
+      glob: 13.0.6
+
+  '@fastify/swagger-ui@5.2.5':
+    dependencies:
+      '@fastify/static': 9.0.0
+      fastify-plugin: 5.1.0
+      openapi-types: 12.1.3
+      rfdc: 1.4.1
+      yaml: 2.8.2
+
+  '@fastify/swagger@9.7.0':
+    dependencies:
+      fastify-plugin: 5.1.0
+      json-schema-resolver: 3.0.0
+      openapi-types: 12.1.3
+      rfdc: 1.4.1
+      yaml: 2.8.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@gar/promise-retry@1.0.2':
     dependencies:
@@ -10020,6 +10094,8 @@ snapshots:
 
   '@lmdb/lmdb-win32-x64@3.5.1':
     optional: true
+
+  '@lukeed/ms@2.0.2': {}
 
   '@modelcontextprotocol/sdk@1.26.0(zod@4.3.6)':
     dependencies:
@@ -14096,6 +14172,14 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  json-schema-resolver@3.0.0:
+    dependencies:
+      debug: 4.4.3
+      fast-uri: 3.1.0
+      rfdc: 1.4.1
+    transitivePeerDependencies:
+      - supports-color
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -14549,6 +14633,8 @@ snapshots:
 
   mime@2.6.0: {}
 
+  mime@3.0.0: {}
+
   mimic-fn@2.1.0: {}
 
   mimic-function@5.0.1: {}
@@ -14939,6 +15025,8 @@ snapshots:
       define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
+
+  openapi-types@12.1.3: {}
 
   opener@1.5.2: {}
 


### PR DESCRIPTION
## Summary
- add generated OpenAPI docs and Swagger UI for the Fastify API
- document app-owned routes plus the configured Better Auth flows with shared schemas and examples
- add export and validation coverage for the docs endpoints and normalized unauthorized responses

## Validation
- pnpm --filter @yotara/api typecheck
- pnpm --filter @yotara/api test
- pnpm --filter @yotara/api docs:check