### PR TITLE
Misc/element sizing

### DIFF
--- a/apps/frontend/src/app/features/auth/login.component.html
+++ b/apps/frontend/src/app/features/auth/login.component.html
@@ -3,6 +3,7 @@
     <div class="hero-icon" aria-hidden="true">
       <svg viewBox="0 0 24 24">
         <path
+          class="hero-leaf"
           d="M20 4C11 4 4 10.3 4 18c0 .9.1 1.8.4 2.6A9.8 9.8 0 0 0 12 24c6.6 0 12-5.4 12-12V4h-4Z"
         />
         <path
@@ -42,7 +43,7 @@
       <div class="field-group">
         <label for="email">Email</label>
         <div class="input-wrap" [class.input-wrap-invalid]="shouldShowFieldError('email')">
-          <span class="input-icon" aria-hidden="true">✉</span>
+          <fa-icon class="input-icon" [icon]="faEnvelope" aria-hidden="true"></fa-icon>
           <input
             id="email"
             type="email"
@@ -68,7 +69,7 @@
           }
         </div>
         <div class="input-wrap" [class.input-wrap-invalid]="shouldShowFieldError('password')">
-          <span class="input-icon" aria-hidden="true">🔒</span>
+          <fa-icon class="input-icon" [icon]="faLock" aria-hidden="true"></fa-icon>
           <input
             id="password"
             type="password"

--- a/apps/frontend/src/app/features/auth/login.component.scss
+++ b/apps/frontend/src/app/features/auth/login.component.scss
@@ -128,7 +128,7 @@ input::placeholder {
   border: 0;
   border-radius: 1rem;
   background: var(--primary-gradient);
-  color: var(--primary-foreground);
+  color: hsl(var(--primary-foreground));
   min-height: 3.6rem;
   font-size: 1.05rem;
   font-weight: 700;

--- a/apps/frontend/src/app/features/auth/login.component.scss
+++ b/apps/frontend/src/app/features/auth/login.component.scss
@@ -18,15 +18,15 @@
   width: min(100%, 32rem);
   background: var(--surface-card);
   box-shadow: inset 0 0 0 1px var(--outline-variant);
-  border-radius: 0.9rem;
+  border-radius: 1.5rem;
   padding: 2rem 2rem 1.7rem;
 }
 
 .hero-icon {
-  width: 4.75rem;
-  height: 4.75rem;
+  width: 5.75rem;
+  height: 5.75rem;
   border-radius: 999px;
-  background: var(--surface-container-low);
+  background: var(--surface-container-high);
   color: var(--primary-solid);
   display: grid;
   place-items: center;
@@ -34,14 +34,17 @@
 }
 
 .hero-icon svg {
-  width: 2rem;
-  height: 2rem;
+  width: 2.7rem;
+  height: 2.7rem;
   display: block;
+}
+
+.hero-leaf {
   fill: currentColor;
 }
 
 .hero-vein {
-  fill: var(--primary-foreground);
+  fill: var(--surface-container-lowest);
 }
 
 h1 {
@@ -88,20 +91,21 @@ label {
   align-items: center;
   gap: 0.55rem;
   box-shadow: inset 0 0 0 1px var(--outline-variant);
-  border-radius: 0.55rem;
+  border-radius: 1rem;
   background: var(--surface-container-lowest);
   padding: 0 0.85rem;
   min-height: 3.25rem;
 }
 
 .input-wrap-invalid {
-  box-shadow: inset 0 0 0 1px rgba(186, 109, 87, 0.5);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--primary-solid) 60%, #c8846d);
 }
 
 .input-icon {
   color: var(--on-surface-subtle);
   font-size: 1rem;
   line-height: 1;
+  flex: 0 0 auto;
 }
 
 input {
@@ -122,7 +126,7 @@ input::placeholder {
   width: 100%;
   margin-top: 1rem;
   border: 0;
-  border-radius: 0.55rem;
+  border-radius: 1rem;
   background: var(--primary-gradient);
   color: var(--primary-foreground);
   min-height: 3.6rem;

--- a/apps/frontend/src/app/features/auth/login.component.scss
+++ b/apps/frontend/src/app/features/auth/login.component.scss
@@ -4,31 +4,30 @@
 
 .login-screen {
   min-height: 100dvh;
-  background: #f4f2ea;
+  background: var(--surface);
   padding: 1.5rem 1rem 2.25rem;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  font-family: 'Avenir Next', 'Manrope', 'Segoe UI', sans-serif;
-  color: #304335;
+  font-family: var(--font-sans);
+  color: var(--on-surface);
 }
 
 .auth-card {
   width: min(100%, 32rem);
-  background: #f8f8f5;
-  border: 1px solid #dbe0d8;
+  background: var(--surface-card);
+  box-shadow: inset 0 0 0 1px var(--outline-variant);
   border-radius: 0.9rem;
   padding: 2rem 2rem 1.7rem;
-  box-shadow: 0 1px 2px rgba(31, 49, 38, 0.06);
 }
 
 .hero-icon {
   width: 4.75rem;
   height: 4.75rem;
   border-radius: 999px;
-  background: #e6eadf;
-  color: #4f986f;
+  background: var(--surface-container-low);
+  color: var(--primary-solid);
   display: grid;
   place-items: center;
   margin: 0 auto 1.2rem;
@@ -42,7 +41,7 @@
 }
 
 .hero-vein {
-  fill: #f2f4ee;
+  fill: var(--primary-foreground);
 }
 
 h1 {
@@ -51,14 +50,14 @@ h1 {
   text-align: center;
   line-height: 1.15;
   letter-spacing: -0.02em;
-  color: #2f4538;
+  color: var(--on-surface);
 }
 
 .subtitle {
   margin: 0.5rem 0 1.8rem;
   text-align: center;
   font-size: 1.05rem;
-  color: #72a687;
+  color: var(--on-surface-muted);
 }
 
 form {
@@ -74,7 +73,7 @@ label {
   margin-bottom: 0.5rem;
   font-size: 1.05rem;
   font-weight: 600;
-  color: #314034;
+  color: var(--on-surface);
 }
 
 .password-label {
@@ -88,20 +87,19 @@ label {
   display: flex;
   align-items: center;
   gap: 0.55rem;
-  border: 1px solid #cfd8ce;
+  box-shadow: inset 0 0 0 1px var(--outline-variant);
   border-radius: 0.55rem;
-  background: #f8faf7;
+  background: var(--surface-container-lowest);
   padding: 0 0.85rem;
   min-height: 3.25rem;
 }
 
 .input-wrap-invalid {
-  border-color: #cb6565;
-  box-shadow: 0 0 0 1px rgba(203, 101, 101, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(186, 109, 87, 0.5);
 }
 
 .input-icon {
-  color: #a5b7a8;
+  color: var(--on-surface-subtle);
   font-size: 1rem;
   line-height: 1;
 }
@@ -112,12 +110,12 @@ input {
   width: 100%;
   background: transparent;
   font-size: 1rem;
-  color: #314034;
+  color: var(--on-surface);
   padding: 0.85rem 0;
 }
 
 input::placeholder {
-  color: #b2c3b5;
+  color: var(--on-surface-subtle);
 }
 
 .submit-button {
@@ -125,13 +123,13 @@ input::placeholder {
   margin-top: 1rem;
   border: 0;
   border-radius: 0.55rem;
-  background: #4f986f;
-  color: #f3f7f2;
+  background: var(--primary-gradient);
+  color: var(--primary-foreground);
   min-height: 3.6rem;
   font-size: 1.05rem;
   font-weight: 700;
   cursor: pointer;
-  box-shadow: 0 6px 14px rgba(55, 116, 84, 0.2);
+  box-shadow: 0 6px 14px var(--surface-dim-strong);
 }
 
 .submit-button:disabled {
@@ -141,32 +139,32 @@ input::placeholder {
 
 .error-msg {
   margin-top: 0.4rem;
-  color: #b13a3a;
+  color: #c8846d;
   font-size: 0.88rem;
 }
 
 .field-error {
   margin-top: 0.4rem;
-  color: #b13a3a;
+  color: #c8846d;
   font-size: 0.85rem;
 }
 
 .divider {
   margin: 1.8rem 0 1rem;
-  border-top: 1px solid #dbe0d8;
+  box-shadow: inset 0 1px 0 0 var(--outline-variant);
 }
 
 .toggle-mode {
   margin: 0;
   font-size: 0.95rem;
-  color: #8c9a8d;
+  color: var(--on-surface-subtle);
   text-align: center;
 }
 
 .link-button {
   border: 0;
   background: transparent;
-  color: #4f986f;
+  color: var(--primary-solid);
   font-size: 0.95rem;
   font-weight: 500;
   cursor: pointer;
@@ -182,7 +180,7 @@ input::placeholder {
 
 .footer-note {
   margin: 1.3rem 0 0;
-  color: #bfd3c0;
+  color: var(--on-surface-subtle);
   font-size: 0.72rem;
   text-align: center;
 }

--- a/apps/frontend/src/app/features/auth/login.component.ts
+++ b/apps/frontend/src/app/features/auth/login.component.ts
@@ -1,16 +1,20 @@
 import { Component, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { faEnvelope, faLock } from '@fortawesome/free-solid-svg-icons';
 import { AuthStateService } from '../../core/services/auth-state.service';
 
 @Component({
   selector: 'app-login',
   standalone: true,
-  imports: [FormsModule],
+  imports: [FormsModule, FontAwesomeModule],
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.scss'],
 })
 export class LoginComponent {
+  protected readonly faEnvelope = faEnvelope;
+  protected readonly faLock = faLock;
   isLogin = signal(true);
   email = signal('');
   password = signal('');

--- a/apps/frontend/src/app/features/onboarding/pages/start-screen/start-screen.component.css
+++ b/apps/frontend/src/app/features/onboarding/pages/start-screen/start-screen.component.css
@@ -79,7 +79,7 @@
 }
 
 .hero-vein {
-  fill: var(--primary-foreground);
+  fill: hsl(var(--primary-foreground));
 }
 
 h1 {
@@ -139,7 +139,7 @@ h1 {
   height: 1.45rem;
   border-radius: 999px;
   background: var(--primary-gradient);
-  color: var(--primary-foreground);
+  color: hsl(var(--primary-foreground));
   font-size: 0.88rem;
   font-weight: 700;
   display: none;
@@ -193,7 +193,7 @@ h1 {
   border: 0;
   border-radius: 999px;
   background: var(--primary-gradient);
-  color: var(--primary-foreground);
+  color: hsl(var(--primary-foreground));
   font-size: 1.35rem;
   font-weight: 650;
   letter-spacing: -0.01em;

--- a/apps/frontend/src/app/features/onboarding/pages/start-screen/start-screen.component.css
+++ b/apps/frontend/src/app/features/onboarding/pages/start-screen/start-screen.component.css
@@ -4,9 +4,9 @@
 
 .onboarding-screen {
   min-height: 100dvh;
-  background: #f4f2ea;
-  color: #111b33;
-  font-family: 'Avenir Next', 'Manrope', 'Segoe UI', sans-serif;
+  background: var(--surface);
+  color: var(--on-surface);
+  font-family: var(--font-sans);
 }
 
 .onboarding-header {
@@ -25,7 +25,7 @@
 .brand-mark {
   width: 2rem;
   height: 2rem;
-  color: #4f986f;
+  color: var(--primary-solid);
 }
 
 .brand-mark svg {
@@ -42,10 +42,10 @@
 }
 
 .help-button {
-  border: 1px solid #c6cec5;
+  box-shadow: inset 0 0 0 1px var(--outline-variant);
   border-radius: 999px;
-  background: #f1f1ec;
-  color: #2f8b63;
+  background: var(--surface-container-lowest);
+  color: var(--primary-solid);
   font-size: 1rem;
   font-weight: 600;
   line-height: 1;
@@ -65,8 +65,8 @@
   width: 4.8rem;
   height: 4.8rem;
   border-radius: 999px;
-  background: #e4e7dd;
-  color: #4f986f;
+  background: var(--surface-container-low);
+  color: var(--primary-solid);
   display: grid;
   place-items: center;
   margin-bottom: 1rem;
@@ -79,7 +79,7 @@
 }
 
 .hero-vein {
-  fill: #f1f2ec;
+  fill: var(--primary-foreground);
 }
 
 h1 {
@@ -91,7 +91,7 @@ h1 {
 
 .subtitle {
   margin: 0.5rem 0 1.4rem;
-  color: #3e5773;
+  color: var(--on-surface-muted);
   font-size: clamp(1rem, 1.35vw, 1.15rem);
   max-width: 26ch;
 }
@@ -100,8 +100,8 @@ h1 {
   margin: 0 0 1.1rem;
   padding: 0.6rem 0.9rem;
   border-radius: 999px;
-  background: #e7f3ea;
-  color: #2f6f4f;
+  background: var(--primary-soft);
+  color: var(--primary-solid);
   font-size: 0.9rem;
   font-weight: 600;
 }
@@ -114,9 +114,9 @@ h1 {
 }
 
 .workspace-card {
-  border: 1px solid #e2e5e8;
+  box-shadow: inset 0 0 0 1px var(--outline-variant);
   border-radius: 0.9rem;
-  background: #f8f8f9;
+  background: var(--surface-card);
   min-height: 13.25rem;
   padding: 1rem 1.1rem 1.1rem;
   text-align: center;
@@ -128,9 +128,7 @@ h1 {
 }
 
 .workspace-card.selected {
-  border-width: 2px;
-  border-color: #308d64;
-  box-shadow: 0 0 0 2px rgba(48, 141, 100, 0.08);
+  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--primary-solid) 66%, transparent);
 }
 
 .card-check {
@@ -140,8 +138,8 @@ h1 {
   width: 1.45rem;
   height: 1.45rem;
   border-radius: 999px;
-  background: #4f986f;
-  color: #f5f6f3;
+  background: var(--primary-gradient);
+  color: var(--primary-foreground);
   font-size: 0.88rem;
   font-weight: 700;
   display: none;
@@ -158,8 +156,8 @@ h1 {
   height: 2.6rem;
   margin: 0.55rem auto 0.8rem;
   border-radius: 999px;
-  background: #eef0ee;
-  color: #4f986f;
+  background: var(--surface-container-low);
+  color: var(--primary-solid);
   display: grid;
   place-items: center;
 }
@@ -185,7 +183,7 @@ h1 {
 .workspace-card p {
   margin: 0.55rem auto 0;
   max-width: 22ch;
-  color: #506889;
+  color: var(--on-surface-muted);
   font-size: 0.96rem;
   line-height: 1.35;
 }
@@ -194,14 +192,14 @@ h1 {
   margin-top: 1.4rem;
   border: 0;
   border-radius: 999px;
-  background: #4f986f;
-  color: #f7f7f2;
+  background: var(--primary-gradient);
+  color: var(--primary-foreground);
   font-size: 1.35rem;
   font-weight: 650;
   letter-spacing: -0.01em;
   min-width: 14rem;
   padding: 0.8rem 1.5rem;
-  box-shadow: 0 8px 18px rgba(42, 96, 70, 0.2);
+  box-shadow: 0 8px 18px var(--surface-dim-strong);
   cursor: pointer;
 }
 
@@ -212,7 +210,7 @@ h1 {
 
 .submit-error {
   margin: 1rem 0 0;
-  color: #b13a3a;
+  color: #c8846d;
   font-size: 0.95rem;
 }
 
@@ -226,11 +224,11 @@ h1 {
   width: 0.58rem;
   height: 0.58rem;
   border-radius: 999px;
-  background: #cad5c8;
+  background: var(--surface-container-highest);
 }
 
 .dot.active {
-  background: #4f986f;
+  background: var(--primary-solid);
 }
 
 @media (max-width: 860px) {

--- a/apps/frontend/src/app/features/personal/components/personal-project-modal.component.ts
+++ b/apps/frontend/src/app/features/personal/components/personal-project-modal.component.ts
@@ -231,7 +231,7 @@ import { PROJECT_PALETTE } from '../project-presentation';
 
       .primary-button {
         background: var(--primary-gradient);
-        color: #f7fbf6;
+        color: hsl(var(--primary-foreground));
       }
 
       .secondary-button {

--- a/apps/frontend/src/app/features/personal/components/personal-project-modal.component.ts
+++ b/apps/frontend/src/app/features/personal/components/personal-project-modal.component.ts
@@ -105,7 +105,7 @@ import { PROJECT_PALETTE } from '../project-presentation';
         position: absolute;
         inset: 0;
         border: 0;
-        background: rgba(41, 39, 31, 0.18);
+        background: rgba(28, 28, 23, 0.18);
         backdrop-filter: blur(10px);
       }
 
@@ -114,9 +114,10 @@ import { PROJECT_PALETTE } from '../project-presentation';
         z-index: 1;
         width: min(100%, 32rem);
         border-radius: 1.7rem;
-        background: rgba(255, 255, 255, 0.94);
-        border: 1px solid rgba(235, 227, 208, 0.95);
-        box-shadow: 0 28px 60px rgba(88, 79, 59, 0.18);
+        background: var(--surface-container-lowest);
+        box-shadow:
+          0 28px 60px var(--surface-dim-strong),
+          inset 0 0 0 1px var(--outline-variant);
         padding: 1.5rem;
       }
 
@@ -135,13 +136,13 @@ import { PROJECT_PALETTE } from '../project-presentation';
 
       .modal-header p {
         margin: 0.35rem 0 0;
-        color: #7e786d;
+        color: var(--on-surface-muted);
       }
 
       .close-button {
         border: 0;
         background: transparent;
-        color: #6f6a5e;
+        color: var(--on-surface-muted);
         font-size: 2rem;
         line-height: 1;
       }
@@ -153,7 +154,7 @@ import { PROJECT_PALETTE } from '../project-presentation';
       }
 
       .field-label {
-        color: #9c957f;
+        color: var(--on-surface-subtle);
         text-transform: uppercase;
         letter-spacing: 0.14em;
         font-size: 0.76rem;
@@ -163,10 +164,10 @@ import { PROJECT_PALETTE } from '../project-presentation';
       input,
       textarea {
         width: 100%;
-        border: 1px solid rgba(231, 222, 204, 0.95);
         border-radius: 1rem;
-        background: #f6f2e7;
-        color: #2f302b;
+        background: var(--surface-container-lowest);
+        box-shadow: inset 0 0 0 1px var(--outline-variant);
+        color: var(--on-surface);
         font: inherit;
         padding: 0.95rem 1rem;
         box-sizing: border-box;
@@ -178,8 +179,8 @@ import { PROJECT_PALETTE } from '../project-presentation';
       }
 
       input.field-error {
-        border-color: #ba6d57;
-        background: rgba(255, 245, 242, 0.95);
+        box-shadow: inset 0 0 0 1px rgba(186, 109, 87, 0.55);
+        background: color-mix(in srgb, var(--surface-container-lowest) 88%, #f5e3da);
       }
 
       .field-error-message,
@@ -197,7 +198,7 @@ import { PROJECT_PALETTE } from '../project-presentation';
       }
 
       .color-chip {
-        --chip-color: #4a8a63;
+        --chip-color: var(--primary-solid);
         width: 2rem;
         height: 2rem;
         border-radius: 999px;
@@ -229,13 +230,13 @@ import { PROJECT_PALETTE } from '../project-presentation';
       }
 
       .primary-button {
-        background: #2d7c53;
+        background: var(--primary-gradient);
         color: #f7fbf6;
       }
 
       .secondary-button {
-        background: #ede6d8;
-        color: #5d584d;
+        background: var(--surface-container-low);
+        color: var(--on-surface-muted);
       }
 
       @media (max-width: 640px) {

--- a/apps/frontend/src/app/features/personal/components/personal-task-card.component.ts
+++ b/apps/frontend/src/app/features/personal/components/personal-task-card.component.ts
@@ -95,14 +95,18 @@ import { ConfirmDialogComponent } from '../../../shared/ui/confirm-dialog/confir
         grid-template-columns: auto minmax(0, 1fr);
         gap: 1rem;
         border-radius: 1.3rem;
-        background: rgba(255, 255, 255, 0.9);
-        border: 1px solid rgba(235, 228, 212, 0.9);
-        box-shadow: 0 14px 30px rgba(105, 97, 74, 0.06);
+        background: var(--surface-card);
+        box-shadow:
+          0 14px 30px var(--surface-dim),
+          inset 0 0 0 1px var(--outline-variant);
         padding: 1.15rem 1.2rem;
       }
 
       .task-card-overdue {
-        border-left: 4px solid #dd8b4c;
+        box-shadow:
+          0 14px 30px var(--surface-dim),
+          inset 0 0 0 1px var(--outline-variant),
+          inset 4px 0 0 0 #dd8b4c;
       }
 
       .task-card-interactive {
@@ -110,7 +114,7 @@ import { ConfirmDialogComponent } from '../../../shared/ui/confirm-dialog/confir
       }
 
       .task-card-complete {
-        background: rgba(252, 250, 243, 0.76);
+        background: color-mix(in srgb, var(--surface-card) 84%, var(--surface-container-low));
         box-shadow: none;
         opacity: 0.76;
       }
@@ -132,8 +136,8 @@ import { ConfirmDialogComponent } from '../../../shared/ui/confirm-dialog/confir
         width: 1.02rem;
         height: 1.02rem;
         border-radius: 0.28rem;
-        border: 1.5px solid #b9c2bb;
-        background: #ffffff;
+        box-shadow: inset 0 0 0 1px var(--outline-variant);
+        background: var(--surface-container-lowest);
         display: grid;
         place-items: center;
         transition:
@@ -144,7 +148,6 @@ import { ConfirmDialogComponent } from '../../../shared/ui/confirm-dialog/confir
 
       .task-check-complete .task-check-box {
         background: #84a4f6;
-        border-color: #84a4f6;
         box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
       }
 
@@ -187,7 +190,7 @@ import { ConfirmDialogComponent } from '../../../shared/ui/confirm-dialog/confir
         font-size: 1.18rem;
         line-height: 1.3;
         letter-spacing: -0.03em;
-        color: #262a24;
+        color: var(--on-surface);
       }
 
       .task-card-complete h3 {
@@ -196,7 +199,7 @@ import { ConfirmDialogComponent } from '../../../shared/ui/confirm-dialog/confir
 
       .task-description {
         margin: 0.45rem 0 0;
-        color: #827b6f;
+        color: var(--on-surface-muted);
         font-size: 0.96rem;
         line-height: 1.45;
       }
@@ -220,43 +223,43 @@ import { ConfirmDialogComponent } from '../../../shared/ui/confirm-dialog/confir
       }
 
       .meta-pill {
-        background: #f2eee3;
-        color: #7a7468;
+        background: var(--surface-container-low);
+        color: var(--on-surface-muted);
       }
 
       .meta-pill-muted {
-        background: #f5f2ea;
-        color: #92897b;
+        background: var(--surface-container-low);
+        color: var(--on-surface-subtle);
       }
 
       .meta-pill-complete {
-        background: #dff0e3;
-        color: #3d7b59;
+        background: var(--primary-soft);
+        color: var(--primary-solid);
       }
 
       .meta-pill-bucket {
-        background: #dff0e6;
-        color: #41785a;
+        background: var(--accent-soft);
+        color: var(--primary-solid);
       }
 
       .meta-pill-simple {
-        background: #edf0f5;
-        color: #6d7690;
+        background: var(--info-soft);
+        color: var(--on-surface-muted);
       }
 
       .priority-chip-high {
-        background: #f9e5de;
+        background: var(--danger-soft);
         color: #cc764b;
       }
 
       .priority-chip-medium {
-        background: #f6edd8;
+        background: var(--warning-soft);
         color: #b28734;
       }
 
       .priority-chip-low {
-        background: #e0efe2;
-        color: #508164;
+        background: var(--primary-soft);
+        color: var(--primary-solid);
       }
 
       @media (max-width: 720px) {

--- a/apps/frontend/src/app/features/personal/components/personal-task-modal.component.scss
+++ b/apps/frontend/src/app/features/personal/components/personal-task-modal.component.scss
@@ -252,7 +252,7 @@ textarea {
 
 .primary-button {
   background: var(--primary-gradient);
-  color: #f7fbf6;
+  color: hsl(var(--primary-foreground));
 }
 
 .secondary-button {

--- a/apps/frontend/src/app/features/personal/components/personal-task-modal.component.scss
+++ b/apps/frontend/src/app/features/personal/components/personal-task-modal.component.scss
@@ -15,7 +15,7 @@
   position: absolute;
   inset: 0;
   border: 0;
-  background: rgba(47, 46, 39, 0.2);
+  background: rgba(28, 28, 23, 0.2);
   backdrop-filter: blur(6px);
 }
 
@@ -28,9 +28,8 @@
   display: grid;
   grid-template-columns: minmax(0, 1.6fr) minmax(16rem, 18rem);
   border-radius: 2rem;
-  background: #f8f4e8;
-  border: 1px solid rgba(229, 220, 200, 0.95);
-  box-shadow: 0 30px 60px rgba(88, 79, 59, 0.15);
+  background: var(--surface-container-lowest);
+  box-shadow: 0 30px 60px var(--surface-dim-strong), inset 0 0 0 1px var(--outline-variant);
 }
 
 .modal-main {
@@ -39,8 +38,8 @@
 
 .modal-sidebar {
   padding: 1.8rem 1.4rem 1.6rem;
-  background: rgba(250, 246, 236, 0.7);
-  border-left: 1px solid rgba(229, 220, 200, 0.95);
+  background: var(--surface-container-low);
+  box-shadow: inset 1px 0 0 0 var(--outline-variant);
 }
 
 .modal-header,
@@ -64,14 +63,14 @@ h2 {
 
 .title-row p {
   margin: 0.35rem 0 0;
-  color: #4e8a67;
+  color: var(--primary-solid);
   font-size: 0.94rem;
 }
 
 .close-button {
   border: 0;
   background: transparent;
-  color: #7d776b;
+  color: var(--on-surface-muted);
   font-size: 2rem;
   line-height: 1;
 }
@@ -84,7 +83,7 @@ h2 {
 }
 
 .field-label {
-  color: #9c957f;
+  color: var(--on-surface-subtle);
   text-transform: uppercase;
   letter-spacing: 0.14em;
   font-size: 0.76rem;
@@ -95,10 +94,10 @@ input,
 textarea,
 select {
   width: 100%;
-  border: 1px solid rgba(231, 222, 204, 0.95);
   border-radius: 1rem;
-  background: rgba(255, 255, 255, 0.92);
-  color: #2f302b;
+  background: var(--surface-container-lowest);
+  box-shadow: inset 0 0 0 1px var(--outline-variant);
+  color: var(--on-surface);
   font: inherit;
   padding: 0.95rem 1rem;
   box-sizing: border-box;
@@ -107,8 +106,8 @@ select {
 input.field-error,
 textarea.field-error,
 select.field-error {
-  border-color: #ba6d57;
-  background-color: rgba(255, 245, 242, 0.92);
+  box-shadow: inset 0 0 0 1px rgba(186, 109, 87, 0.55);
+  background-color: color-mix(in srgb, var(--surface-container-lowest) 88%, #f5e3da);
 }
 
 .field-error-message {
@@ -134,17 +133,15 @@ textarea {
 }
 
 .bucket-chip {
-  border: 1px solid rgba(221, 228, 213, 0.95);
   border-radius: 999px;
-  background: #eef7f0;
-  color: #497a60;
+  background: var(--primary-soft);
+  color: var(--primary-solid);
   padding: 0.5rem 0.8rem;
   font-weight: 700;
 }
 
 .bucket-chip-active {
-  background: #d7f0de;
-  border-color: #7db18f;
+  background: var(--primary-soft-strong);
 }
 
 .toggle-row {
@@ -153,10 +150,10 @@ textarea {
   justify-content: space-between;
   gap: 0.9rem;
   border-radius: 1rem;
-  background: rgba(255, 255, 255, 0.9);
-  border: 1px solid rgba(231, 222, 204, 0.95);
+  background: var(--surface-container-lowest);
+  box-shadow: inset 0 0 0 1px var(--outline-variant);
   padding: 0.85rem 1rem;
-  color: #666156;
+  color: var(--on-surface-muted);
 }
 
 .checkbox-control {
@@ -181,8 +178,8 @@ textarea {
   width: 1.02rem;
   height: 1.02rem;
   border-radius: 0.28rem;
-  border: 1.5px solid #b9c2bb;
-  background: #ffffff;
+  background: var(--surface-container-lowest);
+  box-shadow: inset 0 0 0 1px var(--outline-variant);
   display: grid;
   place-items: center;
   transition:
@@ -193,7 +190,6 @@ textarea {
 
 .checkbox-control input:checked + .checkbox-box {
   background: #84a4f6;
-  border-color: #84a4f6;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
 }
 
@@ -215,7 +211,7 @@ textarea {
   height: 1.15rem;
   border-radius: 999px;
   border: 0;
-  background: #d9ddd4;
+  background: var(--surface-container-highest);
   box-shadow: inset 0 0 0 6px transparent;
 }
 
@@ -228,7 +224,7 @@ textarea {
 }
 
 .priority-dot-low.priority-dot-active {
-  background: #5a9a6d;
+  background: var(--primary-solid);
 }
 
 .priority-dot:not(.priority-dot-active) {
@@ -255,13 +251,13 @@ textarea {
 }
 
 .primary-button {
-  background: #256c47;
+  background: var(--primary-gradient);
   color: #f7fbf6;
 }
 
 .secondary-button {
-  background: #ece7d9;
-  color: #5e5a50;
+  background: var(--surface-container-high);
+  color: var(--on-surface-muted);
 }
 
 .error-copy {
@@ -276,8 +272,7 @@ textarea {
   }
 
   .modal-sidebar {
-    border-left: 0;
-    border-top: 1px solid rgba(229, 220, 200, 0.95);
+    box-shadow: inset 0 1px 0 0 var(--outline-variant);
   }
 }
 

--- a/apps/frontend/src/app/features/personal/pages/archive-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/archive-page.component.ts
@@ -64,7 +64,7 @@ import { PersonalTaskWorkspaceComponent } from '../components/personal-task-work
 
       .status-copy {
         margin-top: 0.6rem;
-        color: #8a8378;
+        color: var(--on-surface-muted);
         font-size: 1.08rem;
       }
 
@@ -74,7 +74,7 @@ import { PersonalTaskWorkspaceComponent } from '../components/personal-task-work
         align-items: baseline;
         justify-content: space-between;
         gap: 1rem;
-        color: #7f786d;
+        color: var(--on-surface-muted);
       }
 
       .archive-summary span {
@@ -91,8 +91,8 @@ import { PersonalTaskWorkspaceComponent } from '../components/personal-task-work
       .task-stack,
       .empty-state {
         border-radius: 1.5rem;
-        background: rgba(255, 251, 242, 0.72);
-        border: 1px solid rgba(236, 228, 210, 0.9);
+        background: var(--surface-card);
+        box-shadow: inset 0 0 0 1px var(--outline-variant);
         padding: 1.25rem;
       }
 
@@ -109,7 +109,7 @@ import { PersonalTaskWorkspaceComponent } from '../components/personal-task-work
 
       .empty-state p {
         margin: 0.55rem 0 0;
-        color: #8a8378;
+        color: var(--on-surface-muted);
       }
     `,
   ],

--- a/apps/frontend/src/app/features/personal/pages/inbox-page.component.scss
+++ b/apps/frontend/src/app/features/personal/pages/inbox-page.component.scss
@@ -15,7 +15,7 @@
 
 .page-header p {
   margin: 0.55rem 0 0;
-  color: #8a8378;
+  color: var(--on-surface-muted);
   font-size: 1.12rem;
 }
 
@@ -25,10 +25,9 @@
   grid-template-columns: auto minmax(0, 1fr) auto auto;
   align-items: center;
   gap: 0.8rem;
-  background: rgba(255, 255, 255, 0.94);
+  background: var(--surface-card);
   border-radius: 1.2rem;
-  border: 1px solid rgba(236, 228, 210, 0.9);
-  box-shadow: 0 18px 32px rgba(120, 109, 83, 0.08);
+  box-shadow: inset 0 0 0 1px var(--outline-variant), 0 18px 32px var(--surface-dim);
   padding: 0.8rem 0.95rem;
 }
 
@@ -37,8 +36,8 @@
   height: 2rem;
   border: 0;
   border-radius: 999px;
-  background: #2e7b53;
-  color: #f5f7f2;
+  background: var(--primary-gradient);
+  color: var(--primary-foreground);
   font-size: 1.4rem;
   line-height: 1;
 }
@@ -47,26 +46,26 @@
   border: 0;
   outline: none;
   background: transparent;
-  color: #2e312a;
+  color: var(--on-surface);
   font-size: 1.06rem;
 }
 
 .capture-bar input::placeholder {
-  color: #c0b7a9;
+  color: var(--on-surface-subtle);
 }
 
 .capture-actions {
   display: flex;
   align-items: center;
   gap: 0.6rem;
-  color: #b9b1a6;
+  color: var(--on-surface-subtle);
 }
 
 .capture-submit {
   border: 0;
   border-radius: 0.92rem;
-  background: #256c47;
-  color: #f8faf5;
+  background: var(--primary-gradient);
+  color: var(--primary-foreground);
   font-weight: 700;
   min-width: 6.8rem;
   min-height: 2.8rem;
@@ -76,7 +75,7 @@
 .capture-error,
 .status-copy {
   margin: 0.7rem 0 0;
-  color: #8a8378;
+  color: var(--on-surface-muted);
 }
 
 .capture-error {
@@ -101,14 +100,14 @@
   font-weight: 800;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: #98907f;
+  color: var(--on-surface-subtle);
 }
 
 .section-count {
   border-radius: 999px;
-  background: #eee8d8;
+  background: var(--surface-container-low);
   padding: 0.28rem 0.7rem;
-  color: #7e776b;
+  color: var(--on-surface-muted);
   font-size: 0.76rem;
   font-weight: 700;
 }
@@ -119,9 +118,9 @@
 }
 
 .empty-state {
-  border: 1px dashed rgba(224, 215, 196, 0.95);
   border-radius: 1.4rem;
-  background: rgba(255, 251, 242, 0.6);
+  background: var(--surface-card);
+  box-shadow: inset 0 0 0 1px var(--outline-variant);
   padding: 2rem 1.3rem;
   text-align: center;
 }
@@ -135,7 +134,7 @@
 .empty-state p {
   margin: 0.55rem auto 0;
   max-width: 28rem;
-  color: #8a8378;
+  color: var(--on-surface-muted);
 }
 
 .promo-grid {
@@ -151,16 +150,16 @@
 }
 
 .promo-card-soft {
-  background: rgba(255, 252, 243, 0.72);
-  border: 1px dashed rgba(224, 215, 196, 0.95);
+  background: var(--surface-card);
+  box-shadow: inset 0 0 0 1px var(--outline-variant);
 }
 
 .promo-icon {
   width: 4rem;
   height: 4rem;
   border-radius: 999px;
-  background: #dcf4e2;
-  color: #2c7c54;
+  background: var(--primary-soft);
+  color: var(--primary-solid);
   display: grid;
   place-items: center;
   font-size: 1.4rem;
@@ -173,12 +172,12 @@
 
 .promo-card-soft p,
 .promo-card-dark span {
-  color: #8a8378;
+  color: var(--on-surface-muted);
 }
 
 .promo-card-dark {
-  background: linear-gradient(135deg, #101815, #1f4434);
-  color: #f2f4ee;
+  background: linear-gradient(135deg, var(--surface-container-highest), var(--surface-container-high));
+  color: var(--primary-foreground);
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
@@ -192,7 +191,7 @@
 
 .promo-card-dark span {
   margin-top: 1rem;
-  color: #c2d4c8;
+  color: var(--on-surface-subtle);
   font-size: 0.82rem;
   text-transform: uppercase;
   letter-spacing: 0.18em;

--- a/apps/frontend/src/app/features/personal/pages/inbox-page.component.scss
+++ b/apps/frontend/src/app/features/personal/pages/inbox-page.component.scss
@@ -36,8 +36,8 @@
   height: 2rem;
   border: 0;
   border-radius: 999px;
-  background: var(--primary-gradient);
-  color: var(--primary-foreground);
+  background: var(--primary-action-gradient);
+  color: hsl(var(--primary-foreground));
   font-size: 1.4rem;
   line-height: 1;
 }
@@ -64,8 +64,8 @@
 .capture-submit {
   border: 0;
   border-radius: 0.92rem;
-  background: var(--primary-gradient);
-  color: var(--primary-foreground);
+  background: var(--primary-action-gradient);
+  color: hsl(var(--primary-foreground));
   font-weight: 700;
   min-width: 6.8rem;
   min-height: 2.8rem;
@@ -177,7 +177,7 @@
 
 .promo-card-dark {
   background: linear-gradient(135deg, var(--surface-container-highest), var(--surface-container-high));
-  color: var(--primary-foreground);
+  color: hsl(var(--primary-foreground));
   display: flex;
   flex-direction: column;
   justify-content: flex-end;

--- a/apps/frontend/src/app/features/personal/pages/labels-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/labels-page.component.ts
@@ -59,8 +59,8 @@ interface PersonalLabelSummary {
       .label-card,
       .note-panel {
         border-radius: 1.5rem;
-        background: rgba(255, 251, 242, 0.72);
-        border: 1px solid rgba(236, 228, 210, 0.9);
+        background: var(--surface-card);
+        box-shadow: inset 0 0 0 1px var(--outline-variant);
         padding: 1.35rem;
       }
 
@@ -80,7 +80,7 @@ interface PersonalLabelSummary {
       .label-card p,
       .note-panel p {
         margin: 0.55rem 0 0;
-        color: #8a8378;
+        color: var(--on-surface-muted);
         line-height: 1.45;
       }
 
@@ -92,7 +92,7 @@ interface PersonalLabelSummary {
         font-size: 0.84rem;
         text-transform: uppercase;
         letter-spacing: 0.16em;
-        color: #6d756c;
+        color: var(--on-surface-subtle);
       }
 
       @media (max-width: 900px) {

--- a/apps/frontend/src/app/features/personal/pages/project-detail-page.component.scss
+++ b/apps/frontend/src/app/features/personal/pages/project-detail-page.component.scss
@@ -7,7 +7,7 @@
       }
 
       .back-link {
-        color: #7d776d;
+        color: var(--on-surface-muted);
         text-decoration: none;
         font-weight: 600;
       }
@@ -15,7 +15,8 @@
       .hero-card {
         margin-top: 1rem;
         border-radius: 1.8rem;
-        border: 1px solid rgba(235, 227, 208, 0.92);
+        background: var(--surface-card);
+        box-shadow: inset 0 0 0 1px var(--outline-variant);
         padding: 1.6rem;
         display: grid;
         grid-template-columns: auto minmax(0, 1fr);
@@ -35,7 +36,7 @@
 
       .eyebrow {
         margin: 0;
-        color: #8c8a7b;
+        color: var(--on-surface-subtle);
         text-transform: uppercase;
         letter-spacing: 0.16em;
         font-size: 0.76rem;
@@ -52,7 +53,7 @@
       .subtitle,
       .status-copy {
         margin: 0.7rem 0 0;
-        color: #7b756a;
+        color: var(--on-surface-muted);
         font-size: 1.05rem;
         line-height: 1.5;
       }
@@ -60,8 +61,8 @@
       .metrics-card {
         margin-top: 1.4rem;
         border-radius: 1.5rem;
-        background: rgba(255, 251, 242, 0.78);
-        border: 1px solid rgba(235, 227, 208, 0.92);
+        background: var(--surface-card);
+        box-shadow: inset 0 0 0 1px var(--outline-variant);
         padding: 1.2rem 1.25rem;
         display: grid;
         grid-template-columns: repeat(2, minmax(0, 10rem)) minmax(0, 1fr);
@@ -73,13 +74,13 @@
         display: block;
         font-size: 2rem;
         letter-spacing: -0.05em;
-        color: #27573f;
+        color: var(--primary-solid);
       }
 
       .metric span,
       .progress-copy span,
       .section-heading span {
-        color: #857f73;
+        color: var(--on-surface-subtle);
         font-size: 0.88rem;
       }
 
@@ -94,14 +95,14 @@
         text-transform: uppercase;
         letter-spacing: 0.06em;
         font-size: 0.82rem;
-        color: #2f6f4d;
+        color: var(--primary-solid);
       }
 
       .progress-track {
         margin-top: 0.65rem;
         height: 0.5rem;
         border-radius: 999px;
-        background: rgba(233, 227, 213, 0.95);
+        background: var(--surface-container-low);
         overflow: hidden;
       }
 
@@ -120,10 +121,10 @@
 
       .view-pill {
         border-radius: 999px;
-        background: rgba(255, 255, 255, 0.9);
-        border: 1px solid rgba(235, 227, 208, 0.95);
+        background: var(--surface-container-lowest);
+        box-shadow: inset 0 0 0 1px var(--outline-variant);
         padding: 0.6rem 1rem;
-        color: #2d6b49;
+        color: var(--primary-solid);
         font-weight: 700;
       }
 
@@ -132,8 +133,8 @@
       .empty-button {
         border: 0;
         border-radius: 1rem;
-        background: #2d7c53;
-        color: #f7fbf6;
+        background: var(--primary-gradient);
+        color: var(--primary-foreground);
         min-height: 3rem;
         padding: 0 1.1rem;
         font-weight: 700;
@@ -174,29 +175,29 @@
       .inline-create {
         justify-content: flex-start;
         background: transparent;
-        color: #7c7568;
-        border: 1px dashed rgba(220, 210, 190, 0.95);
+        color: var(--on-surface-muted);
+        box-shadow: inset 0 0 0 1px var(--outline-variant);
       }
 
       .empty-state {
         margin-top: 1.8rem;
         border-radius: 1.7rem;
-        background: rgba(255, 251, 242, 0.74);
-        border: 1px solid rgba(235, 227, 208, 0.92);
+        background: var(--surface-card);
+        box-shadow: inset 0 0 0 1px var(--outline-variant);
         padding: 2.2rem 1.5rem;
         text-align: center;
       }
 
       .empty-emblem {
         margin: 0 auto;
-        background: rgba(255, 255, 255, 0.9);
-        color: #bcb4a5;
+        background: var(--surface-container-lowest);
+        color: var(--on-surface-subtle);
       }
 
       .quote {
         max-width: 28rem;
         margin: 1.1rem auto 0;
-        color: #665f54;
+        color: var(--on-surface-muted);
         font-size: 1.08rem;
         line-height: 1.7;
       }

--- a/apps/frontend/src/app/features/personal/pages/project-detail-page.component.scss
+++ b/apps/frontend/src/app/features/personal/pages/project-detail-page.component.scss
@@ -134,7 +134,7 @@
         border: 0;
         border-radius: 1rem;
         background: var(--primary-gradient);
-        color: var(--primary-foreground);
+        color: hsl(var(--primary-foreground));
         min-height: 3rem;
         padding: 0 1.1rem;
         font-weight: 700;

--- a/apps/frontend/src/app/features/personal/pages/projects-page.component.scss
+++ b/apps/frontend/src/app/features/personal/pages/projects-page.component.scss
@@ -17,7 +17,7 @@
       .eyebrow,
       .focus-eyebrow {
         margin: 0;
-        color: #9f9887;
+        color: var(--on-surface-subtle);
         text-transform: uppercase;
         letter-spacing: 0.16em;
         font-size: 0.82rem;
@@ -34,7 +34,7 @@
       .subtitle {
         margin: 0.7rem 0 0;
         max-width: 36rem;
-        color: #7f796f;
+        color: var(--on-surface-muted);
         font-size: 1.08rem;
         line-height: 1.5;
       }
@@ -44,8 +44,8 @@
       .focus-button {
         border: 0;
         border-radius: 1rem;
-        background: #2d7c53;
-        color: #f7fbf6;
+        background: var(--primary-gradient);
+        color: var(--primary-foreground);
         font-weight: 700;
         min-height: 3rem;
         padding: 0 1.15rem;
@@ -57,7 +57,7 @@
 
       .status-copy {
         margin-top: 2rem;
-        color: #8a8378;
+        color: var(--on-surface-muted);
       }
 
       .project-grid {
@@ -71,10 +71,10 @@
         position: relative;
         min-height: 18rem;
         border-radius: 1.6rem;
-        border: 1px solid rgba(235, 227, 208, 0.92);
+        background: var(--surface-card);
+        box-shadow: 0 18px 36px var(--surface-dim), inset 0 0 0 1px var(--outline-variant);
         padding: 1.35rem;
         cursor: pointer;
-        box-shadow: 0 18px 36px rgba(105, 97, 74, 0.08);
       }
 
       .project-card h2,
@@ -90,7 +90,7 @@
       .project-card-create p,
       .empty-shell p,
       .focus-card p {
-        color: #797266;
+        color: var(--on-surface-muted);
         line-height: 1.5;
       }
 
@@ -108,7 +108,7 @@
         position: absolute;
         top: 1.35rem;
         right: 1.2rem;
-        color: #a49b8d;
+        color: var(--on-surface-subtle);
         letter-spacing: 0.18em;
       }
 
@@ -122,18 +122,18 @@
       }
 
       .progress-copy strong {
-        color: #345a47;
+        color: var(--primary-solid);
       }
 
       .progress-copy span {
-        color: #847d70;
+        color: var(--on-surface-subtle);
       }
 
       .progress-track {
         margin-top: 0.75rem;
         height: 0.45rem;
         border-radius: 999px;
-        background: rgba(255, 255, 255, 0.86);
+        background: var(--surface-container-low);
         overflow: hidden;
       }
 
@@ -153,9 +153,9 @@
 
       .meta-pill {
         border-radius: 999px;
-        background: rgba(255, 255, 255, 0.88);
+        background: var(--surface-container-lowest);
         padding: 0.28rem 0.7rem;
-        color: #516457;
+        color: var(--on-surface-muted);
         font-size: 0.72rem;
         font-weight: 700;
         text-transform: uppercase;
@@ -163,13 +163,13 @@
       }
 
       .meta-pill-soft {
-        color: #7f796d;
+        color: var(--on-surface-subtle);
       }
 
       .project-card-create,
       .empty-shell {
-        background: rgba(255, 251, 242, 0.72);
-        border: 1px dashed rgba(222, 214, 195, 0.95);
+        background: var(--surface-card);
+        box-shadow: inset 0 0 0 1px var(--outline-variant);
         text-align: center;
       }
 
@@ -182,8 +182,8 @@
 
       .create-orb,
       .empty-orb {
-        background: #f0ece0;
-        color: #9b9588;
+        background: var(--surface-container-low);
+        color: var(--on-surface-subtle);
         font-size: 1.6rem;
       }
 
@@ -195,8 +195,8 @@
       .focus-card {
         margin-top: 2rem;
         border-radius: 1.8rem;
-        background: rgba(255, 251, 242, 0.74);
-        border: 1px solid rgba(235, 227, 208, 0.92);
+        background: var(--surface-card);
+        box-shadow: inset 0 0 0 1px var(--outline-variant);
         padding: 1.5rem;
         display: grid;
         grid-template-columns: minmax(0, 1.2fr) minmax(14rem, 18rem);
@@ -211,7 +211,9 @@
       .focus-visual {
         min-height: 13rem;
         border-radius: 1.5rem;
-        background: radial-gradient(circle at 35% 30%, #f2e8cd, transparent 32%), #3f3428;
+        background:
+          radial-gradient(circle at 35% 30%, rgba(242, 232, 205, 0.8), transparent 32%),
+          var(--surface-container-highest);
         display: grid;
         place-items: center;
         overflow: hidden;
@@ -221,8 +223,8 @@
         width: 6.5rem;
         height: 6.5rem;
         border-radius: 999px;
-        background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.85), #7ca690);
-        box-shadow: 0 0 0 2rem rgba(245, 250, 244, 0.08);
+        background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.85), var(--accent-strong));
+        box-shadow: 0 0 0 2rem var(--surface-dim);
       }
 
       .fab {
@@ -233,10 +235,10 @@
         height: 3.75rem;
         border-radius: 999px;
         border: 0;
-        background: #2d7c53;
-        color: #f7faf5;
+        background: var(--primary-gradient);
+        color: var(--primary-foreground);
         font-size: 2rem;
-        box-shadow: 0 18px 36px rgba(45, 124, 83, 0.22);
+        box-shadow: 0 18px 36px var(--surface-dim-strong);
       }
 
       @media (max-width: 1080px) {

--- a/apps/frontend/src/app/features/personal/pages/projects-page.component.scss
+++ b/apps/frontend/src/app/features/personal/pages/projects-page.component.scss
@@ -45,7 +45,7 @@
         border: 0;
         border-radius: 1rem;
         background: var(--primary-gradient);
-        color: var(--primary-foreground);
+        color: hsl(var(--primary-foreground));
         font-weight: 700;
         min-height: 3rem;
         padding: 0 1.15rem;
@@ -236,7 +236,7 @@
         border-radius: 999px;
         border: 0;
         background: var(--primary-gradient);
-        color: var(--primary-foreground);
+        color: hsl(var(--primary-foreground));
         font-size: 2rem;
         box-shadow: 0 18px 36px var(--surface-dim-strong);
       }

--- a/apps/frontend/src/app/features/personal/pages/search-page.component.scss
+++ b/apps/frontend/src/app/features/personal/pages/search-page.component.scss
@@ -8,8 +8,8 @@
 
 .header-chip {
   border-radius: 999px;
-  background: rgba(37, 108, 71, 0.1);
-  color: #2c6a49;
+  background: var(--primary-soft);
+  color: var(--primary-solid);
   padding: 0.55rem 0.8rem;
   font-size: 0.84rem;
   font-weight: 700;
@@ -30,13 +30,14 @@
   gap: 0.55rem;
   border-radius: 999px;
   padding: 0.82rem 1rem;
-  background: rgba(255, 251, 242, 0.88);
-  border: 1px solid rgba(232, 224, 208, 0.9);
+  background: var(--surface-overlay);
+  box-shadow: inset 0 0 0 1px var(--outline-variant);
 }
 
 .search-input-shell:focus-within {
-  border-color: rgba(75, 133, 96, 0.36);
-  box-shadow: 0 0 0 4px rgba(208, 238, 218, 0.36);
+  box-shadow:
+    inset 0 0 0 1px rgba(35, 104, 73, 0.32),
+    0 10px 28px rgba(28, 28, 23, 0.05);
 }
 
 .search-input-shell input {
@@ -44,18 +45,18 @@
   border: 0;
   outline: none;
   background: transparent;
-  color: #4f534b;
+  color: var(--on-surface);
   font-size: 0.96rem;
 }
 
 .search-input-shell input::placeholder {
-  color: #a6a193;
+  color: var(--on-surface-subtle);
 }
 
 .search-button {
   border: 0;
   border-radius: 999px;
-  background: #256c47;
+  background: var(--primary-gradient);
   color: #f5f8f2;
   font-size: 0.9rem;
   font-weight: 700;
@@ -65,7 +66,7 @@
 .search-icon {
   width: 1rem;
   height: 1rem;
-  color: #a6a193;
+  color: var(--on-surface-subtle);
   flex: 0 0 auto;
 }
 
@@ -88,10 +89,10 @@
 }
 
 .tab-chip {
-  border: 1px solid rgba(226, 217, 198, 0.9);
   border-radius: 999px;
-  background: rgba(255, 251, 242, 0.82);
-  color: #5f645b;
+  background: var(--surface-overlay);
+  box-shadow: inset 0 0 0 1px var(--outline-variant);
+  color: var(--on-surface-muted);
   display: inline-flex;
   align-items: center;
   gap: 0.45rem;
@@ -103,14 +104,13 @@
 .tab-chip strong {
   border-radius: 999px;
   padding: 0.15rem 0.45rem;
-  background: rgba(37, 108, 71, 0.1);
-  color: #285f41;
+  background: var(--primary-soft);
+  color: var(--primary-solid);
 }
 
 .tab-chip-active {
-  border-color: rgba(37, 108, 71, 0.18);
-  background: #dff0e7;
-  color: #275f41;
+  background: var(--primary-soft-strong);
+  color: var(--primary-solid);
 }
 
 .result-group {
@@ -132,7 +132,7 @@
 }
 
 .group-header span {
-  color: #7f7a6f;
+  color: var(--on-surface-muted);
   font-size: 0.88rem;
 }
 
@@ -151,9 +151,8 @@
   display: grid;
   gap: 0.8rem;
   border-radius: 1.25rem;
-  background: rgba(255, 255, 255, 0.88);
-  border: 1px solid rgba(235, 228, 212, 0.9);
-  box-shadow: 0 14px 28px rgba(105, 97, 74, 0.05);
+  background: var(--surface-card);
+  box-shadow: 0 14px 28px var(--surface-dim);
   padding: 1.05rem 1.1rem;
   color: inherit;
   text-decoration: none;
@@ -173,14 +172,14 @@
 }
 
 .project-topline span {
-  color: #7a7369;
+  color: var(--on-surface-subtle);
   font-size: 0.82rem;
   text-align: right;
 }
 
 .project-card p {
   margin: 0;
-  color: #7d776d;
+  color: var(--on-surface-muted);
   line-height: 1.45;
 }
 
@@ -189,22 +188,22 @@
   align-items: center;
   gap: 0.55rem;
   flex-wrap: wrap;
-  color: #6d685d;
+  color: var(--on-surface-muted);
   font-size: 0.8rem;
   font-weight: 700;
 }
 
 .project-meta span {
   border-radius: 999px;
-  background: #f1ede3;
+  background: var(--surface-container-low);
   padding: 0.25rem 0.55rem;
 }
 
 .empty-state {
   margin-top: 1.25rem;
   border-radius: 1.4rem;
-  border: 1px dashed rgba(224, 215, 196, 0.95);
-  background: rgba(255, 251, 242, 0.68);
+  box-shadow: inset 0 0 0 1px var(--outline-variant);
+  background: var(--surface-card);
   padding: 1.6rem 1.3rem;
 }
 
@@ -220,7 +219,7 @@
 
 .empty-state p {
   margin: 0.55rem 0 0;
-  color: #7f7a6f;
+  color: var(--on-surface-muted);
   line-height: 1.45;
 }
 

--- a/apps/frontend/src/app/features/personal/pages/search-page.component.scss
+++ b/apps/frontend/src/app/features/personal/pages/search-page.component.scss
@@ -56,8 +56,8 @@
 .search-button {
   border: 0;
   border-radius: 999px;
-  background: var(--primary-gradient);
-  color: #f5f8f2;
+  background: var(--primary-action-gradient);
+  color: hsl(var(--primary-foreground));
   font-size: 0.9rem;
   font-weight: 700;
   padding: 0.82rem 1.1rem;

--- a/apps/frontend/src/app/features/personal/pages/today-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/today-page.component.ts
@@ -261,7 +261,7 @@ import { PersonalTaskWorkspaceComponent } from '../components/personal-task-work
         height: 4rem;
         border-radius: 999px;
         background: var(--primary-gradient);
-        color: var(--primary-foreground);
+        color: hsl(var(--primary-foreground));
         text-decoration: none;
         font-size: 2rem;
         display: grid;

--- a/apps/frontend/src/app/features/personal/pages/today-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/today-page.component.ts
@@ -128,7 +128,7 @@ import { PersonalTaskWorkspaceComponent } from '../components/personal-task-work
 
       .eyebrow {
         margin: 0;
-        color: #9f9887;
+        color: var(--on-surface-subtle);
         text-transform: uppercase;
         letter-spacing: 0.16em;
         font-size: 0.82rem;
@@ -144,7 +144,7 @@ import { PersonalTaskWorkspaceComponent } from '../components/personal-task-work
 
       .subtitle {
         margin: 0.65rem 0 0;
-        color: #7d776e;
+        color: var(--on-surface-muted);
         font-size: 1.1rem;
       }
 
@@ -154,8 +154,8 @@ import { PersonalTaskWorkspaceComponent } from '../components/personal-task-work
         align-items: center;
         gap: 0.85rem;
         border-radius: 1.2rem;
-        background: rgba(255, 251, 241, 0.72);
-        border: 1px solid rgba(235, 227, 208, 0.9);
+        background: var(--surface-card);
+        box-shadow: inset 0 0 0 1px var(--outline-variant);
         padding: 0.85rem 0.95rem;
       }
 
@@ -163,8 +163,8 @@ import { PersonalTaskWorkspaceComponent } from '../components/personal-task-work
         width: 2.5rem;
         height: 2.5rem;
         border-radius: 0.9rem;
-        background: #e0f1e4;
-        color: #2f7a54;
+        background: var(--primary-soft);
+        color: var(--primary-solid);
         display: grid;
         place-items: center;
       }
@@ -174,12 +174,12 @@ import { PersonalTaskWorkspaceComponent } from '../components/personal-task-work
         text-transform: uppercase;
         letter-spacing: 0.08em;
         font-size: 0.7rem;
-        color: #8e887d;
+        color: var(--on-surface-subtle);
       }
 
       .zen-card p {
         margin: 0.2rem 0 0;
-        color: #5f5c54;
+        color: var(--on-surface-muted);
       }
 
       .task-section {
@@ -201,7 +201,7 @@ import { PersonalTaskWorkspaceComponent } from '../components/personal-task-work
       }
 
       .section-heading-accent h2 {
-        color: #d07f46;
+        color: #c97c46;
       }
 
       .section-actions {
@@ -215,8 +215,9 @@ import { PersonalTaskWorkspaceComponent } from '../components/personal-task-work
         height: 2.4rem;
         border: 0;
         border-radius: 0.9rem;
-        background: rgba(255, 251, 242, 0.8);
-        color: #8b8476;
+        background: var(--surface-container-lowest);
+        box-shadow: inset 0 0 0 1px var(--outline-variant);
+        color: var(--on-surface-subtle);
         font-size: 1rem;
       }
 
@@ -231,13 +232,13 @@ import { PersonalTaskWorkspaceComponent } from '../components/personal-task-work
       }
 
       .status-copy {
-        color: #8a8378;
+        color: var(--on-surface-muted);
       }
 
       .empty-state {
-        border: 1px dashed rgba(224, 215, 196, 0.95);
         border-radius: 1.4rem;
-        background: rgba(255, 251, 242, 0.6);
+        background: var(--surface-card);
+        box-shadow: inset 0 0 0 1px var(--outline-variant);
         padding: 2rem 1.3rem;
       }
 
@@ -249,7 +250,7 @@ import { PersonalTaskWorkspaceComponent } from '../components/personal-task-work
 
       .empty-state p {
         margin: 0.55rem 0 0;
-        color: #8a8378;
+        color: var(--on-surface-muted);
       }
 
       .fab {
@@ -259,13 +260,13 @@ import { PersonalTaskWorkspaceComponent } from '../components/personal-task-work
         width: 4rem;
         height: 4rem;
         border-radius: 999px;
-        background: #2d7c53;
-        color: #f7faf5;
+        background: var(--primary-gradient);
+        color: var(--primary-foreground);
         text-decoration: none;
         font-size: 2rem;
         display: grid;
         place-items: center;
-        box-shadow: 0 18px 36px rgba(45, 124, 83, 0.22);
+        box-shadow: 0 18px 36px var(--surface-dim-strong);
       }
 
       @media (max-width: 900px) {

--- a/apps/frontend/src/app/features/personal/pages/upcoming-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/upcoming-page.component.ts
@@ -68,7 +68,7 @@ import { PageHeaderComponent } from '../../../shared/components/page-header/page
 
       .status-copy {
         margin-top: 0.6rem;
-        color: #8a8378;
+        color: var(--on-surface-muted);
         font-size: 1.08rem;
       }
 
@@ -81,8 +81,8 @@ import { PageHeaderComponent } from '../../../shared/components/page-header/page
       .group-card,
       .empty-state {
         border-radius: 1.5rem;
-        background: rgba(255, 251, 242, 0.72);
-        border: 1px solid rgba(236, 228, 210, 0.9);
+        background: var(--surface-card);
+        box-shadow: inset 0 0 0 1px var(--outline-variant);
         padding: 1.25rem;
       }
 
@@ -102,7 +102,7 @@ import { PageHeaderComponent } from '../../../shared/components/page-header/page
       }
 
       .group-header span {
-        color: #8a8378;
+        color: var(--on-surface-muted);
         font-size: 0.88rem;
       }
 
@@ -113,7 +113,7 @@ import { PageHeaderComponent } from '../../../shared/components/page-header/page
 
       .empty-state p {
         margin: 0.55rem 0 0;
-        color: #8a8378;
+        color: var(--on-surface-muted);
       }
     `,
   ],

--- a/apps/frontend/src/app/features/personal/shell/personal-shell.component.css
+++ b/apps/frontend/src/app/features/personal/shell/personal-shell.component.css
@@ -109,8 +109,8 @@
   gap: 0.7rem;
   min-height: 3rem;
   border-radius: 1.15rem;
-  background: var(--primary-gradient);
-  color: var(--primary-foreground);
+  background: var(--primary-action-gradient);
+  color: hsl(var(--primary-foreground));
   text-decoration: none;
   font-weight: 700;
   box-shadow: 0 18px 36px rgba(28, 28, 23, 0.08);
@@ -192,7 +192,7 @@
 }
 
 .topbar-brand-vein {
-  fill: var(--primary-foreground);
+  fill: hsl(var(--primary-foreground));
 }
 
 .topbar-brand-mark fa-icon {
@@ -234,8 +234,8 @@
 .search-shell button {
   border: 0;
   border-radius: 999px;
-  background: var(--primary-gradient);
-  color: var(--primary-foreground);
+  background: var(--primary-action-gradient);
+  color: hsl(var(--primary-foreground));
   font-size: 0.78rem;
   font-weight: 700;
   padding: 0.48rem 0.78rem;
@@ -293,8 +293,8 @@
   right: 3rem;
   width: min(18rem, calc(100vw - 2rem));
   border-radius: 1.25rem;
-  background: var(--surface-card);
-  box-shadow: 0 20px 40px var(--surface-dim-strong), inset 0 0 0 1px var(--outline-variant);
+  background: color-mix(in srgb, var(--primary-soft) 24%, var(--surface-card));
+  box-shadow: 0 20px 40px var(--surface-dim-strong), inset 0 0 0 1px color-mix(in srgb, var(--primary-solid) 22%, var(--outline-variant));
   padding: 0.4rem;
   display: grid;
   gap: 0.25rem;
@@ -363,7 +363,7 @@
 }
 
 .preferences-toggle-on {
-  background: var(--primary-gradient);
+  background: var(--primary-action-gradient);
 }
 
 .preferences-toggle-on span {
@@ -384,8 +384,8 @@
   right: 0;
   width: 12rem;
   border-radius: 1.25rem;
-  background: var(--surface-card);
-  box-shadow: 0 20px 40px var(--surface-dim-strong), inset 0 0 0 1px var(--outline-variant);
+  background: color-mix(in srgb, var(--primary-soft) 24%, var(--surface-card));
+  box-shadow: 0 20px 40px var(--surface-dim-strong), inset 0 0 0 1px color-mix(in srgb, var(--primary-solid) 22%, var(--outline-variant));
   padding: 0.35rem;
   display: grid;
   gap: 0.2rem;
@@ -401,6 +401,16 @@
   font-weight: 600;
   padding: 0.6rem 0.68rem;
   cursor: pointer;
+}
+
+.profile-menu-item-primary {
+  background: color-mix(in srgb, var(--primary-action-gradient) 14%, var(--surface-container-lowest));
+  color: hsl(var(--primary-foreground));
+}
+
+.profile-menu-item-primary:hover {
+  background: color-mix(in srgb, var(--primary-action-gradient) 18%, var(--surface-container-lowest));
+  color: hsl(var(--primary-foreground));
 }
 
 .profile-menu-item:hover {
@@ -420,6 +430,15 @@
   background: var(--surface-overlay);
   color: var(--on-surface-muted);
   cursor: pointer;
+}
+
+.topbar-actions .icon-button[aria-label='Preferences'] {
+  background: color-mix(in srgb, var(--primary-action-gradient) 24%, var(--surface-overlay));
+  color: var(--primary-solid);
+}
+
+.topbar-actions .icon-button[aria-label='Preferences']:hover {
+  background: color-mix(in srgb, var(--primary-action-gradient) 30%, var(--surface-overlay));
 }
 
 .menu-toggle {

--- a/apps/frontend/src/app/features/personal/shell/personal-shell.component.css
+++ b/apps/frontend/src/app/features/personal/shell/personal-shell.component.css
@@ -2,9 +2,11 @@
   display: block;
   min-height: 100dvh;
   background:
-    radial-gradient(circle at top left, rgba(246, 243, 231, 0.98), transparent 22%), #f8f4e8;
-  color: #20211d;
-  font-family: 'Avenir Next', 'Manrope', 'Segoe UI', sans-serif;
+    radial-gradient(circle at top left, color-mix(in srgb, var(--primary-soft) 28%, transparent), transparent 24%),
+    radial-gradient(circle at bottom right, color-mix(in srgb, var(--accent-soft) 24%, transparent), transparent 28%),
+    var(--surface);
+  color: var(--on-surface);
+  font-family: var(--font-sans);
 }
 
 .personal-shell {
@@ -19,32 +21,33 @@
 }
 
 .sidebar {
-  background: rgba(255, 255, 255, 0.72);
-  border-right: 1px solid rgba(226, 219, 201, 0.8);
-  padding: 1rem 0.95rem 0.95rem;
+  background: var(--surface-container-lowest);
+  padding: 1.15rem 1rem 1rem;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  backdrop-filter: blur(14px);
+  backdrop-filter: blur(22px);
   z-index: 2;
 }
 
 .sidebar-top {
   display: grid;
-  gap: 1.75rem;
+  gap: 1.55rem;
 }
 
 .sidebar-brand h1 {
   margin: 0;
-  font-size: 1.65rem;
+  font-size: 1.2rem;
   line-height: 1.05;
-  letter-spacing: -0.04em;
+  letter-spacing: -0.03em;
 }
 
 .sidebar-brand p {
-  margin: 0.35rem 0 0;
-  font-size: 0.82rem;
-  color: #73a08a;
+  margin: 0.3rem 0 0;
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--on-surface-subtle);
 }
 
 .nav-list {
@@ -57,24 +60,24 @@
   align-items: center;
   gap: 0.8rem;
   text-decoration: none;
-  color: #5c635c;
-  padding: 0.82rem 0.9rem;
-  border-radius: 0.95rem;
+  color: var(--on-surface-muted);
+  padding: 0.76rem 0.85rem;
+  border-radius: 1.15rem;
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: 0.92rem;
   transition:
     background-color 140ms ease,
     color 140ms ease;
 }
 
 .nav-item:hover {
-  background: rgba(167, 230, 204, 0.2);
-  color: #315946;
+  background: var(--primary-soft);
+  color: var(--primary-solid);
 }
 
 .nav-item-active {
-  background: #dbf5e7;
-  color: #255944;
+  background: var(--primary-soft-strong);
+  color: var(--primary-solid);
 }
 
 .nav-icon {
@@ -104,13 +107,13 @@
   align-items: center;
   justify-content: center;
   gap: 0.7rem;
-  min-height: 3.2rem;
-  border-radius: 1rem;
-  background: #256c47;
-  color: #f5f8f2;
+  min-height: 3rem;
+  border-radius: 1.15rem;
+  background: var(--primary-gradient);
+  color: var(--primary-foreground);
   text-decoration: none;
   font-weight: 700;
-  box-shadow: 0 18px 28px rgba(27, 90, 57, 0.2);
+  box-shadow: 0 18px 36px rgba(28, 28, 23, 0.08);
 }
 
 .quick-add-icon {
@@ -126,14 +129,14 @@
 .mode-button {
   border: 0;
   background: transparent;
-  color: #7a7d73;
+  color: var(--on-surface-subtle);
   text-align: left;
   padding: 0.3rem 0.4rem;
   font-size: 0.92rem;
 }
 
 .mode-button-active {
-  color: #255944;
+  color: var(--primary-solid);
   font-weight: 700;
 }
 
@@ -143,7 +146,7 @@
 }
 
 .topbar {
-  min-height: 5.2rem;
+  min-height: 5rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -162,34 +165,34 @@
 .topbar-brand {
   display: inline-flex;
   align-items: center;
-  gap: 0.65rem;
-  color: #1e6f49;
+  gap: 0.8rem;
+  color: var(--primary-solid);
   text-decoration: none;
-  font-size: 1.8rem;
+  font-size: 1.55rem;
   font-weight: 700;
   letter-spacing: -0.04em;
 }
 
 .topbar-brand-mark {
-  width: 1.95rem;
-  height: 1.95rem;
-  border-radius: 999px;
-  background: #e7efe5;
-  color: #4f986f;
+  width: 2.35rem;
+  height: 2.35rem;
+  border-radius: 1rem;
+  background: var(--surface-container-high);
+  color: var(--primary-solid);
   display: grid;
   place-items: center;
   flex: 0 0 auto;
 }
 
 .topbar-brand-mark svg {
-  width: 1rem;
-  height: 1rem;
+  width: 1.2rem;
+  height: 1.2rem;
   display: block;
   fill: currentColor;
 }
 
 .topbar-brand-vein {
-  fill: #f7f8f4;
+  fill: var(--primary-foreground);
 }
 
 .topbar-brand-mark fa-icon {
@@ -199,19 +202,20 @@
 .search-shell {
   flex: 1;
   min-width: 0;
-  max-width: 20rem;
+  max-width: 28rem;
   display: flex;
   align-items: center;
-  gap: 0.55rem;
+  gap: 0.5rem;
   border-radius: 999px;
-  padding: 0.78rem 1rem;
-  background: rgba(255, 251, 242, 0.88);
-  border: 1px solid rgba(232, 224, 208, 0.85);
+  padding: 0.65rem 0.85rem;
+  background: var(--surface-overlay);
+  box-shadow: inset 0 0 0 1px var(--outline-variant);
 }
 
 .search-shell:focus-within {
-  border-color: rgba(75, 133, 96, 0.36);
-  box-shadow: 0 0 0 4px rgba(208, 238, 218, 0.38);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--primary-solid) 50%, transparent),
+    0 10px 28px var(--surface-dim);
 }
 
 .search-shell input {
@@ -219,28 +223,28 @@
   border: 0;
   outline: none;
   background: transparent;
-  color: #4f534b;
-  font-size: 0.92rem;
+  color: var(--on-surface);
+  font-size: 0.88rem;
 }
 
 .search-shell input::placeholder {
-  color: #b1aa9e;
+  color: var(--on-surface-subtle);
 }
 
 .search-shell button {
   border: 0;
   border-radius: 999px;
-  background: #256c47;
-  color: #f5f8f2;
-  font-size: 0.82rem;
+  background: var(--primary-gradient);
+  color: var(--primary-foreground);
+  font-size: 0.78rem;
   font-weight: 700;
-  padding: 0.55rem 0.85rem;
+  padding: 0.48rem 0.78rem;
 }
 
 .search-icon {
   width: 1rem;
   height: 1rem;
-  color: #b1aa9e;
+  color: var(--on-surface-subtle);
 }
 
 .search-icon svg,
@@ -257,9 +261,10 @@
 }
 
 .topbar-actions {
+  position: relative;
   display: flex;
   align-items: center;
-  gap: 0.65rem;
+  gap: 0.5rem;
 }
 
 .icon-button fa-icon,
@@ -272,6 +277,97 @@
 
 .profile-menu {
   position: relative;
+}
+
+.preferences-backdrop {
+  position: fixed;
+  inset: 0;
+  border: 0;
+  background: transparent;
+  z-index: 4;
+}
+
+.preferences-menu {
+  position: absolute;
+  top: calc(100% + 0.65rem);
+  right: 3rem;
+  width: min(18rem, calc(100vw - 2rem));
+  border-radius: 1.25rem;
+  background: var(--surface-card);
+  box-shadow: 0 20px 40px var(--surface-dim-strong), inset 0 0 0 1px var(--outline-variant);
+  padding: 0.4rem;
+  display: grid;
+  gap: 0.25rem;
+  z-index: 5;
+}
+
+.preferences-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.9rem;
+  width: 100%;
+  border: 0;
+  border-radius: 1rem;
+  background: transparent;
+  color: var(--on-surface);
+  text-align: left;
+  padding: 0.85rem 0.9rem;
+  cursor: pointer;
+}
+
+.preferences-item:hover:not(:disabled) {
+  background: var(--surface-container-high);
+}
+
+.preferences-item:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.preferences-item-copy {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.preferences-item-copy strong {
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+.preferences-item-copy span {
+  color: var(--on-surface-muted);
+  font-size: 0.8rem;
+}
+
+.preferences-toggle {
+  position: relative;
+  width: 2.4rem;
+  height: 1.4rem;
+  border-radius: 999px;
+  background: var(--surface-container-highest);
+  box-shadow: inset 0 0 0 1px var(--outline-variant);
+  flex: 0 0 auto;
+}
+
+.preferences-toggle span {
+  position: absolute;
+  top: 0.15rem;
+  left: 0.15rem;
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 999px;
+  background: var(--surface-container-lowest);
+  box-shadow: 0 4px 10px var(--surface-dim);
+  transition: transform 140ms ease, background-color 140ms ease;
+}
+
+.preferences-toggle-on {
+  background: var(--primary-gradient);
+}
+
+.preferences-toggle-on span {
+  transform: translateX(1rem);
 }
 
 .profile-menu-backdrop {
@@ -287,10 +383,9 @@
   top: calc(100% + 0.65rem);
   right: 0;
   width: 12rem;
-  border-radius: 0.95rem;
-  background: rgba(255, 251, 243, 0.97);
-  border: 1px solid rgba(227, 220, 203, 0.95);
-  box-shadow: 0 16px 30px rgba(74, 68, 56, 0.16);
+  border-radius: 1.25rem;
+  background: var(--surface-card);
+  box-shadow: 0 20px 40px var(--surface-dim-strong), inset 0 0 0 1px var(--outline-variant);
   padding: 0.35rem;
   display: grid;
   gap: 0.2rem;
@@ -301,7 +396,7 @@
   border: 0;
   border-radius: 0.7rem;
   background: transparent;
-  color: #3f443c;
+  color: var(--on-surface);
   text-align: left;
   font-weight: 600;
   padding: 0.6rem 0.68rem;
@@ -309,40 +404,38 @@
 }
 
 .profile-menu-item:hover {
-  background: rgba(205, 228, 211, 0.4);
+  background: var(--primary-soft);
 }
 
 .profile-menu-item-danger {
-  color: #8d4438;
+  color: #c8846d;
 }
 
 .icon-button,
 .menu-toggle {
-  width: 2.7rem;
-  height: 2.7rem;
+  width: 2.55rem;
+  height: 2.55rem;
   border: 0;
-  border-radius: 999px;
-  background: transparent;
-  color: #6e7267;
+  border-radius: 1rem;
+  background: var(--surface-overlay);
+  color: var(--on-surface-muted);
   cursor: pointer;
 }
 
 .menu-toggle {
   display: none;
-  border-radius: 0.9rem;
-  background: rgba(255, 255, 255, 0.88);
-  border: 1px solid rgba(228, 220, 202, 0.9);
+  border-radius: 1rem;
 }
 
 .avatar {
-  width: 2.7rem;
-  height: 2.7rem;
-  border-radius: 999px;
-  background: #3d8b61;
-  color: #f5f8f2;
+  width: 2.55rem;
+  height: 2.55rem;
+  border-radius: 1rem;
+  background: var(--primary-gradient);
+  color: var(--primary-foreground);
   display: grid;
   place-items: center;
-  font-size: 0.9rem;
+  font-size: 0.84rem;
   font-weight: 700;
 }
 
@@ -367,7 +460,7 @@
     inset: 0;
     z-index: 1;
     border: 0;
-    background: rgba(37, 39, 34, 0.28);
+    background: rgba(10, 12, 10, 0.34);
   }
 
   .sidebar {
@@ -376,7 +469,7 @@
     width: min(80vw, 19rem);
     transform: translateX(-100%);
     transition: transform 180ms ease;
-    box-shadow: 18px 0 38px rgba(58, 57, 45, 0.14);
+    box-shadow: 18px 0 38px var(--surface-dim-strong);
   }
 
   .sidebar-open {
@@ -422,11 +515,11 @@
   }
 
   .topbar-brand {
-    font-size: 1.7rem;
+    font-size: 1.45rem;
   }
 
   .topbar-brand-mark {
-    width: 1.8rem;
-    height: 1.8rem;
+    width: 2.1rem;
+    height: 2.1rem;
   }
 }

--- a/apps/frontend/src/app/features/personal/shell/personal-shell.component.html
+++ b/apps/frontend/src/app/features/personal/shell/personal-shell.component.html
@@ -12,7 +12,7 @@
     <div class="sidebar-top">
       <div class="sidebar-brand">
         <h1>Personal Sanctuary</h1>
-        <p>Focus Mode Active</p>
+        <p>Focus mode active</p>
       </div>
 
       <nav class="nav-list" aria-label="Personal navigation">
@@ -115,9 +115,48 @@
         <button type="button" class="icon-button" aria-label="Notifications">
           <fa-icon [icon]="faBell" aria-hidden="true"></fa-icon>
         </button>
-        <button type="button" class="icon-button" aria-label="Preferences">
+        <button
+          type="button"
+          class="icon-button"
+          [attr.aria-expanded]="preferencesMenuOpen()"
+          aria-haspopup="menu"
+          aria-label="Preferences"
+          (click)="togglePreferencesMenu()"
+        >
           <fa-icon [icon]="faSliders" aria-hidden="true"></fa-icon>
         </button>
+        @if (preferencesMenuOpen()) {
+          <button
+            type="button"
+            class="preferences-backdrop"
+            aria-label="Close preferences menu"
+            (click)="closePreferencesMenu()"
+          ></button>
+
+          <div class="preferences-menu" role="menu" aria-label="Preferences">
+            <button
+              type="button"
+              class="preferences-item"
+              role="menuitem"
+              (click)="toggleTheme(); closePreferencesMenu()"
+            >
+              <span class="preferences-item-copy">
+                <strong>Dark theme</strong>
+                <span>Use the quieter nighttime palette.</span>
+              </span>
+              <span class="preferences-toggle" [class.preferences-toggle-on]="isDarkTheme()">
+                <span></span>
+              </span>
+            </button>
+
+            <button type="button" class="preferences-item" role="menuitem" disabled>
+              <span class="preferences-item-copy">
+                <strong>Compact mode</strong>
+                <span>Coming soon.</span>
+              </span>
+            </button>
+          </div>
+        }
         <div class="profile-menu">
           @if (profileMenuOpen()) {
             <button

--- a/apps/frontend/src/app/features/personal/shell/personal-shell.component.html
+++ b/apps/frontend/src/app/features/personal/shell/personal-shell.component.html
@@ -181,7 +181,7 @@
             <div class="profile-menu-card" role="menu" aria-label="Account actions">
               <button
                 type="button"
-                class="profile-menu-item"
+                class="profile-menu-item profile-menu-item-primary"
                 role="menuitem"
                 (click)="handleStayFocused()"
               >

--- a/apps/frontend/src/app/features/personal/shell/personal-shell.component.ts
+++ b/apps/frontend/src/app/features/personal/shell/personal-shell.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, computed, inject, signal } from '@angular/core';
+import { Component, computed, effect, inject, signal } from '@angular/core';
 import {
   ActivatedRoute,
   NavigationEnd,
@@ -76,8 +76,10 @@ export class PersonalShellComponent {
   ];
   protected readonly mobileMenuOpen = signal(false);
   protected readonly profileMenuOpen = signal(false);
+  protected readonly preferencesMenuOpen = signal(false);
   protected readonly logoutDialogOpen = signal(false);
   protected readonly signingOut = signal(false);
+  protected readonly isDarkTheme = signal(this.resolveInitialTheme() === 'dark');
   protected readonly userInitials = computed(() => {
     const fallback = 'PS';
     const source = this.authState.user()?.name?.trim() || this.authState.user()?.email || fallback;
@@ -94,9 +96,17 @@ export class PersonalShellComponent {
   });
 
   constructor() {
+    effect(() => {
+      const theme = this.isDarkTheme() ? 'dark' : 'light';
+      document.documentElement.classList.toggle('dark', this.isDarkTheme());
+      document.documentElement.style.colorScheme = theme;
+      localStorage.setItem('yotara-theme', theme);
+    });
+
     this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
       this.mobileMenuOpen.set(false);
       this.profileMenuOpen.set(false);
+      this.preferencesMenuOpen.set(false);
     });
 
     this.route.queryParamMap.pipe(takeUntilDestroyed()).subscribe((params) => {
@@ -121,11 +131,25 @@ export class PersonalShellComponent {
   }
 
   protected toggleProfileMenu() {
+    this.preferencesMenuOpen.set(false);
     this.profileMenuOpen.update((open) => !open);
   }
 
   protected closeProfileMenu() {
     this.profileMenuOpen.set(false);
+  }
+
+  protected togglePreferencesMenu() {
+    this.profileMenuOpen.set(false);
+    this.preferencesMenuOpen.update((open) => !open);
+  }
+
+  protected closePreferencesMenu() {
+    this.preferencesMenuOpen.set(false);
+  }
+
+  protected toggleTheme() {
+    this.isDarkTheme.update((value) => !value);
   }
 
   protected handleStayFocused() {
@@ -155,5 +179,14 @@ export class PersonalShellComponent {
     } finally {
       this.signingOut.set(false);
     }
+  }
+
+  private resolveInitialTheme() {
+    const storedTheme = localStorage.getItem('yotara-theme');
+    if (storedTheme === 'dark' || storedTheme === 'light') {
+      return storedTheme;
+    }
+
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   }
 }

--- a/apps/frontend/src/app/features/shell/auth-shell.component.ts
+++ b/apps/frontend/src/app/features/shell/auth-shell.component.ts
@@ -206,9 +206,14 @@ interface SidebarItem {
         display: block;
         min-height: 100dvh;
         background:
-          radial-gradient(circle at top left, rgba(241, 244, 236, 0.9), transparent 28%), #f4f1e7;
-        color: #1f2937;
-        font-family: 'Avenir Next', 'Manrope', 'Segoe UI', sans-serif;
+          radial-gradient(
+            circle at top left,
+            color-mix(in srgb, var(--primary-soft) 28%, transparent),
+            transparent 28%
+          ),
+          var(--surface);
+        color: var(--on-surface);
+        font-family: var(--font-sans);
       }
 
       .shell {
@@ -227,8 +232,7 @@ interface SidebarItem {
         flex-direction: column;
         justify-content: space-between;
         padding: 1.15rem 1rem 1rem;
-        background: rgba(255, 255, 255, 0.84);
-        border-right: 1px solid rgba(128, 146, 126, 0.2);
+        background: var(--surface-container-lowest);
         backdrop-filter: blur(12px);
         position: relative;
         z-index: 2;
@@ -250,8 +254,8 @@ interface SidebarItem {
         width: 2.15rem;
         height: 2.15rem;
         border-radius: 999px;
-        background: #e7efe5;
-        color: #4f986f;
+        background: var(--surface-container-low);
+        color: var(--primary-solid);
         display: grid;
         place-items: center;
       }
@@ -265,7 +269,7 @@ interface SidebarItem {
         line-height: 1;
         font-weight: 700;
         letter-spacing: -0.03em;
-        color: #203027;
+        color: var(--on-surface);
       }
 
       .workspace-label {
@@ -273,7 +277,7 @@ interface SidebarItem {
         font-size: 0.74rem;
         font-weight: 700;
         letter-spacing: 0.08em;
-        color: #6ea288;
+        color: var(--on-surface-subtle);
       }
 
       .nav-list {
@@ -289,7 +293,7 @@ interface SidebarItem {
         border: 0;
         border-radius: 0.7rem;
         background: transparent;
-        color: #55657d;
+        color: var(--on-surface-muted);
         text-decoration: none;
         text-align: left;
         padding: 0.9rem 0.85rem;
@@ -303,14 +307,14 @@ interface SidebarItem {
       }
 
       .nav-item:hover {
-        background: rgba(79, 152, 111, 0.08);
-        color: #355e4b;
+        background: var(--primary-soft);
+        color: var(--primary-solid);
       }
 
       .nav-item-active {
-        background: #4f986f;
-        color: #f7f7f2;
-        box-shadow: 0 10px 22px rgba(69, 127, 92, 0.18);
+        background: var(--primary-gradient);
+        color: var(--primary-foreground);
+        box-shadow: 0 10px 22px var(--surface-dim-strong);
       }
 
       .nav-item-active .nav-icon {
@@ -324,14 +328,14 @@ interface SidebarItem {
 
       .nav-item-disabled:hover {
         background: transparent;
-        color: #55657d;
+        color: var(--on-surface-muted);
         transform: none;
       }
 
       .nav-icon {
         width: 1.15rem;
         height: 1.15rem;
-        color: #5d6d86;
+        color: var(--on-surface-subtle);
         flex: 0 0 auto;
       }
 
@@ -356,8 +360,8 @@ interface SidebarItem {
       .nav-badge {
         margin-left: auto;
         border-radius: 999px;
-        background: rgba(79, 152, 111, 0.1);
-        color: #5b896f;
+        background: var(--primary-soft);
+        color: var(--primary-solid);
         padding: 0.18rem 0.45rem;
         font-size: 0.68rem;
         font-weight: 700;
@@ -374,8 +378,8 @@ interface SidebarItem {
         width: 100%;
         border: 0;
         border-radius: 0.78rem;
-        background: #eef4ed;
-        color: #4f986f;
+        background: var(--surface-container-low);
+        color: var(--primary-solid);
         padding: 0.95rem 1rem;
         font-size: 0.95rem;
         font-weight: 700;
@@ -400,9 +404,10 @@ interface SidebarItem {
         left: 0;
         right: 0;
         border-radius: 0.9rem;
-        background: rgba(255, 251, 243, 0.97);
-        border: 1px solid rgba(226, 219, 204, 0.95);
-        box-shadow: 0 14px 30px rgba(64, 62, 51, 0.18);
+        background: var(--surface-card);
+        box-shadow:
+          inset 0 0 0 1px var(--outline-variant),
+          0 14px 30px var(--surface-dim-strong);
         padding: 0.3rem;
         display: grid;
         gap: 0.2rem;
@@ -413,7 +418,7 @@ interface SidebarItem {
         border: 0;
         border-radius: 0.64rem;
         background: transparent;
-        color: #3d423b;
+        color: var(--on-surface);
         text-align: left;
         font-weight: 600;
         padding: 0.58rem 0.66rem;
@@ -421,11 +426,11 @@ interface SidebarItem {
       }
 
       .profile-menu-item:hover {
-        background: rgba(207, 225, 214, 0.45);
+        background: var(--primary-soft);
       }
 
       .profile-menu-item-danger {
-        color: #8a453a;
+        color: #c7846d;
       }
 
       .profile-card {
@@ -434,7 +439,7 @@ interface SidebarItem {
         align-items: center;
         gap: 0.82rem;
         padding: 0.9rem 0.35rem 0;
-        border-top: 1px solid rgba(120, 138, 143, 0.18);
+        box-shadow: inset 0 1px 0 0 var(--outline-variant);
       }
 
       .profile-card-button {
@@ -449,8 +454,12 @@ interface SidebarItem {
         width: 2.7rem;
         height: 2.7rem;
         border-radius: 999px;
-        background: linear-gradient(135deg, #f4c7a1, #8bb49a);
-        color: #fffdf8;
+        background: linear-gradient(
+          135deg,
+          var(--surface-container-highest),
+          var(--surface-container-low)
+        );
+        color: var(--primary-foreground);
         display: grid;
         place-items: center;
         font-size: 0.92rem;
@@ -472,13 +481,13 @@ interface SidebarItem {
       .profile-name {
         font-size: 0.95rem;
         font-weight: 700;
-        color: #223128;
+        color: var(--on-surface);
       }
 
       .profile-meta {
         margin-top: 0.12rem;
         font-size: 0.79rem;
-        color: #6f7f91;
+        color: var(--on-surface-subtle);
       }
 
       .content {
@@ -491,17 +500,16 @@ interface SidebarItem {
       }
 
       .menu-toggle {
-        border: 1px solid rgba(128, 146, 126, 0.28);
         border-radius: 0.9rem;
-        background: rgba(255, 255, 255, 0.92);
+        background: var(--surface-container-lowest);
         width: 3rem;
         height: 3rem;
         padding: 0;
-        color: #2f4b3d;
+        color: var(--on-surface);
         align-items: center;
         justify-content: center;
         cursor: pointer;
-        box-shadow: 0 8px 22px rgba(51, 79, 61, 0.08);
+        box-shadow: 0 8px 22px var(--surface-dim);
       }
 
       .menu-toggle svg {
@@ -518,7 +526,7 @@ interface SidebarItem {
         font-size: 1.15rem;
         font-weight: 700;
         letter-spacing: -0.03em;
-        color: #203027;
+        color: var(--on-surface);
       }
 
       .mobile-brand-subtitle {
@@ -526,14 +534,14 @@ interface SidebarItem {
         font-size: 0.68rem;
         font-weight: 700;
         letter-spacing: 0.08em;
-        color: #6ea288;
+        color: var(--on-surface-subtle);
       }
 
       .content-inner {
         min-height: calc(100dvh - 3.2rem);
         border-radius: 1.6rem;
-        background: rgba(255, 251, 242, 0.5);
-        border: 1px solid rgba(214, 221, 208, 0.7);
+        background: var(--surface-container-low);
+        box-shadow: inset 0 0 0 1px var(--outline-variant);
         padding: 1.75rem;
       }
 
@@ -548,19 +556,19 @@ interface SidebarItem {
           inset: 0;
           z-index: 1;
           border: 0;
-          background: rgba(25, 37, 33, 0.3);
+          background: rgba(10, 12, 10, 0.34);
         }
 
         .sidebar {
           gap: 1.25rem;
           border-right: 0;
-          border-bottom: 1px solid rgba(128, 146, 126, 0.2);
+          box-shadow: inset 0 -1px 0 0 var(--outline-variant);
           position: fixed;
           inset: 0 auto 0 0;
           width: min(85vw, 20rem);
           transform: translateX(-100%);
           transition: transform 180ms ease;
-          box-shadow: 18px 0 36px rgba(45, 65, 57, 0.18);
+          box-shadow: 18px 0 36px var(--surface-dim-strong);
         }
 
         .sidebar.sidebar-open {

--- a/apps/frontend/src/app/features/tasks/components/task-list/task-list.component.css
+++ b/apps/frontend/src/app/features/tasks/components/task-list/task-list.component.css
@@ -3,12 +3,12 @@
   align-items: center;
   gap: 0.75rem;
   padding: 0.5rem 0;
-  border-bottom: 1px solid #f3f4f6;
+  box-shadow: inset 0 -1px 0 0 var(--outline-variant);
 }
 
 .task-item--done strong {
   text-decoration: line-through;
-  color: #9ca3af;
+  color: var(--on-surface-subtle);
 }
 
 .priority {
@@ -20,27 +20,27 @@
 }
 
 .priority--high {
-  background: #fee2e2;
-  color: #dc2626;
+  background: var(--danger-soft);
+  color: #c8846d;
 }
 
 .priority--medium {
-  background: #fef3c7;
-  color: #d97706;
+  background: var(--warning-soft);
+  color: #b28734;
 }
 
 .priority--low {
-  background: #dcfce7;
-  color: #16a34a;
+  background: var(--primary-soft);
+  color: var(--primary-solid);
 }
 
 .status {
   margin-left: auto;
   font-size: 0.75rem;
-  color: #9ca3af;
+  color: var(--on-surface-subtle);
 }
 
 .empty-state {
-  color: #9ca3af;
+  color: var(--on-surface-subtle);
   font-size: 0.9rem;
 }

--- a/apps/frontend/src/app/shared/components/page-header/page-header.component.css
+++ b/apps/frontend/src/app/shared/components/page-header/page-header.component.css
@@ -11,12 +11,24 @@
 
 .tagline {
   margin: 0.35rem 0 0;
-  color: #6b7280;
-  font-style: italic;
+  color: var(--on-surface-muted);
+  font-size: 0.95rem;
 }
 
 .page-header-actions {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+}
+
+:host {
+  display: block;
+  padding-bottom: 1.25rem;
+}
+
+.page-header-copy h1 {
+  margin: 0;
+  font-size: clamp(2.1rem, 3vw, 2.8rem);
+  line-height: 1.05;
+  letter-spacing: -0.05em;
 }

--- a/apps/frontend/src/app/shared/ui/confirm-dialog/confirm-dialog.component.scss
+++ b/apps/frontend/src/app/shared/ui/confirm-dialog/confirm-dialog.component.scss
@@ -17,7 +17,7 @@
 
 .confirm-description {
   margin: 0;
-  color: #5e6159;
+  color: var(--on-surface-muted);
   line-height: 1.5;
   max-width: 22rem;
 }
@@ -43,14 +43,14 @@
 }
 
 .primary-button {
-  background: #2b7f57;
-  color: #f5faf4;
-  box-shadow: 0 10px 22px rgba(43, 127, 87, 0.28);
+  background: var(--primary-gradient);
+  color: var(--primary-foreground);
+  box-shadow: 0 10px 22px var(--surface-dim-strong);
 }
 
 .secondary-button {
-  background: #ece9df;
-  color: #4f5149;
+  background: var(--surface-container-low);
+  color: var(--on-surface-muted);
 }
 
 .primary-button:disabled,
@@ -60,6 +60,6 @@
 }
 
 .confirm-dialog-danger .primary-button {
-  background: #b13a3a;
+  background: linear-gradient(135deg, #a83f3f, #c45d52);
   box-shadow: 0 10px 22px rgba(177, 58, 58, 0.24);
 }

--- a/apps/frontend/src/app/shared/ui/confirm-dialog/confirm-dialog.component.scss
+++ b/apps/frontend/src/app/shared/ui/confirm-dialog/confirm-dialog.component.scss
@@ -44,7 +44,7 @@
 
 .primary-button {
   background: var(--primary-gradient);
-  color: var(--primary-foreground);
+  color: hsl(var(--primary-foreground));
   box-shadow: 0 10px 22px var(--surface-dim-strong);
 }
 

--- a/apps/frontend/src/app/shared/ui/logout-confirm-modal/logout-confirm-modal.component.ts
+++ b/apps/frontend/src/app/shared/ui/logout-confirm-modal/logout-confirm-modal.component.ts
@@ -45,7 +45,7 @@ import { ConfirmDialogComponent } from '../confirm-dialog/confirm-dialog.compone
         width: 4.4rem;
         height: 4.4rem;
         border-radius: 999px;
-        background: #f0efe8;
+        background: var(--surface-container-low);
         display: grid;
         place-items: center;
       }
@@ -53,7 +53,7 @@ import { ConfirmDialogComponent } from '../confirm-dialog/confirm-dialog.compone
       .icon-disc svg {
         width: 2rem;
         height: 2rem;
-        stroke: #6d947c;
+        stroke: var(--primary-solid);
         fill: none;
         stroke-width: 1.8;
         stroke-linecap: round;

--- a/apps/frontend/src/app/shared/ui/modal/modal.component.scss
+++ b/apps/frontend/src/app/shared/ui/modal/modal.component.scss
@@ -15,7 +15,7 @@
   position: absolute;
   inset: 0;
   border: 0;
-  background: rgba(32, 30, 24, 0.22);
+  background: rgba(28, 28, 23, 0.22);
   backdrop-filter: blur(10px);
 }
 
@@ -24,9 +24,8 @@
   z-index: 1;
   width: min(100%, 34rem);
   border-radius: 1.6rem;
-  background: rgba(255, 255, 255, 0.96);
-  border: 1px solid rgba(232, 225, 209, 0.95);
-  box-shadow: 0 28px 60px rgba(88, 79, 59, 0.18);
+  background: var(--surface-container-lowest);
+  box-shadow: 0 28px 60px var(--surface-dim-strong), inset 0 0 0 1px var(--outline-variant);
   padding: 1.35rem;
   outline: none;
 }
@@ -55,13 +54,13 @@ h2 {
   font-size: 1.65rem;
   line-height: 1.1;
   letter-spacing: -0.04em;
-  color: #1d241f;
+  color: var(--on-surface);
 }
 
 .close-button {
   border: 0;
   background: transparent;
-  color: #6f6a5e;
+  color: var(--on-surface-muted);
   font-size: 2rem;
   line-height: 1;
   cursor: pointer;

--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -1,4 +1,5 @@
 @import '@angular/cdk/overlay-prebuilt.css';
+@import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap');
 
 @tailwind base;
 @tailwind components;
@@ -6,54 +7,96 @@
 
 :root {
   color-scheme: light;
-  --font-sans:
-    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans',
-    sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-  /* Light Mode Colors */
-  --background: 45 38% 94%; /* Warm Pebble Beige */
-  --foreground: 150 16% 12%; /* Dark Woodland */
-  --card: 45 38% 94%; /* Warm Pebble Beige */
-  --card-foreground: 150 16% 12%; /* Dark Woodland */
-  --popover: 45 38% 94%; /* Warm Pebble Beige */
-  --popover-foreground: 150 16% 12%; /* Dark Woodland */
-  --primary: 150 31% 42%; /* Soft River Green */
-  --primary-foreground: 45 38% 94%; /* Warm Pebble Beige */
-  --secondary: 45 38% 94%; /* Warm Pebble Beige */
-  --secondary-foreground: 150 16% 12%; /* Dark Woodland */
-  --muted: 124 14% 21%; /* Deep Forest Charcoal - slightly lighter for muted */
-  --muted-foreground: 45 38% 94%; /* Warm Pebble Beige */
-  --accent: 181 26% 54%; /* Gentle Stream Blue */
-  --accent-foreground: 150 16% 12%; /* Dark Woodland */
+  --font-sans: 'Manrope', sans-serif;
+  --background: 42 58% 97%;
+  --foreground: 75 13% 14%;
+  --card: 45 27% 95%;
+  --card-foreground: 75 13% 14%;
+  --popover: 45 27% 95%;
+  --popover-foreground: 75 13% 14%;
+  --primary: 151 47% 28%;
+  --primary-foreground: 45 56% 96%;
+  --secondary: 38 28% 91%;
+  --secondary-foreground: 75 13% 14%;
+  --muted: 45 19% 89%;
+  --muted-foreground: 76 8% 37%;
+  --accent: 147 27% 84%;
+  --accent-foreground: 75 13% 14%;
   --destructive: 0 84.2% 60.2%;
-  --destructive-foreground: 45 38% 94%;
-  --border: 150 31% 42%; /* Soft River Green - subtle border */
-  --input: 45 38% 94%; /* Warm Pebble Beige */
-  --ring: 181 26% 54%; /* Gentle Stream Blue */
-  --radius: 0.5rem;
+  --destructive-foreground: 45 56% 96%;
+  --border: 46 18% 80%;
+  --input: 45 27% 95%;
+  --ring: 151 47% 28%;
+  --radius: 1.5rem;
+  --surface: #fcf9f0;
+  --surface-container-lowest: #ffffff;
+  --surface-container-low: #f6f3ea;
+  --surface-container-high: #ece7dd;
+  --surface-container-highest: #e5e2da;
+  --outline-variant: rgba(28, 28, 23, 0.15);
+  --on-surface: #1c1c17;
+  --on-surface-muted: #6d685f;
+  --on-surface-subtle: #8f897d;
+  --surface-overlay: color-mix(in srgb, var(--surface-container-lowest) 88%, transparent);
+  --surface-card: color-mix(in srgb, var(--surface-container-lowest) 92%, transparent);
+  --surface-card-strong: color-mix(in srgb, var(--surface-container-highest) 88%, white);
+  --surface-dim: rgba(28, 28, 23, 0.08);
+  --surface-dim-strong: rgba(28, 28, 23, 0.14);
+  --primary-gradient: linear-gradient(135deg, #236849 0%, #3f8161 100%);
+  --primary-solid: #236849;
+  --primary-soft: #dff0e7;
+  --primary-soft-strong: #cfe8db;
+  --accent-soft: #e8f3ec;
+  --accent-strong: #79a08d;
+  --danger-soft: #f5e3da;
+  --warning-soft: #f6edd8;
+  --info-soft: #edf0f5;
 }
 
 :root.dark {
   color-scheme: dark;
-  /* Dark Mode Colors */
-  --background: 124 14% 21%; /* Deep Forest Charcoal */
-  --foreground: 45 38% 94%; /* Warm Pebble Beige */
-  --card: 124 14% 21%; /* Deep Forest Charcoal */
-  --card-foreground: 45 38% 94%; /* Warm Pebble Beige */
-  --popover: 124 14% 21%; /* Deep Forest Charcoal */
-  --popover-foreground: 45 38% 94%; /* Warm Pebble Beige */
-  --primary: 150 31% 42%; /* Soft River Green */
-  --primary-foreground: 124 14% 21%; /* Deep Forest Charcoal */
-  --secondary: 92 33% 56%; /* Fresh Sprout */
-  --secondary-foreground: 124 14% 21%; /* Deep Forest Charcoal */
-  --muted: 150 16% 12%; /* Dark Woodland */
-  --muted-foreground: 45 38% 94%; /* Warm Pebble Beige */
-  --accent: 181 26% 54%; /* Gentle Stream Blue */
-  --accent-foreground: 124 14% 21%; /* Deep Forest Charcoal */
+  --background: 147 18% 14%;
+  --foreground: 146 19% 87%;
+  --card: 149 11% 17%;
+  --card-foreground: 146 19% 87%;
+  --popover: 149 11% 17%;
+  --popover-foreground: 146 19% 87%;
+  --primary: 151 35% 50%;
+  --primary-foreground: 147 18% 14%;
+  --secondary: 149 11% 17%;
+  --secondary-foreground: 146 19% 87%;
+  --muted: 149 11% 17%;
+  --muted-foreground: 146 11% 73%;
+  --accent: 151 35% 50%;
+  --accent-foreground: 147 18% 14%;
   --destructive: 0 62.8% 30.6%;
-  --destructive-foreground: 45 38% 94%;
-  --border: 150 31% 42%; /* Soft River Green */
-  --input: 124 14% 21%; /* Deep Forest Charcoal */
-  --ring: 181 26% 54%; /* Gentle Stream Blue */
+  --destructive-foreground: 45 56% 96%;
+  --border: 45 12% 27%;
+  --input: 75 12% 18%;
+  --ring: 151 47% 38%;
+  --surface: #1a241f;
+  --surface-container-lowest: #1a241f;
+  --surface-container-low: #242e29;
+  --surface-container-high: #2b352f;
+  --surface-container-highest: #313c36;
+  --outline-variant: rgba(208, 224, 212, 0.12);
+  --on-surface: #d0e0d4;
+  --on-surface-muted: #adc0b1;
+  --on-surface-subtle: #89a18f;
+  --surface-overlay: color-mix(in srgb, var(--surface-container-lowest) 88%, transparent);
+  --surface-card: color-mix(in srgb, var(--surface-container-lowest) 92%, transparent);
+  --surface-card-strong: color-mix(in srgb, var(--surface-container-highest) 90%, black);
+  --surface-dim: rgba(208, 224, 212, 0.06);
+  --surface-dim-strong: rgba(208, 224, 212, 0.1);
+  --primary-gradient: linear-gradient(135deg, #4f8f72 0%, #5aa37d 100%);
+  --primary-solid: #5aa37d;
+  --primary-soft: rgba(90, 163, 125, 0.16);
+  --primary-soft-strong: rgba(90, 163, 125, 0.24);
+  --accent-soft: rgba(90, 163, 125, 0.12);
+  --accent-strong: #5aa37d;
+  --danger-soft: rgba(186, 109, 87, 0.16);
+  --warning-soft: rgba(210, 161, 61, 0.14);
+  --info-soft: rgba(109, 118, 144, 0.14);
 }
 
 @layer base {
@@ -69,5 +112,6 @@
 
   body {
     @apply bg-background text-foreground;
+    font-family: var(--font-sans);
   }
 }

--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -43,6 +43,7 @@
   --surface-dim: rgba(28, 28, 23, 0.08);
   --surface-dim-strong: rgba(28, 28, 23, 0.14);
   --primary-gradient: linear-gradient(135deg, #236849 0%, #3f8161 100%);
+  --primary-action-gradient: linear-gradient(135deg, #4f8f72 0%, #66ae86 100%);
   --primary-solid: #236849;
   --primary-soft: #dff0e7;
   --primary-soft-strong: #cfe8db;
@@ -89,6 +90,7 @@
   --surface-dim: rgba(208, 224, 212, 0.06);
   --surface-dim-strong: rgba(208, 224, 212, 0.1);
   --primary-gradient: linear-gradient(135deg, #4f8f72 0%, #5aa37d 100%);
+  --primary-action-gradient: linear-gradient(135deg, #4f8f72 0%, #5aa37d 100%);
   --primary-solid: #5aa37d;
   --primary-soft: rgba(90, 163, 125, 0.16);
   --primary-soft-strong: rgba(90, 163, 125, 0.24);

--- a/apps/frontend/tailwind.config.js
+++ b/apps/frontend/tailwind.config.js
@@ -7,6 +7,12 @@ module.exports = {
       colors: {
         background: 'hsl(var(--background))',
         foreground: 'hsl(var(--foreground))',
+        surface: 'var(--surface)',
+        'surface-container-lowest': 'var(--surface-container-lowest)',
+        'surface-container-low': 'var(--surface-container-low)',
+        'surface-container-high': 'var(--surface-container-high)',
+        'surface-container-highest': 'var(--surface-container-highest)',
+        'outline-variant': 'var(--outline-variant)',
         card: {
           DEFAULT: 'hsl(var(--card))',
           foreground: 'hsl(var(--card-foreground))',


### PR DESCRIPTION
## Description

Refined the UI to align with the “Breathable Interface” design system and complete the light/dark theme implementation across the app. This includes shared semantic color tokens, a fuller dark palette, a preferences dropdown with dark mode toggle, and visual consistency updates across the personal, auth, onboarding, and shared UI surfaces. It also corrects button foreground behavior so primary actions render with the intended light text in light mode.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Test coverage improvement
- [ ] Performance improvement
- [x] Refactoring (code improvement with no functional change)

## Related Issue

Closes: #

## Roadmap Reference

Implements the sanctuary theme and shell polish work for the personal experience and auth surfaces.

## Changes Made

- Added a shared semantic theme token system in `styles.css` for surfaces, foregrounds, accents, and action buttons.
- Implemented a complete dark mode palette based on the brand guide, using darker forest tones and softer contrast.
- Added a preferences dropdown in the personal shell with a dark theme toggle.
- Updated the personal shell, search, inbox, projects, project detail, today, archive, upcoming, labels, and modal surfaces to use the shared palette.
- Updated the auth shell, login screen, and onboarding screen to match the same visual language.
- Swapped login screen glyphs back to the brand SVG mark and adjusted it to match the brand logo treatment.
- Fixed button foreground colors in light mode so primary actions use the intended light brand text instead of falling back to dark text.

## Testing

### Test Coverage

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed

### Verification Steps

1. Run the app and switch between light and dark mode from the preferences menu.
2. Confirm primary buttons, search submit, capture, quick add, and profile menu actions use the shared light foreground in light mode.
3. Verify the login and onboarding screens render with the updated brand mark and palette without layout changes.

## Screenshots or Demo

Not included.

## Checklist

- [x] Code follows the project style and conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have verified that this PR is against the correct branch (`main`)

## Additional Notes

The primary button foreground fix required using `hsl(var(--primary-foreground))` in plain CSS, because the token is stored as HSL components rather than a raw color value.
