### PR TITLE
fix(projects): surface edit errors and stabilize project task order

### DIFF
--- a/apps/api/src/routes/projects.test.ts
+++ b/apps/api/src/routes/projects.test.ts
@@ -263,3 +263,80 @@ test('project task listing returns only active tasks assigned to that project', 
     await ctx.cleanup();
   }
 });
+
+test('project task listing returns tasks in stable order', async () => {
+  const ctx = await createAuthedApp();
+
+  try {
+    const userCookie = await signUpAndGetCookie(`order-${randomUUID()}@example.com`);
+
+    const createProjectResponse = await ctx.app.inject({
+      method: 'POST',
+      url: '/projects',
+      headers: { cookie: userCookie },
+      payload: {
+        name: 'Ordered Project',
+        color: 'sage',
+      },
+    });
+    assert.equal(createProjectResponse.statusCode, 201);
+    const projectId = createProjectResponse.json().id as string;
+
+    const lowOrderTaskResponse = await ctx.app.inject({
+      method: 'POST',
+      url: '/tasks',
+      headers: { cookie: userCookie },
+      payload: {
+        title: 'Second task',
+        projectId,
+      },
+    });
+    assert.equal(lowOrderTaskResponse.statusCode, 201);
+
+    const highOrderTaskResponse = await ctx.app.inject({
+      method: 'POST',
+      url: '/tasks',
+      headers: { cookie: userCookie },
+      payload: {
+        title: 'First task',
+        projectId,
+      },
+    });
+    assert.equal(highOrderTaskResponse.statusCode, 201);
+
+    const firstTaskId = lowOrderTaskResponse.json().id as string;
+    const secondTaskId = highOrderTaskResponse.json().id as string;
+
+    await ctx.app.inject({
+      method: 'PATCH',
+      url: `/tasks/${firstTaskId}`,
+      headers: { cookie: userCookie },
+      payload: {
+        order: 2,
+      },
+    });
+
+    await ctx.app.inject({
+      method: 'PATCH',
+      url: `/tasks/${secondTaskId}`,
+      headers: { cookie: userCookie },
+      payload: {
+        order: 1,
+      },
+    });
+
+    const projectTasksResponse = await ctx.app.inject({
+      method: 'GET',
+      url: `/projects/${projectId}/tasks`,
+      headers: { cookie: userCookie },
+    });
+
+    assert.equal(projectTasksResponse.statusCode, 200);
+    assert.deepEqual(
+      projectTasksResponse.json().map((task: { title: string }) => task.title),
+      ['First task', 'Second task'],
+    );
+  } finally {
+    await ctx.cleanup();
+  }
+});

--- a/apps/api/src/services/project-service.ts
+++ b/apps/api/src/services/project-service.ts
@@ -10,13 +10,25 @@ import {
 
 const DEFAULT_PROJECTS = [
   { name: 'Inbox', description: 'Default capture space for incoming tasks.', color: 'sage' },
-  { name: 'Focus', description: 'High-focus work that needs uninterrupted attention.', color: 'forest' },
-  { name: 'Deep Work', description: 'Long-form thinking and concentrated execution.', color: 'deep-ocean' },
+  {
+    name: 'Focus',
+    description: 'High-focus work that needs uninterrupted attention.',
+    color: 'forest',
+  },
+  {
+    name: 'Deep Work',
+    description: 'Long-form thinking and concentrated execution.',
+    color: 'deep-ocean',
+  },
   { name: 'Writing', description: 'Drafts, notes, and editorial work.', color: 'olive' },
   { name: 'Home', description: 'Household planning and personal upkeep.', color: 'clay' },
   { name: 'Health', description: 'Fitness, recovery, and wellbeing.', color: 'teal' },
   { name: 'Admin', description: 'Life admin, follow-ups, and maintenance.', color: 'sage' },
-  { name: 'Ideas', description: 'Scratchpad for future experiments and concepts.', color: 'forest' },
+  {
+    name: 'Ideas',
+    description: 'Scratchpad for future experiments and concepts.',
+    color: 'forest',
+  },
 ] as const;
 
 type ProjectWithCountsRow = typeof projects.$inferSelect & {
@@ -49,7 +61,10 @@ async function loadProjectById(projectId: string, ownerId: string) {
 }
 
 export async function seedDefaultProjectsForOwner(ownerId: string) {
-  const existing = await db.select({ name: projects.name }).from(projects).where(eq(projects.ownerId, ownerId));
+  const existing = await db
+    .select({ name: projects.name })
+    .from(projects)
+    .where(eq(projects.ownerId, ownerId));
   const existingNames = new Set(existing.map((project) => project.name.toLowerCase()));
   const now = new Date().toISOString();
   const missingProjects = DEFAULT_PROJECTS.filter(
@@ -158,6 +173,18 @@ export async function listTasksForProject(projectId: string, ownerId: string) {
     .select()
     .from(tasks)
     .where(and(eq(tasks.userId, ownerId), eq(tasks.projectId, projectId), isNull(tasks.deletedAt)));
+  rows.sort((left, right) => {
+    if (left.order !== right.order) {
+      return left.order - right.order;
+    }
+
+    const createdAtOrder = left.createdAt.localeCompare(right.createdAt);
+    if (createdAtOrder !== 0) {
+      return createdAtOrder;
+    }
+
+    return left.id.localeCompare(right.id);
+  });
 
   return rows;
 }

--- a/apps/frontend/src/app/features/personal/pages/project-detail-page.component.html
+++ b/apps/frontend/src/app/features/personal/pages/project-detail-page.component.html
@@ -8,6 +8,7 @@
     mode="edit"
     [project]="project()"
     [saving]="projectService.saving()"
+    [error]="projectService.error()"
     (close)="closeProjectModal()"
     (save)="saveProject($event)"
   />

--- a/apps/frontend/src/app/features/personal/pages/project-detail-page.component.spec.ts
+++ b/apps/frontend/src/app/features/personal/pages/project-detail-page.component.spec.ts
@@ -11,6 +11,7 @@ describe('ProjectDetailPageComponent', () => {
   let projectServiceStub: {
     projects: ReturnType<typeof signal>;
     saving: ReturnType<typeof signal>;
+    error: ReturnType<typeof signal>;
     getProject: jasmine.Spy;
     getProjectTasks: jasmine.Spy;
     updateProject: jasmine.Spy;
@@ -63,10 +64,16 @@ describe('ProjectDetailPageComponent', () => {
     projectServiceStub = {
       projects: signal([baseProject]),
       saving: signal(false),
+      error: signal<string | null>(null),
       getProject: jasmine.createSpy('getProject').and.resolveTo(projectResponse),
-      getProjectTasks: jasmine
-        .createSpy('getProjectTasks')
-        .and.resolveTo(projectResponse ? [activeTask, completedTask] : null),
+      getProjectTasks: jasmine.createSpy('getProjectTasks').and.resolveTo(
+        projectResponse
+          ? [
+              { ...completedTask, order: 2 },
+              { ...activeTask, order: 1 },
+            ]
+          : null,
+      ),
       updateProject: jasmine.createSpy('updateProject').and.resolveTo(baseProject),
       refreshProjects: jasmine.createSpy('refreshProjects'),
     };
@@ -115,6 +122,24 @@ describe('ProjectDetailPageComponent', () => {
     expect(text).toContain('Outline release checklist');
     expect(text).toContain('Edit Project');
     expect(text).toContain('Add Task');
+    expect(text.indexOf('Draft launch copy')).toBeLessThan(
+      text.indexOf('Outline release checklist'),
+    );
+  });
+
+  it('surfaces project save errors in the edit modal', async () => {
+    await configure(baseProject);
+
+    const fixture = TestBed.createComponent(ProjectDetailPageComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    (fixture.componentInstance as any).openEditProjectModal();
+    projectServiceStub.error.set('Could not update your project right now.');
+    fixture.detectChanges();
+
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain('Could not update your project right now.');
   });
 
   it('shows a not found state when the project is missing', async () => {

--- a/apps/frontend/src/app/features/personal/pages/project-detail-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/project-detail-page.component.ts
@@ -50,10 +50,14 @@ export class ProjectDetailPageComponent {
     { initialValue: this.route.snapshot.paramMap.get('id') },
   );
   protected readonly activeProjectTasks = computed(() =>
-    this.projectTasks().filter((task) => !task.completed && task.status !== 'archived'),
+    [...this.projectTasks()]
+      .filter((task) => !task.completed && task.status !== 'archived')
+      .sort(compareTasksByOrder),
   );
   protected readonly completedProjectTasks = computed(() =>
-    this.projectTasks().filter((task) => task.completed && task.status !== 'archived'),
+    [...this.projectTasks()]
+      .filter((task) => task.completed && task.status !== 'archived')
+      .sort(compareTasksByOrder),
   );
 
   constructor() {
@@ -187,4 +191,20 @@ export class ProjectDetailPageComponent {
       this.projectState.set('error');
     }
   }
+}
+
+function compareTasksByOrder(left: Task, right: Task) {
+  const leftOrder = left.order ?? 0;
+  const rightOrder = right.order ?? 0;
+
+  if (leftOrder !== rightOrder) {
+    return leftOrder - rightOrder;
+  }
+
+  const createdAtOrder = left.createdAt.localeCompare(right.createdAt);
+  if (createdAtOrder !== 0) {
+    return createdAtOrder;
+  }
+
+  return left.id.localeCompare(right.id);
 }


### PR DESCRIPTION
## Description

Fixes the project detail page so edit failures surface the same error feedback as the directory page, and makes project task ordering stable when viewing `/projects/:id`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test coverage improvement

## Related Issue

Closes: #

## Roadmap Reference

Implements Project detail view / task detail flow work from `ROADMAP.md`.

## Changes Made

- Passed `projectService.error()` into the project edit modal on the detail page so failed saves display visible feedback.
- Sorted project tasks by `task.order` before rendering in the detail view, with a stable fallback for ties.
- Updated the `/projects/:id/tasks` API path to return tasks in deterministic order.
- Added regression tests for the modal error state and task ordering.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing completed

### Verification Steps

1. Run `pnpm --filter @yotara/api test`
2. Run `pnpm --filter @yotara/frontend exec ng test --watch=false --browsers ChromeHeadless --include src/app/features/personal/pages/project-detail-page.component.spec.ts`
3. Open `/projects/:id` and confirm edit save failures show an error message and task order stays stable after refresh

## Screenshots or Demo

N/A

## Checklist

- [x] Code follows the project style and conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have verified that this PR is against the correct branch (`main`)

## Additional Notes

The backend ordering change makes the detail route deterministic even if the frontend sort is removed later.