### PR TITLE
Fix task, project, and label refresh flows

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,4 @@
 {
-  "*.ts": ["eslint --fix", "prettier --write"],
+  "*.ts": ["eslint --fix --no-warn-ignored", "prettier --write"],
   "*.{js,json,md}": ["prettier --write"]
 }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -75,13 +75,12 @@ This document outlines the complete list of screens, pages, and modals needed fo
 - Visual timeline sense
 
 ### Project / List Detail (`/projects/:id` or `/lists/:slug`)
-- **Status**: 🟡 Placeholder UI exists, full project data model still pending
+- **Status**: ✅ Built for personal mode
 - Project name header + description
-- **View switcher**: List | Kanban
-  - List view: traditional task list
-  - Kanban view: To Do | In Progress | Done columns
-- Add task button (inline and/or floating action button)
-- Edit/archive project options
+- Project-scoped task list with add-task actions
+- Edit from the directory and detail views
+- Kanban view remains a later enhancement
+- Archive/delete project options remain a separate follow-up slice
 
 ### Task Detail / Edit Modal ⭐ (Most Important)
 - **Status**: ✅ Built for personal-mode task create/edit
@@ -313,7 +312,7 @@ These features should be built as personal-mode improvements first, but they sho
 5. ✅ Inbox list + task item component
 6. ✅ Task create & detail modal
 7. ✅ Today + Upcoming views
-8. 🟡 Project create + project detail (data model still pending)
+8. ✅ Project create + project detail
 
 ### Phase 3: Polish & Secondary Features
 9. 🟡 Settings basics + logout
@@ -373,13 +372,13 @@ These features should be built as personal-mode improvements first, but they sho
 - Auth guard integration
 - Task service (CRUD + paginated task loading)
 - Task API with pagination and soft delete
+- Project create + project detail screens
 - OpenAPI docs and Swagger UI
 - Docker deployment and smoke checks
 - Inbox counter pipe
 
 ### 🔄 In Progress
 - Team-mode shell and workspace primitives
-- Project data model and project detail screens
 - Settings shell and account/logout flows
 - Archive flow for completed tasks
 

--- a/apps/frontend/TODO.md
+++ b/apps/frontend/TODO.md
@@ -20,9 +20,9 @@
   - [x] Support subtitle and optional action slot/button area
   - [ ] Replace repeated `page-header` markup in personal pages
 
-- [ ] Create a generic `SectionHeader` component:
-  - [ ] Inputs: `title`, `count`, `accent/tone`
-  - [ ] Replace repeated `section-heading` markup
+- [x] Create a generic `SectionHeader` component:
+  - [x] Inputs: `title`, `count`, `accent/tone`
+  - [x] Replace repeated `section-heading` markup
 
 - [ ] Create a generic `EmptyState` component:
   - [ ] Inputs: `title`, `description`, optional icon/illustration

--- a/apps/frontend/src/app/core/services/project.service.ts
+++ b/apps/frontend/src/app/core/services/project.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, computed, inject, signal } from '@angular/core';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { CreateProjectDto, Project, UpdateProjectDto } from '@yotara/shared';
+import { CreateProjectDto, Project, Task, UpdateProjectDto } from '@yotara/shared';
 import {
   catchError,
   combineLatest,
@@ -67,6 +67,36 @@ export class ProjectService {
   readonly saving = this.savingState.asReadonly();
   readonly error = this.errorState.asReadonly();
   readonly hasProjects = computed(() => this.projects().length > 0);
+
+  async getProject(projectId: string): Promise<Project | null> {
+    try {
+      return await firstValueFrom(
+        this.http.get<Project>(`${this.baseUrl}/projects/${projectId}`, { withCredentials: true }),
+      );
+    } catch (error) {
+      if (error instanceof HttpErrorResponse && error.status === 404) {
+        return null;
+      }
+
+      throw error;
+    }
+  }
+
+  async getProjectTasks(projectId: string): Promise<Task[] | null> {
+    try {
+      return await firstValueFrom(
+        this.http.get<Task[]>(`${this.baseUrl}/projects/${projectId}/tasks`, {
+          withCredentials: true,
+        }),
+      );
+    } catch (error) {
+      if (error instanceof HttpErrorResponse && error.status === 404) {
+        return null;
+      }
+
+      throw error;
+    }
+  }
 
   async createProject(payload: CreateProjectDto) {
     this.savingState.set(true);

--- a/apps/frontend/src/app/core/services/task.service.spec.ts
+++ b/apps/frontend/src/app/core/services/task.service.spec.ts
@@ -3,12 +3,16 @@ import { signal } from '@angular/core';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { TaskService } from './task.service';
 import { AuthStateService } from './auth-state.service';
+import { LabelService } from './label.service';
+import { ProjectService } from './project.service';
 import { Task } from '@yotara/shared';
 
 describe('TaskService', () => {
   const initialized = signal(false);
   const isAuthenticated = signal(false);
   const currentUserId = signal<string | null>(null);
+  let labelServiceStub: { refreshLabels: jasmine.Spy };
+  let projectServiceStub: { projects: ReturnType<typeof signal>; refreshProjects: jasmine.Spy };
 
   function dayOffset(offset: number) {
     const date = new Date();
@@ -40,6 +44,13 @@ describe('TaskService', () => {
     initialized.set(false);
     isAuthenticated.set(false);
     currentUserId.set(null);
+    projectServiceStub = {
+      projects: signal([]),
+      refreshProjects: jasmine.createSpy('refreshProjects'),
+    };
+    labelServiceStub = {
+      refreshLabels: jasmine.createSpy('refreshLabels'),
+    };
 
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -52,6 +63,14 @@ describe('TaskService', () => {
             isAuthenticated,
             currentUserId,
           },
+        },
+        {
+          provide: ProjectService,
+          useValue: projectServiceStub,
+        },
+        {
+          provide: LabelService,
+          useValue: labelServiceStub,
         },
       ],
     });
@@ -361,6 +380,8 @@ describe('TaskService', () => {
 
     expect(createdTask?.id).toBe('created-1');
     expect(service.inboxTasks().map((task) => task.id)).toEqual(['created-1']);
+    expect(labelServiceStub.refreshLabels).toHaveBeenCalled();
+    expect(projectServiceStub.refreshProjects).toHaveBeenCalled();
   }));
 
   it('updates a task with metadata and refreshes the list', fakeAsync(() => {
@@ -422,5 +443,7 @@ describe('TaskService', () => {
 
     expect(service.inboxTasks()[0]?.bucket).toBe('deep-work');
     expect(service.inboxTasks()[0]?.simpleMode).toBeFalse();
+    expect(labelServiceStub.refreshLabels).toHaveBeenCalled();
+    expect(projectServiceStub.refreshProjects).toHaveBeenCalled();
   }));
 });

--- a/apps/frontend/src/app/core/services/task.service.ts
+++ b/apps/frontend/src/app/core/services/task.service.ts
@@ -14,6 +14,8 @@ import {
 } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { AuthStateService } from './auth-state.service';
+import { LabelService } from './label.service';
+import { ProjectService } from './project.service';
 
 type UpcomingBucket = 'This Week' | 'Next Week' | 'Later';
 
@@ -26,6 +28,8 @@ export interface UpcomingTaskGroup {
 export class TaskService {
   private http = inject(HttpClient);
   private authState = inject(AuthStateService);
+  private labelService = inject(LabelService);
+  private projectService = inject(ProjectService);
   private baseUrl = environment.apiBaseUrl;
   private refreshState = signal(0);
   private loadingState = signal(false);
@@ -75,6 +79,7 @@ export class TaskService {
   readonly loading = this.loadingState.asReadonly();
   readonly creating = this.creatingState.asReadonly();
   readonly error = this.errorState.asReadonly();
+  readonly revision = this.refreshState.asReadonly();
   readonly activeTasks = computed(() =>
     this.tasks().filter((task) => !task.completed && task.status !== 'archived'),
   );
@@ -123,6 +128,8 @@ export class TaskService {
         this.http.post<Task>(`${this.baseUrl}/tasks`, payload, { withCredentials: true }),
       );
       this.refreshState.update((value: number) => value + 1);
+      this.labelService.refreshLabels();
+      this.projectService.refreshProjects();
       return createdTask;
     } catch (error) {
       console.error('Failed to create task', error);
@@ -144,6 +151,8 @@ export class TaskService {
         }),
       );
       this.refreshState.update((value: number) => value + 1);
+      this.labelService.refreshLabels();
+      this.projectService.refreshProjects();
       return updatedTask;
     } catch (error) {
       console.error('Failed to update task', error);

--- a/apps/frontend/src/app/features/personal/components/personal-project-modal.component.ts
+++ b/apps/frontend/src/app/features/personal/components/personal-project-modal.component.ts
@@ -1,7 +1,15 @@
 import { CommonModule } from '@angular/common';
-import { Component, EventEmitter, Input, Output, signal } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output,
+  SimpleChanges,
+  signal,
+} from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import type { CreateProjectDto, ProjectColor } from '@yotara/shared';
+import type { CreateProjectDto, Project, ProjectColor } from '@yotara/shared';
 import { PROJECT_PALETTE } from '../project-presentation';
 
 @Component({
@@ -21,8 +29,14 @@ import { PROJECT_PALETTE } from '../project-presentation';
         <section class="modal-card" role="dialog" aria-modal="true" aria-labelledby="project-title">
           <header class="modal-header">
             <div>
-              <h2 id="project-title">New Project</h2>
-              <p>A project is a home for related tasks and progress.</p>
+              <h2 id="project-title">{{ mode === 'edit' ? 'Edit Project' : 'New Project' }}</h2>
+              <p>
+                {{
+                  mode === 'edit'
+                    ? 'Adjust the name, description, or color of this project space.'
+                    : 'A project is a home for related tasks and progress.'
+                }}
+              </p>
             </div>
 
             <button type="button" class="close-button" aria-label="Close" (click)="close.emit()">
@@ -79,7 +93,15 @@ import { PROJECT_PALETTE } from '../project-presentation';
           <div class="actions">
             <button type="button" class="secondary-button" (click)="close.emit()">Cancel</button>
             <button type="button" class="primary-button" [disabled]="saving" (click)="submit()">
-              {{ saving ? 'Creating...' : 'Create Project' }}
+              {{
+                saving
+                  ? mode === 'edit'
+                    ? 'Saving...'
+                    : 'Creating...'
+                  : mode === 'edit'
+                    ? 'Save Changes'
+                    : 'Create Project'
+              }}
             </button>
           </div>
         </section>
@@ -266,8 +288,10 @@ import { PROJECT_PALETTE } from '../project-presentation';
     `,
   ],
 })
-export class PersonalProjectModalComponent {
+export class PersonalProjectModalComponent implements OnChanges {
   @Input() open = false;
+  @Input() mode: 'create' | 'edit' = 'create';
+  @Input() project: Project | null = null;
   @Input() saving = false;
   @Input() error: string | null = null;
   @Output() readonly close = new EventEmitter<void>();
@@ -278,6 +302,16 @@ export class PersonalProjectModalComponent {
   protected readonly draftDescription = signal('');
   protected readonly draftColor = signal<ProjectColor>('sage');
   protected readonly nameError = signal<string | null>(null);
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (this.open && (changes['open'] || changes['mode'] || changes['project'])) {
+      this.hydrateDrafts();
+    }
+
+    if (changes['open'] && !this.open) {
+      this.nameError.set(null);
+    }
+  }
 
   protected submit() {
     const name = this.draftName().trim();
@@ -293,5 +327,19 @@ export class PersonalProjectModalComponent {
       description: this.draftDescription().trim() || undefined,
       color: this.draftColor(),
     });
+  }
+
+  private hydrateDrafts() {
+    if (this.mode === 'edit' && this.project) {
+      this.draftName.set(this.project.name);
+      this.draftDescription.set(this.project.description ?? '');
+      this.draftColor.set(this.project.color ?? 'sage');
+    } else {
+      this.draftName.set('');
+      this.draftDescription.set('');
+      this.draftColor.set('sage');
+    }
+
+    this.nameError.set(null);
   }
 }

--- a/apps/frontend/src/app/features/personal/components/personal-task-workspace.component.ts
+++ b/apps/frontend/src/app/features/personal/components/personal-task-workspace.component.ts
@@ -20,7 +20,9 @@ type SavePayload =
       [open]="modalOpen()"
       [task]="selectedTask()"
       [projects]="projectService.projects()"
-      [initialProjectId]="draftProjectId() || initialProjectId || projectService.projects()[0]?.id || null"
+      [initialProjectId]="
+        draftProjectId() || initialProjectId || projectService.projects()[0]?.id || null
+      "
       [initialTitle]="initialTitle"
       [error]="taskService.error()"
       (close)="closeTaskModal()"
@@ -42,7 +44,9 @@ export class PersonalTaskWorkspaceComponent {
 
   openCreateTaskModal(projectId?: string | null) {
     this.selectedTask.set(null);
-    this.draftProjectId.set(projectId ?? this.initialProjectId ?? this.projectService.projects()[0]?.id ?? null);
+    this.draftProjectId.set(
+      projectId ?? this.initialProjectId ?? this.projectService.projects()[0]?.id ?? null,
+    );
     this.modalOpen.set(true);
   }
 
@@ -68,7 +72,6 @@ export class PersonalTaskWorkspaceComponent {
         await this.taskService.updateTask(event.taskId, event.payload);
       }
 
-      this.projectService.refreshProjects();
       this.taskSaved.emit(event.mode);
       this.closeTaskModal();
     } catch {

--- a/apps/frontend/src/app/features/personal/pages/labels-page.component.spec.ts
+++ b/apps/frontend/src/app/features/personal/pages/labels-page.component.spec.ts
@@ -1,10 +1,64 @@
 import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
+import { of } from 'rxjs';
 import { LabelsPageComponent } from './labels-page.component';
+import { LabelService } from '../../../core/services/label.service';
+import { ProjectService } from '../../../core/services/project.service';
+import { TaskService } from '../../../core/services/task.service';
 
 describe('LabelsPageComponent', () => {
+  const labels = signal([
+    { id: 'writing', name: 'Writing', color: '#82d7a9', taskCount: 3 },
+    { id: 'focus', name: 'Focus', color: '#81d7e8', taskCount: 1 },
+    { id: 'finance', name: 'Finance', color: '#f1c582', taskCount: 2 },
+    { id: 'frontend-only', name: 'frontend-only', color: '#b9a3f4', taskCount: 4 },
+  ]);
+  const tasks = signal([]);
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [LabelsPageComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            queryParamMap: of(convertToParamMap({})),
+            snapshot: { queryParamMap: convertToParamMap({}) },
+          },
+        },
+        {
+          provide: LabelService,
+          useValue: {
+            labels,
+            loading: signal(false),
+            error: signal(null),
+            createLabel: jasmine.createSpy('createLabel').and.resolveTo({
+              id: 'created-label',
+              name: 'Created Label',
+              color: '#82d7a9',
+              taskCount: 0,
+            }),
+            refreshLabels: jasmine.createSpy('refreshLabels'),
+          },
+        },
+        {
+          provide: TaskService,
+          useValue: {
+            tasks,
+            error: signal(null),
+            createTask: jasmine.createSpy('createTask').and.resolveTo(undefined),
+            updateTask: jasmine.createSpy('updateTask').and.resolveTo(undefined),
+          },
+        },
+        {
+          provide: ProjectService,
+          useValue: {
+            projects: signal([]),
+          },
+        },
+      ],
     }).compileComponents();
   });
 

--- a/apps/frontend/src/app/features/personal/pages/labels-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/labels-page.component.ts
@@ -30,10 +30,7 @@ import { LabelModalComponent } from '../components/label-modal.component';
           subtitle="Tap a label to see its tasks. Manage colors and names from the same modal."
         >
           <div page-header-actions class="header-actions">
-            <button type="button" class="header-button" (click)="openCreateLabel()">
-              Create Label
-            </button>
-            <button type="button" class="header-button secondary" (click)="openManageLabels()">
+            <button type="button" class="header-button" (click)="openManageLabels()">
               Manage Labels
             </button>
           </div>

--- a/apps/frontend/src/app/features/personal/pages/project-detail-page.component.html
+++ b/apps/frontend/src/app/features/personal/pages/project-detail-page.component.html
@@ -3,8 +3,18 @@
   [initialProjectId]="projectId()"
   (taskSaved)="handleTaskSaved()"
 >
+  <app-personal-project-modal
+    [open]="projectModalOpen()"
+    mode="edit"
+    [project]="project()"
+    [saving]="projectService.saving()"
+    (close)="closeProjectModal()"
+    (save)="saveProject($event)"
+  />
+
   <section class="page">
-    @if (project(); as currentProject) {
+    @if (projectState() === 'ready') {
+      @if (project(); as currentProject) {
       <app-page-header [title]="currentProject.name">
         <a
           page-header-back
@@ -14,7 +24,20 @@
         >
           <fa-icon [icon]="faArrowLeft"></fa-icon>
         </a>
+
+        <button
+          page-header-actions
+          type="button"
+          class="header-action-button"
+          (click)="openEditProjectModal()"
+        >
+          Edit Project
+        </button>
       </app-page-header>
+
+      @if (currentProject.description) {
+        <p class="project-description">{{ currentProject.description }}</p>
+      }
 
       <section class="metrics-card">
         <div class="metric">
@@ -95,8 +118,15 @@
           </section>
         }
       }
-    } @else if (projectService.loading()) {
+      }
+    } @else if (projectState() === 'loading') {
       <p class="status-copy">Loading your project...</p>
+    } @else if (projectState() === 'error') {
+      <section class="empty-state">
+        <h2>We could not load this project</h2>
+        <p>{{ loadError() }}</p>
+        <button type="button" class="empty-button" (click)="retryLoad()">Try Again</button>
+      </section>
     } @else {
       <section class="empty-state">
         <h2>Project not found</h2>

--- a/apps/frontend/src/app/features/personal/pages/project-detail-page.component.scss
+++ b/apps/frontend/src/app/features/personal/pages/project-detail-page.component.scss
@@ -63,6 +63,14 @@ h1 {
   line-height: 1.5;
 }
 
+.project-description {
+  margin: -0.6rem 0 0;
+  max-width: 48rem;
+  color: var(--on-surface-muted);
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
 .metrics-card {
   --metric-accent: var(--primary-solid);
 
@@ -156,6 +164,17 @@ h1 {
   justify-content: center;
 }
 
+.header-action-button {
+  border: 0;
+  border-radius: 999px;
+  background: var(--surface-container-low);
+  box-shadow: inset 0 0 0 1px var(--outline-variant);
+  color: var(--on-surface-muted);
+  min-height: 2.75rem;
+  padding: 0 1rem;
+  font-weight: 700;
+}
+
 .task-section {
   margin-top: 1.6rem;
 }
@@ -228,5 +247,9 @@ h1 {
   .actions-row {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .header-action-button {
+    width: 100%;
   }
 }

--- a/apps/frontend/src/app/features/personal/pages/project-detail-page.component.spec.ts
+++ b/apps/frontend/src/app/features/personal/pages/project-detail-page.component.spec.ts
@@ -1,0 +1,151 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { convertToParamMap, ActivatedRoute, provideRouter } from '@angular/router';
+import { of } from 'rxjs';
+import { ProjectDetailPageComponent } from './project-detail-page.component';
+import { ProjectService } from '../../../core/services/project.service';
+import { TaskService } from '../../../core/services/task.service';
+import { LabelService } from '../../../core/services/label.service';
+
+describe('ProjectDetailPageComponent', () => {
+  let projectServiceStub: {
+    projects: ReturnType<typeof signal>;
+    saving: ReturnType<typeof signal>;
+    getProject: jasmine.Spy;
+    getProjectTasks: jasmine.Spy;
+    updateProject: jasmine.Spy;
+    refreshProjects: jasmine.Spy;
+  };
+  let taskRevision = signal(0);
+
+  const baseProject = {
+    id: 'project-1',
+    name: 'Launch Yotara MVP',
+    description: 'Core release scope',
+    color: 'sage' as const,
+    ownerId: 'user-1',
+    taskCount: 2,
+    completedTaskCount: 1,
+    openTaskCount: 1,
+    createdAt: '2026-04-01T10:00:00.000Z',
+    updatedAt: '2026-04-03T10:00:00.000Z',
+  };
+
+  const activeTask = {
+    id: 'task-1',
+    title: 'Draft launch copy',
+    description: 'Write the first pass',
+    status: 'inbox' as const,
+    priority: 'medium' as const,
+    completed: false,
+    order: 0,
+    dueDate: null,
+    simpleMode: false,
+    bucket: 'personal-sanctuary' as const,
+    projectId: 'project-1',
+    deletedAt: null,
+    createdAt: '2026-04-02T10:00:00.000Z',
+    updatedAt: '2026-04-02T10:00:00.000Z',
+  };
+
+  const completedTask = {
+    ...activeTask,
+    id: 'task-2',
+    title: 'Outline release checklist',
+    completed: true,
+    status: 'done' as const,
+  };
+
+  async function configure(projectResponse: typeof baseProject | null) {
+    TestBed.resetTestingModule();
+    taskRevision = signal(0);
+
+    projectServiceStub = {
+      projects: signal([baseProject]),
+      saving: signal(false),
+      getProject: jasmine.createSpy('getProject').and.resolveTo(projectResponse),
+      getProjectTasks: jasmine
+        .createSpy('getProjectTasks')
+        .and.resolveTo(projectResponse ? [activeTask, completedTask] : null),
+      updateProject: jasmine.createSpy('updateProject').and.resolveTo(baseProject),
+      refreshProjects: jasmine.createSpy('refreshProjects'),
+    };
+
+    const taskServiceStub = {
+      error: signal(null),
+      revision: taskRevision,
+      createTask: jasmine.createSpy('createTask').and.resolveTo(undefined),
+      updateTask: jasmine.createSpy('updateTask').and.resolveTo(undefined),
+    };
+
+    const labelServiceStub = {
+      labels: signal([]),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [ProjectDetailPageComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            paramMap: of(convertToParamMap({ id: 'project-1' })),
+            snapshot: { paramMap: convertToParamMap({ id: 'project-1' }) },
+          },
+        },
+        { provide: ProjectService, useValue: projectServiceStub },
+        { provide: TaskService, useValue: taskServiceStub },
+        { provide: LabelService, useValue: labelServiceStub },
+      ],
+    }).compileComponents();
+  }
+
+  it('loads project-scoped data on a cold route load', async () => {
+    await configure(baseProject);
+
+    const fixture = TestBed.createComponent(ProjectDetailPageComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain('Launch Yotara MVP');
+    expect(text).toContain('Core release scope');
+    expect(text).toContain('Draft launch copy');
+    expect(text).toContain('Outline release checklist');
+    expect(text).toContain('Edit Project');
+    expect(text).toContain('Add Task');
+  });
+
+  it('shows a not found state when the project is missing', async () => {
+    await configure(null);
+
+    const fixture = TestBed.createComponent(ProjectDetailPageComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain('Project not found');
+    expect(text).not.toContain('Edit Project');
+  });
+
+  it('reloads project details when task revisions change', async () => {
+    await configure(baseProject);
+
+    const fixture = TestBed.createComponent(ProjectDetailPageComponent);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const initialTaskCalls = projectServiceStub.getProjectTasks.calls.count();
+    taskRevision.set(1);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(projectServiceStub.getProjectTasks.calls.count()).toBeGreaterThan(initialTaskCalls);
+  });
+});

--- a/apps/frontend/src/app/features/personal/pages/project-detail-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/project-detail-page.component.ts
@@ -1,18 +1,21 @@
 import { CommonModule } from '@angular/common';
-import { Component, computed, inject, viewChild } from '@angular/core';
+import { Component, computed, effect, inject, signal, viewChild } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { map } from 'rxjs';
-import type { Project } from '@yotara/shared';
+import type { CreateProjectDto, Project, Task } from '@yotara/shared';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faArrowLeft } from '@fortawesome/free-solid-svg-icons';
 import { ProjectService } from '../../../core/services/project.service';
 import { TaskService } from '../../../core/services/task.service';
 import { PersonalTaskCardComponent } from '../components/personal-task-card.component';
 import { PersonalTaskWorkspaceComponent } from '../components/personal-task-workspace.component';
+import { PersonalProjectModalComponent } from '../components/personal-project-modal.component';
 import { SectionHeaderComponent } from '../../../shared/components/section-header/section-header.component';
 import { PageHeaderComponent } from '../../../shared/components/page-header/page-header.component';
 import { projectPaletteFor, projectProgressPercent } from '../project-presentation';
+
+type ProjectLoadState = 'loading' | 'ready' | 'not-found' | 'error';
 
 @Component({
   selector: 'app-project-detail-page',
@@ -21,6 +24,7 @@ import { projectPaletteFor, projectProgressPercent } from '../project-presentati
     CommonModule,
     RouterLink,
     FontAwesomeModule,
+    PersonalProjectModalComponent,
     PersonalTaskCardComponent,
     PersonalTaskWorkspaceComponent,
     SectionHeaderComponent,
@@ -31,26 +35,89 @@ import { projectPaletteFor, projectProgressPercent } from '../project-presentati
 })
 export class ProjectDetailPageComponent {
   protected readonly projectService = inject(ProjectService);
-  protected readonly taskService = inject(TaskService);
+  private readonly taskService = inject(TaskService);
   private readonly route = inject(ActivatedRoute);
   private readonly workspace = viewChild(PersonalTaskWorkspaceComponent);
   protected readonly faArrowLeft = faArrowLeft;
+  protected readonly projectModalOpen = signal(false);
+  protected readonly projectState = signal<ProjectLoadState>('loading');
+  protected readonly loadError = signal<string | null>(null);
+  protected readonly project = signal<Project | null>(null);
+  protected readonly projectTasks = signal<Task[]>([]);
+  private readonly lastSeenTaskRevision = signal(this.taskService.revision());
   protected readonly projectId = toSignal(
     this.route.paramMap.pipe(map((params) => params.get('id'))),
     { initialValue: this.route.snapshot.paramMap.get('id') },
   );
-  protected readonly project = computed(
-    () => this.projectService.projects().find((project) => project.id === this.projectId()) ?? null,
-  );
   protected readonly activeProjectTasks = computed(() =>
-    this.taskService.activeTasks().filter((task) => task.projectId === this.projectId()),
+    this.projectTasks().filter((task) => !task.completed && task.status !== 'archived'),
   );
   protected readonly completedProjectTasks = computed(() =>
-    this.taskService.completedTasks().filter((task) => task.projectId === this.projectId()),
+    this.projectTasks().filter((task) => task.completed && task.status !== 'archived'),
   );
+
+  constructor() {
+    effect(() => {
+      const projectId = this.projectId();
+      if (!projectId) {
+        this.project.set(null);
+        this.projectTasks.set([]);
+        this.projectState.set('not-found');
+        return;
+      }
+
+      void this.loadProject(projectId);
+    });
+
+    effect(() => {
+      const projectId = this.projectId();
+      const taskRevision = this.taskService.revision();
+
+      if (!projectId || this.projectState() !== 'ready') {
+        return;
+      }
+
+      if (this.lastSeenTaskRevision() === taskRevision) {
+        return;
+      }
+
+      this.lastSeenTaskRevision.set(taskRevision);
+      void this.loadProject(projectId);
+    });
+  }
 
   protected handleTaskSaved() {
     this.workspace()?.closeTaskModal();
+    this.reloadProjectDetails();
+  }
+
+  protected openEditProjectModal() {
+    if (!this.project()) {
+      return;
+    }
+
+    this.projectModalOpen.set(true);
+  }
+
+  protected closeProjectModal() {
+    this.projectModalOpen.set(false);
+  }
+
+  protected async saveProject(payload: CreateProjectDto) {
+    const currentProject = this.project();
+    if (!currentProject) {
+      return;
+    }
+
+    const updated = await this.projectService.updateProject(currentProject.id, payload);
+    this.closeProjectModal();
+    if (updated) {
+      this.project.set(updated);
+      this.projectState.set('ready');
+    }
+
+    this.lastSeenTaskRevision.set(this.taskService.revision());
+    this.reloadProjectDetails();
   }
 
   protected projectColorClass(project: Project) {
@@ -59,5 +126,65 @@ export class ProjectDetailPageComponent {
 
   protected progressPercent(project: Project) {
     return projectProgressPercent(project.openTaskCount, project.completedTaskCount);
+  }
+
+  protected retryLoad() {
+    this.reloadProjectDetails();
+  }
+
+  private loadToken = 0;
+
+  private reloadProjectDetails() {
+    this.loadToken += 1;
+    const projectId = this.projectId();
+    if (projectId) {
+      void this.loadProject(projectId);
+    }
+  }
+
+  private async loadProject(projectId: string) {
+    const requestToken = ++this.loadToken;
+    this.projectState.set('loading');
+    this.loadError.set(null);
+    this.lastSeenTaskRevision.set(this.taskService.revision());
+
+    try {
+      const project = await this.projectService.getProject(projectId);
+      if (requestToken !== this.loadToken) {
+        return;
+      }
+
+      if (!project) {
+        this.project.set(null);
+        this.projectTasks.set([]);
+        this.projectState.set('not-found');
+        return;
+      }
+
+      const projectTasks = await this.projectService.getProjectTasks(projectId);
+      if (requestToken !== this.loadToken) {
+        return;
+      }
+
+      if (!projectTasks) {
+        this.project.set(null);
+        this.projectTasks.set([]);
+        this.projectState.set('not-found');
+        return;
+      }
+
+      this.project.set(project);
+      this.projectTasks.set(projectTasks);
+      this.projectState.set('ready');
+    } catch {
+      if (requestToken !== this.loadToken) {
+        return;
+      }
+
+      this.project.set(null);
+      this.projectTasks.set([]);
+      this.loadError.set('Could not load this project right now.');
+      this.projectState.set('error');
+    }
   }
 }

--- a/apps/frontend/src/app/features/personal/pages/projects-page.component.html
+++ b/apps/frontend/src/app/features/personal/pages/projects-page.component.html
@@ -15,9 +15,11 @@
 
   <app-personal-project-modal
     [open]="createModalOpen()"
+    [mode]="modalMode()"
+    [project]="selectedProject()"
     [saving]="projectService.saving()"
     [error]="projectService.error()"
-    (close)="closeCreateModal()"
+    (close)="closeProjectModal()"
     (save)="createProject($event)"
   />
 
@@ -52,6 +54,13 @@
                   <p>
                     {{ project.description || 'A calm place for the work that belongs together.' }}
                   </p>
+                  <button
+                    type="button"
+                    class="project-edit-button"
+                    (click)="openEditModal(project, $event)"
+                  >
+                    Edit
+                  </button>
                 </div>
               </div>
             </div>

--- a/apps/frontend/src/app/features/personal/pages/projects-page.component.scss
+++ b/apps/frontend/src/app/features/personal/pages/projects-page.component.scss
@@ -152,6 +152,8 @@
 .project-info {
   flex: 1;
   min-width: 0;
+  display: grid;
+  gap: 0.45rem;
 
   h3 {
     margin: 0;
@@ -167,6 +169,19 @@
     color: var(--on-surface-muted);
     line-height: 1.4;
   }
+}
+
+.project-edit-button {
+  justify-self: start;
+  border: 0;
+  border-radius: 999px;
+  padding: 0.35rem 0.8rem;
+  background: color-mix(in srgb, var(--primary-solid) 12%, var(--surface-container-low));
+  color: var(--primary-solid);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .col-progress {
@@ -337,6 +352,10 @@
 
   .col-identification {
     grid-column: 1;
+  }
+
+  .project-edit-button {
+    margin-top: 0.2rem;
   }
 
   .table-row {

--- a/apps/frontend/src/app/features/personal/pages/projects-page.component.spec.ts
+++ b/apps/frontend/src/app/features/personal/pages/projects-page.component.spec.ts
@@ -46,7 +46,9 @@ describe('ProjectsPageComponent', () => {
     const text = fixture.nativeElement.textContent;
     expect(text).toContain('Launch Yotara MVP');
     expect(text).toContain('Core release scope');
-    expect(text).toContain('18 tasks');
+    expect(text).toContain('61%');
+    expect(text).toContain('ACTIVE');
     expect(text).toContain('New Project');
+    expect(text).toContain('Edit');
   });
 });

--- a/apps/frontend/src/app/features/personal/pages/projects-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/projects-page.component.ts
@@ -18,6 +18,8 @@ export class ProjectsPageComponent {
   protected readonly projectService = inject(ProjectService);
   private readonly router = inject(Router);
   protected readonly createModalOpen = signal(false);
+  protected readonly modalMode = signal<'create' | 'edit'>('create');
+  protected readonly selectedProject = signal<Project | null>(null);
   protected readonly projects = this.projectService.projects;
   protected readonly focusHeadline = computed(() => {
     const projects = this.projects();
@@ -41,16 +43,35 @@ export class ProjectsPageComponent {
   });
 
   protected openCreateModal() {
+    this.selectedProject.set(null);
+    this.modalMode.set('create');
     this.createModalOpen.set(true);
   }
 
-  protected closeCreateModal() {
+  protected openEditModal(project: Project, event?: MouseEvent) {
+    event?.stopPropagation();
+    this.selectedProject.set(project);
+    this.modalMode.set('edit');
+    this.createModalOpen.set(true);
+  }
+
+  protected closeProjectModal() {
     this.createModalOpen.set(false);
+    this.selectedProject.set(null);
+    this.modalMode.set('create');
   }
 
   protected async createProject(payload: CreateProjectDto) {
+    const selectedProject = this.selectedProject();
+
+    if (this.modalMode() === 'edit' && selectedProject) {
+      await this.projectService.updateProject(selectedProject.id, payload);
+      this.closeProjectModal();
+      return;
+    }
+
     const created = await this.projectService.createProject(payload);
-    this.createModalOpen.set(false);
+    this.closeProjectModal();
     await this.router.navigate(['/projects', created.id]);
   }
 

--- a/docs/personal-mode-mvp.md
+++ b/docs/personal-mode-mvp.md
@@ -14,7 +14,7 @@ This document captures what is now implemented for Yotara's personal-mode experi
 - mode-aware redirect logic so personal users land in `/inbox`
 - separate team routing so team users continue to `/dashboard`
 - task-backed Inbox, Today, and Upcoming views
-- placeholder-ready Projects and Labels pages
+- projects directory/detail screens and labels page
 - mobile drawer behavior for the personal shell
 - quick task capture from Inbox
 - richer task detail modal for create and edit flows
@@ -75,8 +75,9 @@ Project persistence now exists at the API/domain layer:
 - `GET /projects/:id/tasks` returns active tasks assigned to a project
 - projects are personal-mode scoped and return derived task counts
 
-Frontend project screens are still a follow-up slice. This backend work exists so the personal-mode
-Projects UI can connect to real data next.
+Frontend project screens now connect to live project data and support editing from both the
+directory and detail views. Follow-up slices remain Kanban, archive/delete, and any future team-mode
+layering.
 
 ## Verification
 


### PR DESCRIPTION
## Description

This PR tightens the personal-mode task flow so task completion and edits update the UI immediately across projects, labels, inbox, and project detail views. It also removes duplicate label actions in the header and keeps the `Create New Label` card as the primary create affordance.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Test coverage improvement
- [ ] Performance improvement
- [x] Refactoring (code improvement with no functional change)

## Related Issue

Closes: #

## Roadmap Reference

Implements the personal-mode project completion slice and label/task refresh polish from `ROADMAP.md`.

## Changes Made

- Task create/update now refreshes tasks, projects, and labels so completed tasks and label counts update without a manual refresh.
- Project detail now loads project-scoped data directly and refreshes when task revisions change.
- Label actions were simplified so the header has one `Manage Labels` button while `Create New Label` stays in the grid.
- Added and updated focused tests for task refresh behavior, project detail loading, and labels-page rendering.
- Updated roadmap and TODO documentation to match the shipped state.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed

### Verification Steps

1. Open a project, complete a task, and confirm the task moves to done immediately without refreshing.
2. Open the labels page and confirm label task counts and filtered task lists update after task edits.
3. Run the frontend test and typecheck suite.

## Screenshots or Demo

No screenshot included.

## Checklist

- [x] Code follows the project style and conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have verified that this PR is against the correct branch (`main`)

## Additional Notes

Archive/delete for projects is intentionally left as a follow-up slice, since that needs a separate product/backend decision.