### PR TITLE
Multiple users were broken. Fixing it.

### DIFF
--- a/apps/frontend/src/app/core/services/auth-state.service.ts
+++ b/apps/frontend/src/app/core/services/auth-state.service.ts
@@ -18,6 +18,9 @@ export class AuthStateService {
   readonly initialized = this.initializedState.asReadonly();
   readonly loading = this.loadingState.asReadonly();
   readonly isAuthenticated = computed(() => !!this.sessionState());
+  readonly currentUserId = computed(
+    () => this.userState()?.id ?? this.sessionState()?.userId ?? null,
+  );
   readonly needsOnboarding = computed(
     () => this.isAuthenticated() && !this.userState()?.onboardingCompleted,
   );

--- a/apps/frontend/src/app/core/services/project.service.spec.ts
+++ b/apps/frontend/src/app/core/services/project.service.spec.ts
@@ -8,10 +8,12 @@ import { ProjectService } from './project.service';
 describe('ProjectService', () => {
   const initialized = signal(false);
   const isAuthenticated = signal(false);
+  const currentUserId = signal<string | null>(null);
 
   beforeEach(() => {
     initialized.set(false);
     isAuthenticated.set(false);
+    currentUserId.set(null);
 
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -22,6 +24,7 @@ describe('ProjectService', () => {
           useValue: {
             initialized,
             isAuthenticated,
+            currentUserId,
           },
         },
       ],
@@ -49,6 +52,7 @@ describe('ProjectService', () => {
 
     initialized.set(true);
     isAuthenticated.set(true);
+    currentUserId.set('user-1');
     tick();
 
     const projects: Project[] = [
@@ -75,12 +79,70 @@ describe('ProjectService', () => {
     expect(service.hasProjects()).toBeTrue();
   }));
 
+  it('drops the previous user projects and reloads for the next login', fakeAsync(() => {
+    const service = TestBed.inject(ProjectService);
+    const http = TestBed.inject(HttpTestingController);
+
+    initialized.set(true);
+    isAuthenticated.set(true);
+    currentUserId.set('user-1');
+    tick();
+
+    http.expectOne('http://localhost:3000/projects').flush([
+      {
+        id: 'project-1',
+        name: 'User One Project',
+        description: 'First account',
+        color: 'sage',
+        ownerId: 'user-1',
+        taskCount: 1,
+        completedTaskCount: 0,
+        openTaskCount: 1,
+        createdAt: '2026-04-01T10:00:00.000Z',
+        updatedAt: '2026-04-03T10:00:00.000Z',
+      },
+    ]);
+    tick();
+
+    expect(service.projects().map((project) => project.id)).toEqual(['project-1']);
+
+    currentUserId.set(null);
+    isAuthenticated.set(false);
+    tick();
+
+    expect(service.projects()).toEqual([]);
+    http.expectNone('http://localhost:3000/projects');
+
+    isAuthenticated.set(true);
+    currentUserId.set('user-2');
+    tick();
+
+    http.expectOne('http://localhost:3000/projects').flush([
+      {
+        id: 'project-2',
+        name: 'User Two Project',
+        description: 'Second account',
+        color: 'olive',
+        ownerId: 'user-2',
+        taskCount: 2,
+        completedTaskCount: 1,
+        openTaskCount: 1,
+        createdAt: '2026-04-04T10:00:00.000Z',
+        updatedAt: '2026-04-05T10:00:00.000Z',
+      },
+    ]);
+    tick();
+
+    expect(service.projects().map((project) => project.id)).toEqual(['project-2']);
+  }));
+
   it('creates a project and refreshes the list', fakeAsync(() => {
     const service = TestBed.inject(ProjectService);
     const http = TestBed.inject(HttpTestingController);
 
     initialized.set(true);
     isAuthenticated.set(true);
+    currentUserId.set('user-1');
     tick();
 
     http.expectOne('http://localhost:3000/projects').flush([]);

--- a/apps/frontend/src/app/core/services/project.service.ts
+++ b/apps/frontend/src/app/core/services/project.service.ts
@@ -28,10 +28,11 @@ export class ProjectService {
   readonly projects = toSignal(
     combineLatest([
       toObservable(this.authState.initialized).pipe(distinctUntilChanged()),
+      toObservable(this.authState.currentUserId).pipe(distinctUntilChanged()),
       toObservable(this.refreshState),
     ]).pipe(
-      switchMap(([initialized]) => {
-        if (!initialized || !this.authState.isAuthenticated()) {
+      switchMap(([initialized, currentUserId]) => {
+        if (!initialized || !currentUserId) {
           this.errorState.set(null);
           return of([] as Project[]);
         }

--- a/apps/frontend/src/app/core/services/task.service.spec.ts
+++ b/apps/frontend/src/app/core/services/task.service.spec.ts
@@ -8,6 +8,7 @@ import { Task } from '@yotara/shared';
 describe('TaskService', () => {
   const initialized = signal(false);
   const isAuthenticated = signal(false);
+  const currentUserId = signal<string | null>(null);
 
   function dayOffset(offset: number) {
     const date = new Date();
@@ -32,6 +33,7 @@ describe('TaskService', () => {
   beforeEach(() => {
     initialized.set(false);
     isAuthenticated.set(false);
+    currentUserId.set(null);
 
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -42,6 +44,7 @@ describe('TaskService', () => {
           useValue: {
             initialized,
             isAuthenticated,
+            currentUserId,
           },
         },
       ],
@@ -74,12 +77,74 @@ describe('TaskService', () => {
     http.expectNone('http://localhost:3000/tasks?page=1&pageSize=100');
   }));
 
+  it('clears the previous user data and refetches when the active account changes', fakeAsync(() => {
+    const service = TestBed.inject(TaskService);
+    const http = TestBed.inject(HttpTestingController);
+
+    initialized.set(true);
+    isAuthenticated.set(true);
+    currentUserId.set('user-1');
+    tick();
+
+    http.expectOne('http://localhost:3000/tasks?page=1&pageSize=100').flush(
+      paginated([
+        {
+          id: 'user-1-task',
+          title: 'User one task',
+          status: 'inbox',
+          priority: 'medium',
+          completed: false,
+          simpleMode: true,
+          bucket: 'personal-sanctuary',
+          order: 0,
+          createdAt: dayOffset(0),
+          updatedAt: dayOffset(0),
+        },
+      ]),
+    );
+    tick();
+
+    expect(service.tasks().map((task) => task.id)).toEqual(['user-1-task']);
+
+    currentUserId.set(null);
+    isAuthenticated.set(false);
+    tick();
+
+    expect(service.tasks()).toEqual([]);
+    http.expectNone('http://localhost:3000/tasks?page=1&pageSize=100');
+
+    isAuthenticated.set(true);
+    currentUserId.set('user-2');
+    tick();
+
+    http.expectOne('http://localhost:3000/tasks?page=1&pageSize=100').flush(
+      paginated([
+        {
+          id: 'user-2-task',
+          title: 'User two task',
+          status: 'today',
+          priority: 'high',
+          completed: false,
+          simpleMode: false,
+          bucket: 'deep-work',
+          order: 0,
+          createdAt: dayOffset(1),
+          updatedAt: dayOffset(1),
+        },
+      ]),
+    );
+    tick();
+
+    expect(service.tasks().map((task) => task.id)).toEqual(['user-2-task']);
+  }));
+
   it('returns an empty list when the tasks endpoint responds with 401', fakeAsync(() => {
     const service = TestBed.inject(TaskService);
     const http = TestBed.inject(HttpTestingController);
 
     initialized.set(true);
     isAuthenticated.set(true);
+    currentUserId.set('user-1');
     tick();
 
     const request = http.expectOne('http://localhost:3000/tasks?page=1&pageSize=100');
@@ -98,6 +163,7 @@ describe('TaskService', () => {
 
     initialized.set(true);
     isAuthenticated.set(true);
+    currentUserId.set('user-1');
     tick();
 
     const tasks: Task[] = [
@@ -189,6 +255,7 @@ describe('TaskService', () => {
 
     initialized.set(true);
     isAuthenticated.set(true);
+    currentUserId.set('user-1');
     tick();
 
     http.expectOne('http://localhost:3000/tasks?page=1&pageSize=100').flush(paginated([]));
@@ -253,6 +320,7 @@ describe('TaskService', () => {
 
     initialized.set(true);
     isAuthenticated.set(true);
+    currentUserId.set('user-1');
     tick();
 
     http.expectOne('http://localhost:3000/tasks?page=1&pageSize=100').flush(paginated([]));

--- a/apps/frontend/src/app/core/services/task.service.ts
+++ b/apps/frontend/src/app/core/services/task.service.ts
@@ -35,10 +35,11 @@ export class TaskService {
   readonly tasks = toSignal(
     combineLatest([
       toObservable(this.authState.initialized).pipe(distinctUntilChanged()),
+      toObservable(this.authState.currentUserId).pipe(distinctUntilChanged()),
       toObservable(this.refreshState),
     ]).pipe(
-      switchMap(([initialized]) => {
-        if (!initialized || !this.authState.isAuthenticated()) {
+      switchMap(([initialized, currentUserId]) => {
+        if (!initialized || !currentUserId) {
           this.errorState.set(null);
           return of([] as Task[]);
         }


### PR DESCRIPTION
## Description

The UI was not loading the new user details on login

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Test coverage improvement
- [ ] Performance improvement
- [ ] Refactoring (code improvement with no functional change)




## Changes Made

The cross-user bug was in the frontend state layer, not the API. Tasks and projects were only reacting to initial auth setup plus manual refreshes, so after logout/login they could keep showing the previous user’s in-memory data or stay empty until something else forced a reload.


### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed

### Verification Steps

1. Login with 1 user create tasks
2. Login with another user and create tasks
3. See that tasks are different for both users



## Checklist

- [ ] Code follows the project style and conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [x ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] I have verified that this PR is against the correct branch (`main`)

