### PR TITLE
Took out the section header from the personal pages

### DIFF
--- a/apps/frontend/src/app/features/personal/pages/inbox-page.component.html
+++ b/apps/frontend/src/app/features/personal/pages/inbox-page.component.html
@@ -44,10 +44,7 @@
     }
 
     <section class="list-section">
-      <div class="section-heading">
-        <h2>Pending Processing</h2>
-        <span class="section-count">{{ inboxCountLabel() }}</span>
-      </div>
+      <app-section-header title="Pending Processing" [count]="inboxCountLabel()" size="sm" />
 
       @if (taskService.loading()) {
         <p class="status-copy">Loading your inbox...</p>

--- a/apps/frontend/src/app/features/personal/pages/inbox-page.component.scss
+++ b/apps/frontend/src/app/features/personal/pages/inbox-page.component.scss
@@ -88,32 +88,6 @@
   margin-top: 2.8rem;
 }
 
-.section-heading {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: 1rem;
-}
-
-.section-heading h2 {
-  margin: 0;
-  font-size: 1rem;
-  font-weight: 800;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--on-surface-subtle);
-}
-
-.section-count {
-  border-radius: 999px;
-  background: var(--surface-container-low);
-  padding: 0.28rem 0.7rem;
-  color: var(--on-surface-muted);
-  font-size: 0.76rem;
-  font-weight: 700;
-}
-
 .task-stack {
   display: grid;
   gap: 0.95rem;

--- a/apps/frontend/src/app/features/personal/pages/inbox-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/inbox-page.component.ts
@@ -4,11 +4,18 @@ import { FormsModule } from '@angular/forms';
 import { TaskService } from '../../../core/services/task.service';
 import { PersonalTaskCardComponent } from '../components/personal-task-card.component';
 import { PersonalTaskWorkspaceComponent } from '../components/personal-task-workspace.component';
+import { SectionHeaderComponent } from '../../../shared/components/section-header/section-header.component';
 
 @Component({
   selector: 'app-inbox-page',
   standalone: true,
-  imports: [CommonModule, FormsModule, PersonalTaskCardComponent, PersonalTaskWorkspaceComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    PersonalTaskCardComponent,
+    PersonalTaskWorkspaceComponent,
+    SectionHeaderComponent,
+  ],
   templateUrl: './inbox-page.component.html',
   styleUrl: './inbox-page.component.scss',
 })

--- a/apps/frontend/src/app/features/personal/pages/project-detail-page.component.html
+++ b/apps/frontend/src/app/features/personal/pages/project-detail-page.component.html
@@ -67,10 +67,11 @@
             </section>
           } @else {
             <section class="task-section">
-              <div class="section-heading">
-                <h2>To Do</h2>
-                <span>{{ activeProjectTasks().length }}</span>
-              </div>
+              <app-section-header
+                title="To Do"
+                [count]="activeProjectTasks().length"
+                size="lg"
+              />
 
               <div class="task-stack">
                 @for (task of activeProjectTasks(); track task.id) {
@@ -93,10 +94,11 @@
 
             @if (completedProjectTasks().length > 0) {
               <section class="task-section task-section-soft">
-                <div class="section-heading">
-                  <h2>Completed</h2>
-                  <span>{{ completedProjectTasks().length }}</span>
-                </div>
+                <app-section-header
+                  title="Completed"
+                  [count]="completedProjectTasks().length"
+                  size="lg"
+                />
 
                 <div class="task-stack">
                   @for (task of completedProjectTasks(); track task.id) {

--- a/apps/frontend/src/app/features/personal/pages/project-detail-page.component.scss
+++ b/apps/frontend/src/app/features/personal/pages/project-detail-page.component.scss
@@ -135,8 +135,7 @@
       }
 
       .metric span,
-      .progress-copy span,
-      .section-heading span {
+      .progress-copy span {
         color: var(--on-surface-subtle);
         font-size: 0.88rem;
       }
@@ -211,15 +210,6 @@
         margin-top: 2rem;
       }
 
-      .section-heading {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 1rem;
-        margin-bottom: 1rem;
-      }
-
-      .section-heading h2,
       .empty-state h2 {
         margin: 0;
         font-size: 2rem;

--- a/apps/frontend/src/app/features/personal/pages/project-detail-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/project-detail-page.component.ts
@@ -8,12 +8,19 @@ import { ProjectService } from '../../../core/services/project.service';
 import { TaskService } from '../../../core/services/task.service';
 import { PersonalTaskCardComponent } from '../components/personal-task-card.component';
 import { PersonalTaskWorkspaceComponent } from '../components/personal-task-workspace.component';
+import { SectionHeaderComponent } from '../../../shared/components/section-header/section-header.component';
 import { projectPaletteFor, projectProgressPercent } from '../project-presentation';
 
 @Component({
   selector: 'app-project-detail-page',
   standalone: true,
-  imports: [CommonModule, RouterLink, PersonalTaskCardComponent, PersonalTaskWorkspaceComponent],
+  imports: [
+    CommonModule,
+    RouterLink,
+    PersonalTaskCardComponent,
+    PersonalTaskWorkspaceComponent,
+    SectionHeaderComponent,
+  ],
   templateUrl: './project-detail-page.component.html',
   styleUrl: './project-detail-page.component.scss',
 })

--- a/apps/frontend/src/app/features/personal/pages/search-page.component.html
+++ b/apps/frontend/src/app/features/personal/pages/search-page.component.html
@@ -47,9 +47,9 @@
       }
     </nav>
 
-    @if (!searchQuery()) {
-      <section class="empty-state">
-        <h2>Start with a title, project, or keyword</h2>
+      @if (!searchQuery()) {
+        <section class="empty-state">
+          <h2>Start with a title, project, or keyword</h2>
         <p>
           Search looks through task titles, descriptions, project names, and status keywords like
           inbox, today, upcoming, done, and archived.
@@ -60,18 +60,15 @@
         <h2>No matches found</h2>
         <p>Try a different phrase, project name, or status keyword.</p>
       </section>
-    } @else {
-      @if (activeTab() === 'all') {
-        @if (taskResults().length > 0) {
-          <section class="result-group">
-            <div class="group-header">
-              <h2>Tasks</h2>
-              <span>{{ results().tasks.length }} matches</span>
-            </div>
+      } @else {
+        @if (activeTab() === 'all') {
+          @if (taskResults().length > 0) {
+            <section class="result-group">
+              <app-section-header title="Tasks" [count]="results().tasks.length + ' matches'" />
 
-            <div class="task-stack">
-              @for (taskResult of taskResults(); track taskResult.task.id) {
-                <app-personal-task-card
+              <div class="task-stack">
+                @for (taskResult of taskResults(); track taskResult.task.id) {
+                  <app-personal-task-card
                   [task]="taskResult.task"
                   [interactive]="true"
                   (select)="openTask(taskResult.task)"
@@ -81,15 +78,15 @@
           </section>
         }
 
-        @if (projectResults().length > 0) {
-          <section class="result-group">
-            <div class="group-header">
-              <h2>Projects</h2>
-              <span>{{ results().projects.length }} matches</span>
-            </div>
+          @if (projectResults().length > 0) {
+            <section class="result-group">
+              <app-section-header
+                title="Projects"
+                [count]="results().projects.length + ' matches'"
+              />
 
-            <div class="project-grid">
-              @for (projectResult of projectResults(); track projectResult.project.id) {
+              <div class="project-grid">
+                @for (projectResult of projectResults(); track projectResult.project.id) {
                 <a class="project-card" [routerLink]="['/projects', projectResult.project.id]">
                   <div class="project-topline">
                     <h3>{{ projectResult.project.name }}</h3>
@@ -109,10 +106,7 @@
 
       @if (activeTab() === 'tasks') {
         <section class="result-group">
-          <div class="group-header">
-            <h2>Tasks</h2>
-            <span>{{ results().tasks.length }} matches</span>
-          </div>
+          <app-section-header title="Tasks" [count]="results().tasks.length + ' matches'" />
 
           <div class="task-stack">
             @for (taskResult of results().tasks; track taskResult.task.id) {
@@ -128,10 +122,10 @@
 
       @if (activeTab() === 'projects') {
         <section class="result-group">
-          <div class="group-header">
-            <h2>Projects</h2>
-            <span>{{ results().projects.length }} matches</span>
-          </div>
+          <app-section-header
+            title="Projects"
+            [count]="results().projects.length + ' matches'"
+          />
 
           <div class="project-grid">
             @for (projectResult of results().projects; track projectResult.project.id) {
@@ -153,10 +147,7 @@
 
       @if (activeTab() === 'labels') {
         <section class="result-group">
-          <div class="group-header">
-            <h2>Labels</h2>
-            <span>Planned</span>
-          </div>
+          <app-section-header title="Labels" count="Planned" />
 
           <div class="empty-state compact">
             <h2>Label search will come online with label persistence</h2>

--- a/apps/frontend/src/app/features/personal/pages/search-page.component.scss
+++ b/apps/frontend/src/app/features/personal/pages/search-page.component.scss
@@ -117,25 +117,6 @@
   margin-top: 1.35rem;
 }
 
-.group-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: 0.85rem;
-}
-
-.group-header h2 {
-  margin: 0;
-  font-size: 1.5rem;
-  letter-spacing: -0.04em;
-}
-
-.group-header span {
-  color: var(--on-surface-muted);
-  font-size: 0.88rem;
-}
-
 .task-stack {
   display: grid;
   gap: 0.9rem;
@@ -237,10 +218,5 @@
 
   .search-button {
     width: 100%;
-  }
-
-  .group-header {
-    align-items: flex-start;
-    flex-direction: column;
   }
 }

--- a/apps/frontend/src/app/features/personal/pages/search-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/search-page.component.ts
@@ -6,6 +6,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { map } from 'rxjs';
 import { Project, Task } from '@yotara/shared';
 import { PageHeaderComponent } from '../../../shared/components/page-header/page-header.component';
+import { SectionHeaderComponent } from '../../../shared/components/section-header/section-header.component';
 import { PersonalTaskCardComponent } from '../components/personal-task-card.component';
 import { PersonalTaskWorkspaceComponent } from '../components/personal-task-workspace.component';
 import { SearchService, SearchTab } from '../../../core/services/search.service';
@@ -18,6 +19,7 @@ import { SearchService, SearchTab } from '../../../core/services/search.service'
     FormsModule,
     RouterLink,
     PageHeaderComponent,
+    SectionHeaderComponent,
     PersonalTaskCardComponent,
     PersonalTaskWorkspaceComponent,
   ],

--- a/apps/frontend/src/app/features/personal/pages/today-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/today-page.component.ts
@@ -4,11 +4,17 @@ import { Task } from '@yotara/shared';
 import { TaskService } from '../../../core/services/task.service';
 import { PersonalTaskCardComponent } from '../components/personal-task-card.component';
 import { PersonalTaskWorkspaceComponent } from '../components/personal-task-workspace.component';
+import { SectionHeaderComponent } from '../../../shared/components/section-header/section-header.component';
 
 @Component({
   selector: 'app-today-page',
   standalone: true,
-  imports: [CommonModule, PersonalTaskCardComponent, PersonalTaskWorkspaceComponent],
+  imports: [
+    CommonModule,
+    PersonalTaskCardComponent,
+    PersonalTaskWorkspaceComponent,
+    SectionHeaderComponent,
+  ],
   template: `
     <app-personal-task-workspace #workspace>
       <section class="page">
@@ -30,9 +36,7 @@ import { PersonalTaskWorkspaceComponent } from '../components/personal-task-work
 
         @if (taskService.overdueTasks().length > 0) {
           <section class="task-section">
-            <div class="section-heading section-heading-accent">
-              <h2>Overdue</h2>
-            </div>
+            <app-section-header title="Overdue" size="lg" tone="accent" />
 
             <div class="task-stack">
               @for (task of taskService.overdueTasks(); track task.id) {
@@ -48,14 +52,12 @@ import { PersonalTaskWorkspaceComponent } from '../components/personal-task-work
         }
 
         <section class="task-section">
-          <div class="section-heading">
-            <h2>Due Today</h2>
-
-            <div class="section-actions">
+          <app-section-header title="Due Today" size="lg">
+            <div section-header-actions class="section-actions">
               <button type="button" class="icon-chip" aria-label="Filter tasks">≡</button>
               <button type="button" class="icon-chip" aria-label="More actions">…</button>
             </div>
-          </div>
+          </app-section-header>
 
           @if (taskService.loading()) {
             <p class="status-copy">Loading your focused list...</p>
@@ -184,24 +186,6 @@ import { PersonalTaskWorkspaceComponent } from '../components/personal-task-work
 
       .task-section {
         margin-top: 2rem;
-      }
-
-      .section-heading {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 1rem;
-        margin-bottom: 1rem;
-      }
-
-      .section-heading h2 {
-        margin: 0;
-        font-size: 1.85rem;
-        letter-spacing: -0.04em;
-      }
-
-      .section-heading-accent h2 {
-        color: #c97c46;
       }
 
       .section-actions {

--- a/apps/frontend/src/app/features/personal/pages/upcoming-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/upcoming-page.component.ts
@@ -4,6 +4,7 @@ import { TaskService } from '../../../core/services/task.service';
 import { PersonalTaskCardComponent } from '../components/personal-task-card.component';
 import { PersonalTaskWorkspaceComponent } from '../components/personal-task-workspace.component';
 import { PageHeaderComponent } from '../../../shared/components/page-header/page-header.component';
+import { SectionHeaderComponent } from '../../../shared/components/section-header/section-header.component';
 
 @Component({
   selector: 'app-upcoming-page',
@@ -13,6 +14,7 @@ import { PageHeaderComponent } from '../../../shared/components/page-header/page
     PersonalTaskCardComponent,
     PersonalTaskWorkspaceComponent,
     PageHeaderComponent,
+    SectionHeaderComponent,
   ],
   template: `
     <app-personal-task-workspace #workspace>
@@ -35,10 +37,11 @@ import { PageHeaderComponent } from '../../../shared/components/page-header/page
           <div class="group-stack">
             @for (group of taskService.upcomingTaskGroups(); track group.label) {
               <section class="group-card">
-                <div class="group-header">
-                  <h2>{{ group.label }}</h2>
-                  <span>{{ group.tasks.length }} tasks</span>
-                </div>
+                <app-section-header
+                  [title]="group.label"
+                  [count]="group.tasks.length + ' tasks'"
+                  size="md"
+                />
 
                 <div class="task-stack">
                   @for (task of group.tasks; track task.id) {
@@ -86,24 +89,10 @@ import { PageHeaderComponent } from '../../../shared/components/page-header/page
         padding: 1.25rem;
       }
 
-      .group-header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 1rem;
-        margin-bottom: 0.95rem;
-      }
-
-      .group-header h2,
       .empty-state h2 {
         margin: 0;
         font-size: 1.7rem;
         letter-spacing: -0.04em;
-      }
-
-      .group-header span {
-        color: var(--on-surface-muted);
-        font-size: 0.88rem;
       }
 
       .task-stack {

--- a/apps/frontend/src/app/shared/components/section-header/section-header.component.css
+++ b/apps/frontend/src/app/shared/components/section-header/section-header.component.css
@@ -1,0 +1,74 @@
+:host {
+  display: block;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.section-header-copy {
+  min-width: 0;
+}
+
+.section-header h2 {
+  margin: 0;
+  color: var(--on-surface);
+}
+
+.section-header-sm h2 {
+  font-size: 1rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--on-surface-subtle);
+}
+
+.section-header-md h2 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+}
+
+.section-header-lg h2 {
+  font-size: 1.85rem;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+}
+
+.section-header-accent.section-header-lg h2,
+.section-header-accent.section-header-md h2 {
+  color: #c97c46;
+}
+
+.section-header-meta {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.section-header-count {
+  border-radius: 999px;
+  background: var(--surface-container-low);
+  padding: 0.28rem 0.7rem;
+  color: var(--on-surface-muted);
+  font-size: 0.76rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.section-header-accent .section-header-count {
+  background: var(--primary-soft-strong);
+  color: var(--primary-solid);
+}
+
+.section-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+}

--- a/apps/frontend/src/app/shared/components/section-header/section-header.component.html
+++ b/apps/frontend/src/app/shared/components/section-header/section-header.component.html
@@ -1,0 +1,21 @@
+<header
+  class="section-header"
+  [class.section-header-sm]="size === 'sm'"
+  [class.section-header-md]="size === 'md'"
+  [class.section-header-lg]="size === 'lg'"
+  [class.section-header-accent]="tone === 'accent'"
+>
+  <div class="section-header-copy">
+    <h2>{{ title }}</h2>
+  </div>
+
+  <div class="section-header-meta">
+    @if (count !== null && count !== undefined && count !== '') {
+      <span class="section-header-count">{{ count }}</span>
+    }
+
+    <div class="section-header-actions">
+      <ng-content select="[section-header-actions]" />
+    </div>
+  </div>
+</header>

--- a/apps/frontend/src/app/shared/components/section-header/section-header.component.spec.ts
+++ b/apps/frontend/src/app/shared/components/section-header/section-header.component.spec.ts
@@ -1,0 +1,37 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { SectionHeaderComponent } from './section-header.component';
+
+@Component({
+  standalone: true,
+  imports: [SectionHeaderComponent],
+  template: `
+    <app-section-header title="Inbox" count="12 tasks" size="sm" tone="accent">
+      <button section-header-actions type="button">Filter</button>
+    </app-section-header>
+  `,
+})
+class SectionHeaderHostComponent {}
+
+describe('SectionHeaderComponent', () => {
+  let fixture: ComponentFixture<SectionHeaderHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SectionHeaderHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SectionHeaderHostComponent);
+  });
+
+  it('renders the title, count, and projected actions', () => {
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Inbox');
+    expect(fixture.nativeElement.textContent).toContain('12 tasks');
+    expect(
+      fixture.debugElement.query(By.css('[section-header-actions]')).nativeElement.textContent,
+    ).toContain('Filter');
+  });
+});

--- a/apps/frontend/src/app/shared/components/section-header/section-header.component.ts
+++ b/apps/frontend/src/app/shared/components/section-header/section-header.component.ts
@@ -1,0 +1,19 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+
+type SectionHeaderSize = 'sm' | 'md' | 'lg';
+type SectionHeaderTone = 'default' | 'accent';
+
+@Component({
+  selector: 'app-section-header',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './section-header.component.html',
+  styleUrl: './section-header.component.css',
+})
+export class SectionHeaderComponent {
+  @Input() title = '';
+  @Input() count: string | number | null = null;
+  @Input() size: SectionHeaderSize = 'md';
+  @Input() tone: SectionHeaderTone = 'default';
+}


### PR DESCRIPTION
## Description

Introduces a reusable `SectionHeader` component for shared section-level headings across the frontend, then migrates the repeated heading patterns in the personal pages to use it.

This reduces duplicated markup and styling in places like Today, Inbox, Upcoming, Project Detail, and Search while keeping page-level headers separate.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Test coverage improvement
- [x] Refactoring (code improvement with no functional change)

## Related Issue

Closes: #

## Roadmap Reference

Implements the shared `SectionHeader` refactor from the frontend roadmap.

## Changes Made

- Added a new shared `SectionHeader` component with support for title, count, size, tone, and projected actions.
- Replaced repeated `section-heading` / `group-header` markup in personal pages with the shared component.
- Removed duplicated page-local heading CSS that the shared component now owns.
- Added unit coverage for the new shared component.
- Ran frontend typecheck and test suite successfully.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed

### Verification Steps

1. Run `pnpm --filter @yotara/frontend typecheck`
2. Run `pnpm --filter @yotara/frontend test`
3. Verify the updated personal pages render their section headings and counts correctly

## Screenshots or Demo

Not included.

## Checklist

- [x] Code follows the project style and conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have verified that this PR is against the correct branch (`main`)

## Additional Notes

Karma reported an existing Angular `NG0912` component ID collision warning in the test suite, but the suite still passed successfully.