### PR TITLE
Fixed codex review issue

### DIFF
--- a/apps/frontend/src/app/features/personal/components/personal-task-card.component.ts
+++ b/apps/frontend/src/app/features/personal/components/personal-task-card.component.ts
@@ -29,6 +29,7 @@ import { ConfirmDialogComponent } from '../../../shared/ui/confirm-dialog/confir
         [class.task-check-complete]="task.completed"
         [attr.aria-label]="task.completed ? 'Task completed' : 'Mark task complete'"
         (click)="requestComplete($event)"
+        (keydown)="$event.stopPropagation()"
       >
         <span class="task-check-box" aria-hidden="true">
           @if (task.completed) {
@@ -48,6 +49,7 @@ import { ConfirmDialogComponent } from '../../../shared/ui/confirm-dialog/confir
                 type="button"
                 class="restore-pill"
                 (click)="requestComplete($event)"
+                (keydown)="$event.stopPropagation()"
                 aria-label="Restore task"
               >
                 <fa-icon [icon]="faRotateLeft" class="restore-icon"></fa-icon>


### PR DESCRIPTION
When this card is used in interactive mode, pressing Space (and potentially Enter) on the new Restore button bubbles a keydown to the parent <article> handler, which calls preventDefault() and emits select, so keyboard users can open task details instead of (or before) triggering restore. This regression is introduced by adding the new button without any keydown suppression, and it affects accessibility/keyboard behavior specifically when cards are focusable/clickable.

Fixed codex caught issue
