### PR TITLE
feat(frontend): add account logout dropdown with confirmation modal

### DIFF
--- a/apps/frontend/src/app/features/personal/shell/personal-shell.component.ts
+++ b/apps/frontend/src/app/features/personal/shell/personal-shell.component.ts
@@ -3,6 +3,7 @@ import { Component, computed, inject, signal } from '@angular/core';
 import { NavigationEnd, Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { filter } from 'rxjs';
 import { AuthStateService } from '../../../core/services/auth-state.service';
+import { LogoutConfirmModalComponent } from '../../../shared/ui/logout-confirm-modal/logout-confirm-modal.component';
 
 type PersonalIcon = 'inbox' | 'today' | 'upcoming' | 'projects' | 'labels';
 
@@ -15,7 +16,7 @@ interface PersonalNavItem {
 @Component({
   selector: 'app-personal-shell',
   standalone: true,
-  imports: [CommonModule, RouterLink, RouterLinkActive, RouterOutlet],
+  imports: [CommonModule, RouterLink, RouterLinkActive, RouterOutlet, LogoutConfirmModalComponent],
   template: `
     <div class="personal-shell">
       @if (mobileMenuOpen()) {
@@ -143,7 +144,47 @@ interface PersonalNavItem {
                 />
               </svg>
             </button>
-            <div class="avatar">{{ userInitials() }}</div>
+            <div class="profile-menu">
+              @if (profileMenuOpen()) {
+                <button
+                  type="button"
+                  class="profile-menu-backdrop"
+                  aria-label="Close profile menu"
+                  (click)="closeProfileMenu()"
+                ></button>
+              }
+
+              <button
+                type="button"
+                class="avatar avatar-button"
+                [attr.aria-expanded]="profileMenuOpen()"
+                aria-label="Open account menu"
+                (click)="toggleProfileMenu()"
+              >
+                {{ userInitials() }}
+              </button>
+
+              @if (profileMenuOpen()) {
+                <div class="profile-menu-card" role="menu" aria-label="Account actions">
+                  <button
+                    type="button"
+                    class="profile-menu-item"
+                    role="menuitem"
+                    (click)="handleStayFocused()"
+                  >
+                    Stay and Focus
+                  </button>
+                  <button
+                    type="button"
+                    class="profile-menu-item profile-menu-item-danger"
+                    role="menuitem"
+                    (click)="openLogoutDialog()"
+                  >
+                    Logout
+                  </button>
+                </div>
+              }
+            </div>
           </div>
         </header>
 
@@ -152,6 +193,14 @@ interface PersonalNavItem {
         </div>
       </main>
     </div>
+
+    <app-logout-confirm-modal
+      [open]="logoutDialogOpen()"
+      [loading]="signingOut()"
+      (close)="closeLogoutDialog()"
+      (stay)="handleStayFocused()"
+      (confirm)="confirmLogout()"
+    />
   `,
   styles: [
     `
@@ -376,6 +425,52 @@ interface PersonalNavItem {
         gap: 0.65rem;
       }
 
+      .profile-menu {
+        position: relative;
+      }
+
+      .profile-menu-backdrop {
+        position: fixed;
+        inset: 0;
+        border: 0;
+        background: transparent;
+        z-index: 4;
+      }
+
+      .profile-menu-card {
+        position: absolute;
+        top: calc(100% + 0.65rem);
+        right: 0;
+        width: 12rem;
+        border-radius: 0.95rem;
+        background: rgba(255, 251, 243, 0.97);
+        border: 1px solid rgba(227, 220, 203, 0.95);
+        box-shadow: 0 16px 30px rgba(74, 68, 56, 0.16);
+        padding: 0.35rem;
+        display: grid;
+        gap: 0.2rem;
+        z-index: 5;
+      }
+
+      .profile-menu-item {
+        border: 0;
+        border-radius: 0.7rem;
+        background: transparent;
+        color: #3f443c;
+        text-align: left;
+        font-weight: 600;
+        padding: 0.6rem 0.68rem;
+        cursor: pointer;
+      }
+
+      .profile-menu-item:hover {
+        background: rgba(205, 228, 211, 0.4);
+      }
+
+      .profile-menu-item-danger {
+        color: #8d4438;
+      }
+
       .icon-button,
       .menu-toggle {
         width: 2.7rem;
@@ -404,6 +499,11 @@ interface PersonalNavItem {
         place-items: center;
         font-size: 0.9rem;
         font-weight: 700;
+      }
+
+      .avatar-button {
+        border: 0;
+        cursor: pointer;
       }
 
       .page-surface {
@@ -493,6 +593,9 @@ export class PersonalShellComponent {
     { label: 'Labels', route: '/labels', icon: 'labels' },
   ];
   protected readonly mobileMenuOpen = signal(false);
+  protected readonly profileMenuOpen = signal(false);
+  protected readonly logoutDialogOpen = signal(false);
+  protected readonly signingOut = signal(false);
   protected readonly userInitials = computed(() => {
     const fallback = 'PS';
     const source = this.authState.user()?.name?.trim() || this.authState.user()?.email || fallback;
@@ -511,6 +614,7 @@ export class PersonalShellComponent {
   constructor() {
     this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
       this.mobileMenuOpen.set(false);
+      this.profileMenuOpen.set(false);
     });
   }
 
@@ -520,5 +624,42 @@ export class PersonalShellComponent {
 
   protected closeMobileMenu() {
     this.mobileMenuOpen.set(false);
+  }
+
+  protected toggleProfileMenu() {
+    this.profileMenuOpen.update((open) => !open);
+  }
+
+  protected closeProfileMenu() {
+    this.profileMenuOpen.set(false);
+  }
+
+  protected handleStayFocused() {
+    this.profileMenuOpen.set(false);
+    this.logoutDialogOpen.set(false);
+  }
+
+  protected openLogoutDialog() {
+    this.profileMenuOpen.set(false);
+    this.logoutDialogOpen.set(true);
+  }
+
+  protected closeLogoutDialog() {
+    this.logoutDialogOpen.set(false);
+  }
+
+  protected async confirmLogout() {
+    if (this.signingOut()) {
+      return;
+    }
+
+    this.signingOut.set(true);
+    try {
+      await this.authState.signOut();
+      this.logoutDialogOpen.set(false);
+      await this.router.navigateByUrl('/login');
+    } finally {
+      this.signingOut.set(false);
+    }
   }
 }

--- a/apps/frontend/src/app/features/shell/auth-shell.component.ts
+++ b/apps/frontend/src/app/features/shell/auth-shell.component.ts
@@ -3,6 +3,7 @@ import { Component, computed, inject, signal } from '@angular/core';
 import { NavigationEnd, Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { filter } from 'rxjs';
 import { AuthStateService } from '../../core/services/auth-state.service';
+import { LogoutConfirmModalComponent } from '../../shared/ui/logout-confirm-modal/logout-confirm-modal.component';
 
 type SidebarIcon = 'dashboard' | 'tasks' | 'workspaces' | 'calendar' | 'team';
 
@@ -16,7 +17,7 @@ interface SidebarItem {
 @Component({
   selector: 'app-auth-shell',
   standalone: true,
-  imports: [CommonModule, RouterLink, RouterLinkActive, RouterOutlet],
+  imports: [CommonModule, RouterLink, RouterLinkActive, RouterOutlet, LogoutConfirmModalComponent],
   template: `
     <div class="shell">
       @if (mobileMenuOpen()) {
@@ -152,12 +153,50 @@ interface SidebarItem {
         <div class="sidebar-bottom">
           <button type="button" class="invite-button">Invite Member</button>
 
-          <div class="profile-card">
-            <div class="avatar" aria-hidden="true">{{ userInitials() }}</div>
-            <div class="profile-copy">
-              <div class="profile-name">{{ displayName() }}</div>
-              <div class="profile-meta">{{ profileMeta() }}</div>
-            </div>
+          <div class="profile-menu">
+            @if (profileMenuOpen()) {
+              <button
+                type="button"
+                class="profile-menu-backdrop"
+                aria-label="Close profile menu"
+                (click)="closeProfileMenu()"
+              ></button>
+            }
+
+            <button
+              type="button"
+              class="profile-card profile-card-button"
+              [attr.aria-expanded]="profileMenuOpen()"
+              aria-label="Open account menu"
+              (click)="toggleProfileMenu()"
+            >
+              <div class="avatar" aria-hidden="true">{{ userInitials() }}</div>
+              <div class="profile-copy">
+                <div class="profile-name">{{ displayName() }}</div>
+                <div class="profile-meta">{{ profileMeta() }}</div>
+              </div>
+            </button>
+
+            @if (profileMenuOpen()) {
+              <div class="profile-menu-card" role="menu" aria-label="Account actions">
+                <button
+                  type="button"
+                  class="profile-menu-item"
+                  role="menuitem"
+                  (click)="handleStayFocused()"
+                >
+                  Stay and Focus
+                </button>
+                <button
+                  type="button"
+                  class="profile-menu-item profile-menu-item-danger"
+                  role="menuitem"
+                  (click)="openLogoutDialog()"
+                >
+                  Logout
+                </button>
+              </div>
+            }
           </div>
         </div>
       </aside>
@@ -190,6 +229,14 @@ interface SidebarItem {
         </div>
       </main>
     </div>
+
+    <app-logout-confirm-modal
+      [open]="logoutDialogOpen()"
+      [loading]="signingOut()"
+      (close)="closeLogoutDialog()"
+      (stay)="handleStayFocused()"
+      (confirm)="confirmLogout()"
+    />
   `,
   styles: [
     `
@@ -373,12 +420,67 @@ interface SidebarItem {
         letter-spacing: -0.01em;
       }
 
+      .profile-menu {
+        position: relative;
+      }
+
+      .profile-menu-backdrop {
+        position: fixed;
+        inset: 0;
+        border: 0;
+        background: transparent;
+        z-index: 4;
+      }
+
+      .profile-menu-card {
+        position: absolute;
+        bottom: calc(100% + 0.4rem);
+        left: 0;
+        right: 0;
+        border-radius: 0.9rem;
+        background: rgba(255, 251, 243, 0.97);
+        border: 1px solid rgba(226, 219, 204, 0.95);
+        box-shadow: 0 14px 30px rgba(64, 62, 51, 0.18);
+        padding: 0.3rem;
+        display: grid;
+        gap: 0.2rem;
+        z-index: 5;
+      }
+
+      .profile-menu-item {
+        border: 0;
+        border-radius: 0.64rem;
+        background: transparent;
+        color: #3d423b;
+        text-align: left;
+        font-weight: 600;
+        padding: 0.58rem 0.66rem;
+        cursor: pointer;
+      }
+
+      .profile-menu-item:hover {
+        background: rgba(207, 225, 214, 0.45);
+      }
+
+      .profile-menu-item-danger {
+        color: #8a453a;
+      }
+
       .profile-card {
+        width: 100%;
         display: flex;
         align-items: center;
         gap: 0.82rem;
         padding: 0.9rem 0.35rem 0;
         border-top: 1px solid rgba(120, 138, 143, 0.18);
+      }
+
+      .profile-card-button {
+        border-left: 0;
+        border-right: 0;
+        border-bottom: 0;
+        background: transparent;
+        cursor: pointer;
       }
 
       .avatar {
@@ -391,6 +493,7 @@ interface SidebarItem {
         place-items: center;
         font-size: 0.92rem;
         font-weight: 700;
+        flex: 0 0 auto;
       }
 
       .profile-copy {
@@ -549,6 +652,9 @@ export class AuthShellComponent {
   private router = inject(Router);
 
   protected readonly mobileMenuOpen = signal(false);
+  protected readonly profileMenuOpen = signal(false);
+  protected readonly logoutDialogOpen = signal(false);
+  protected readonly signingOut = signal(false);
 
   protected readonly navItems: SidebarItem[] = [
     { label: 'Dashboard', icon: 'dashboard', route: '/dashboard' },
@@ -604,6 +710,7 @@ export class AuthShellComponent {
   constructor() {
     this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
       this.mobileMenuOpen.set(false);
+      this.profileMenuOpen.set(false);
     });
   }
 
@@ -613,5 +720,42 @@ export class AuthShellComponent {
 
   protected closeMobileMenu() {
     this.mobileMenuOpen.set(false);
+  }
+
+  protected toggleProfileMenu() {
+    this.profileMenuOpen.update((open) => !open);
+  }
+
+  protected closeProfileMenu() {
+    this.profileMenuOpen.set(false);
+  }
+
+  protected handleStayFocused() {
+    this.profileMenuOpen.set(false);
+    this.logoutDialogOpen.set(false);
+  }
+
+  protected openLogoutDialog() {
+    this.profileMenuOpen.set(false);
+    this.logoutDialogOpen.set(true);
+  }
+
+  protected closeLogoutDialog() {
+    this.logoutDialogOpen.set(false);
+  }
+
+  protected async confirmLogout() {
+    if (this.signingOut()) {
+      return;
+    }
+
+    this.signingOut.set(true);
+    try {
+      await this.authState.signOut();
+      this.logoutDialogOpen.set(false);
+      await this.router.navigateByUrl('/login');
+    } finally {
+      this.signingOut.set(false);
+    }
   }
 }

--- a/apps/frontend/src/app/shared/ui/logout-confirm-modal/logout-confirm-modal.component.ts
+++ b/apps/frontend/src/app/shared/ui/logout-confirm-modal/logout-confirm-modal.component.ts
@@ -1,0 +1,227 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'app-logout-confirm-modal',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    @if (open) {
+      <div class="modal-shell">
+        <button
+          type="button"
+          class="backdrop"
+          aria-label="Close logout confirmation"
+          (click)="close.emit()"
+        ></button>
+
+        <section
+          class="modal-card"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="logout-modal-title"
+        >
+          <button
+            type="button"
+            class="dismiss-button"
+            aria-label="Close logout confirmation"
+            (click)="close.emit()"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M6 6l12 12" />
+              <path d="M18 6 6 18" />
+            </svg>
+          </button>
+
+          <div class="icon-wrap" aria-hidden="true">
+            <div class="icon-disc">
+              <svg viewBox="0 0 24 24">
+                <path d="M12 3v10" />
+                <path d="m16 9-4 4-4-4" />
+                <path d="M4 17v2h16v-2" />
+              </svg>
+            </div>
+          </div>
+
+          <h2 id="logout-modal-title">{{ title }}</h2>
+          <p>{{ description }}</p>
+
+          <div class="actions">
+            <button
+              type="button"
+              class="secondary-button"
+              [disabled]="loading"
+              (click)="stay.emit()"
+            >
+              {{ stayLabel }}
+            </button>
+            <button
+              type="button"
+              class="primary-button"
+              [disabled]="loading"
+              (click)="confirm.emit()"
+            >
+              {{ loading ? loadingLabel : confirmLabel }}
+            </button>
+          </div>
+        </section>
+      </div>
+    }
+  `,
+  styles: [
+    `
+      :host {
+        display: contents;
+      }
+
+      .modal-shell {
+        position: fixed;
+        inset: 0;
+        z-index: 60;
+        display: grid;
+        place-items: center;
+        padding: 1.5rem;
+      }
+
+      .backdrop {
+        position: absolute;
+        inset: 0;
+        border: 0;
+        background: rgba(42, 39, 32, 0.22);
+        backdrop-filter: blur(4px);
+      }
+
+      .modal-card {
+        position: relative;
+        z-index: 1;
+        width: min(100%, 30rem);
+        border-radius: 1.8rem;
+        background: #fcfbf7;
+        border: 1px solid rgba(230, 224, 209, 0.95);
+        box-shadow: 0 28px 58px rgba(78, 71, 57, 0.18);
+        padding: 2rem 1.9rem 1.5rem;
+        text-align: center;
+      }
+
+      .dismiss-button {
+        position: absolute;
+        top: 0.85rem;
+        right: 0.85rem;
+        width: 2rem;
+        height: 2rem;
+        border: 0;
+        border-radius: 999px;
+        background: transparent;
+        color: #7d7767;
+        cursor: pointer;
+      }
+
+      .dismiss-button svg {
+        width: 100%;
+        height: 100%;
+        display: block;
+        stroke: currentColor;
+        fill: none;
+        stroke-width: 1.8;
+        stroke-linecap: round;
+      }
+
+      .icon-wrap {
+        display: grid;
+        place-items: center;
+        margin-bottom: 1rem;
+      }
+
+      .icon-disc {
+        width: 4.4rem;
+        height: 4.4rem;
+        border-radius: 999px;
+        background: #f0efe8;
+        display: grid;
+        place-items: center;
+      }
+
+      .icon-disc svg {
+        width: 2rem;
+        height: 2rem;
+        stroke: #6d947c;
+        fill: none;
+        stroke-width: 1.8;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+      }
+
+      h2 {
+        margin: 0;
+        color: #1f2420;
+        font-size: clamp(1.8rem, 3.2vw, 2.4rem);
+        line-height: 1.02;
+        letter-spacing: -0.04em;
+      }
+
+      p {
+        margin: 0.95rem auto 0;
+        max-width: 22rem;
+        color: #5e6159;
+        font-size: 1rem;
+        line-height: 1.45;
+      }
+
+      .actions {
+        margin-top: 1.5rem;
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.7rem;
+      }
+
+      .primary-button,
+      .secondary-button {
+        border: 0;
+        border-radius: 999px;
+        min-height: 2.8rem;
+        padding: 0 0.9rem;
+        font-size: 0.96rem;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+        cursor: pointer;
+      }
+
+      .primary-button {
+        background: #2b7f57;
+        color: #f5faf4;
+        box-shadow: 0 10px 22px rgba(43, 127, 87, 0.28);
+      }
+
+      .secondary-button {
+        background: #ece9df;
+        color: #4f5149;
+      }
+
+      .primary-button:disabled,
+      .secondary-button:disabled {
+        opacity: 0.75;
+        cursor: default;
+      }
+
+      @media (max-width: 540px) {
+        .modal-card {
+          padding: 1.6rem 1.2rem 1.2rem;
+          border-radius: 1.3rem;
+        }
+      }
+    `,
+  ],
+})
+export class LogoutConfirmModalComponent {
+  @Input() open = false;
+  @Input() loading = false;
+  @Input() title = 'Leave the Sanctuary?';
+  @Input() description =
+    "Your progress is safe. We'll be here when you're ready to find your focus again.";
+  @Input() stayLabel = 'Stay and Focus';
+  @Input() confirmLabel = 'Logout';
+  @Input() loadingLabel = 'Logging out...';
+  @Output() readonly close = new EventEmitter<void>();
+  @Output() readonly stay = new EventEmitter<void>();
+  @Output() readonly confirm = new EventEmitter<void>();
+}


### PR DESCRIPTION
Introduce avatar-triggered account menus in both shell layouts and add a reusable logout confirmation modal so sign-out is deliberate and consistent across personal and team experiences.

## Description

Adds a unified logout flow across both shell experiences by introducing an account dropdown and a reusable confirmation modal before sign-out.

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Test coverage improvement
- [ ] Performance improvement
- [ ] Refactoring (code improvement with no functional change)

## Related Issue

Closes: #

## Roadmap Reference

Implements the logout confirmation UX for account actions across both personal and team shell layouts.

## Changes Made

- Added avatar/profile-triggered account dropdowns in both personal and team/auth shells
- Added Stay and Focus and Logout actions to account menus
- Added a reusable shared logout confirmation modal component
- Wired confirm action to `AuthStateService.signOut()` with redirect to `/login`
- Added dropdown/modal state handling and route-change cleanup behavior
- Matched modal/dropdown styling to the existing sanctuary UI aesthetic

## Testing

### Test Coverage

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed

### Verification Steps

1. Open personal shell and click the avatar to confirm the account dropdown opens
2. Click Stay and Focus and confirm the UI closes while session remains active
3. Click Logout from the dropdown and confirm the logout modal opens
4. Close/cancel the modal and confirm session remains active
5. Confirm Logout in the modal and verify sign-out plus redirect to `/login`
6. Repeat the same flow in the team/auth shell
7. Verify lint/pre-commit checks pass with no new warnings or errors

## Screenshots or Demo

<!-- Add screenshots or demo links here -->

## Checklist

- [x] Code follows the project style and conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have verified that this PR is against the correct branch (`main`)

## Additional Notes

Validation is currently manual plus lint/pre-commit checks.

Follow-up enhancement: keyboard/focus accessibility improvements for dropdown and modal interactions.
