### PR TITLE
Improve mobile layout for personal workspace screens

### DIFF
--- a/apps/frontend/src/app/features/personal/components/personal-project-modal.component.ts
+++ b/apps/frontend/src/app/features/personal/components/personal-project-modal.component.ts
@@ -237,6 +237,31 @@ import { PROJECT_PALETTE } from '../project-presentation';
         background: #ede6d8;
         color: #5d584d;
       }
+
+      @media (max-width: 640px) {
+        .modal-shell {
+          padding: 0;
+          place-items: end center;
+        }
+
+        .modal-card {
+          width: 100%;
+          max-height: 92dvh;
+          border-radius: 1.4rem 1.4rem 0 0;
+          padding: 1.25rem;
+          overflow: auto;
+        }
+
+        .actions {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .primary-button,
+        .secondary-button {
+          width: 100%;
+        }
+      }
     `,
   ],
 })

--- a/apps/frontend/src/app/features/personal/components/personal-task-card.component.ts
+++ b/apps/frontend/src/app/features/personal/components/personal-task-card.component.ts
@@ -196,6 +196,24 @@ import { Task, TaskBucket } from '@yotara/shared';
         .task-card {
           padding: 1rem;
           border-radius: 1rem;
+          gap: 0.8rem;
+        }
+
+        .task-title-row {
+          flex-direction: column;
+          align-items: flex-start;
+          gap: 0.45rem;
+        }
+
+        .task-meta {
+          gap: 0.35rem;
+          margin-top: 0.65rem;
+        }
+
+        .meta-pill,
+        .priority-chip {
+          font-size: 0.64rem;
+          padding: 0.16rem 0.5rem;
         }
 
         h3 {

--- a/apps/frontend/src/app/features/personal/components/personal-task-modal.component.ts
+++ b/apps/frontend/src/app/features/personal/components/personal-task-modal.component.ts
@@ -475,6 +475,52 @@ type SavePayload =
           border-top: 1px solid rgba(229, 220, 200, 0.95);
         }
       }
+
+      @media (max-width: 640px) {
+        .modal-shell {
+          padding: 0;
+          place-items: end center;
+        }
+
+        .modal-card {
+          width: 100%;
+          max-height: 92dvh;
+          border-radius: 1.4rem 1.4rem 0 0;
+        }
+
+        .modal-main,
+        .modal-sidebar {
+          padding: 1.2rem;
+        }
+
+        .modal-header {
+          align-items: center;
+        }
+
+        .title-row {
+          gap: 0.75rem;
+        }
+
+        .title-row h2 {
+          font-size: 1.5rem;
+        }
+
+        .bucket-chip,
+        .primary-button,
+        .secondary-button,
+        .status-select,
+        .toggle-row {
+          width: 100%;
+        }
+
+        .bucket-grid {
+          gap: 0.5rem;
+        }
+
+        .actions {
+          grid-template-columns: 1fr;
+        }
+      }
     `,
   ],
 })

--- a/apps/frontend/src/app/features/personal/pages/inbox-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/inbox-page.component.ts
@@ -312,15 +312,26 @@ import { PersonalTaskWorkspaceComponent } from '../components/personal-task-work
         }
 
         .capture-bar {
-          grid-template-columns: auto minmax(0, 1fr);
+          grid-template-columns: 1fr;
+          align-items: stretch;
+          gap: 0.65rem;
+        }
+
+        .capture-plus {
+          width: 2.4rem;
+          height: 2.4rem;
         }
 
         .capture-actions {
-          display: none;
+          justify-content: flex-start;
         }
 
         .capture-submit {
-          grid-column: 1 / -1;
+          width: 100%;
+        }
+
+        .promo-grid {
+          grid-template-columns: 1fr;
         }
       }
     `,

--- a/apps/frontend/src/app/features/personal/pages/projects-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/projects-page.component.ts
@@ -371,6 +371,32 @@ import { projectPaletteFor, projectProgressPercent } from '../project-presentati
       }
 
       @media (max-width: 720px) {
+        .hero-row {
+          align-items: stretch;
+        }
+
+        .hero-button,
+        .focus-button {
+          width: 100%;
+        }
+
+        .project-card,
+        .project-card-create,
+        .empty-shell,
+        .focus-card {
+          padding: 1.15rem;
+        }
+
+        .progress-copy {
+          flex-direction: column;
+          align-items: flex-start;
+          gap: 0.35rem;
+        }
+
+        .meta-row {
+          gap: 0.45rem;
+        }
+
         .fab {
           right: 1rem;
           bottom: 1rem;


### PR DESCRIPTION
## Summary\n- stack the Inbox capture bar more naturally on small screens\n- tighten task card spacing and metadata density on mobile\n- make task and project modals behave like mobile sheets\n- reduce cramped spacing on the Projects page for phone widths\n\n## Verification\n- pnpm --filter @yotara/frontend typecheck