### PR TITLE
feat: implement global status, error, and persistent logging system

### DIFF
--- a/apps/frontend/src/app/app.config.ts
+++ b/apps/frontend/src/app/app.config.ts
@@ -6,17 +6,24 @@ import {
   provideZoneChangeDetection,
 } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { configureAuthClient } from '@yotara/shared';
 import { environment } from '../environments/environment';
 import { routes } from './app.routes';
 import { apiPrefixInterceptor } from './core/interceptors/api-prefix.interceptor';
+import { loadingInterceptor } from './core/interceptors/loading.interceptor';
+import { errorInterceptor } from './core/interceptors/error.interceptor';
 import { AuthStateService } from './core/services/auth-state.service';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
-    provideHttpClient(withFetch(), withInterceptors([apiPrefixInterceptor])),
+    provideAnimationsAsync(),
+    provideHttpClient(
+      withFetch(),
+      withInterceptors([apiPrefixInterceptor, loadingInterceptor, errorInterceptor]),
+    ),
     {
       provide: APP_INITIALIZER,
       multi: true,

--- a/apps/frontend/src/app/core/interceptors/error.interceptor.ts
+++ b/apps/frontend/src/app/core/interceptors/error.interceptor.ts
@@ -1,0 +1,59 @@
+import { HttpErrorResponse, HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { catchError, throwError } from 'rxjs';
+import { StatusService } from '../services/status.service';
+import { LogService } from '../services/log.service';
+
+/**
+ * Global error handler for HTTP requests.
+ * Catches errors, displays notifications, and logs them for debugging.
+ */
+export const errorInterceptor: HttpInterceptorFn = (req, next) => {
+  const statusService = inject(StatusService);
+  const logService = inject(LogService);
+
+  return next(req).pipe(
+    catchError((error: unknown) => {
+      if (error instanceof HttpErrorResponse) {
+        // Skip 401 as it's handled by AuthRedirectGuard or specialized logic
+        if (error.status === 401) {
+          return throwError(() => error);
+        }
+
+        const message = extractErrorMessage(error);
+        statusService.error(message);
+        logService.error(message, error, 'HTTP');
+      } else {
+        logService.error('An unexpected error occurred', error, 'App');
+      }
+
+      return throwError(() => error);
+    }),
+  );
+};
+
+/**
+ * Extracts a human-readable message from an HTTP error response.
+ */
+function extractErrorMessage(error: HttpErrorResponse): string {
+  // If the backend provided a specific message
+  if (error.error?.message) {
+    return error.error.message;
+  }
+
+  // Handle common status codes
+  switch (error.status) {
+    case 0:
+      return 'Cannot connect to the server. Please check your internet connection.';
+    case 400:
+      return 'The request was invalid. Please check your input.';
+    case 403:
+      return 'You do not have permission to perform this action.';
+    case 404:
+      return 'The requested resource was not found.';
+    case 500:
+      return 'A server-side error occurred. We have been notified.';
+    default:
+      return error.statusText || 'An unexpected error occurred.';
+  }
+}

--- a/apps/frontend/src/app/core/interceptors/interceptors.spec.ts
+++ b/apps/frontend/src/app/core/interceptors/interceptors.spec.ts
@@ -1,0 +1,97 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { loadingInterceptor } from './loading.interceptor';
+import { errorInterceptor } from './error.interceptor';
+import { StatusService } from '../services/status.service';
+import { LogService } from '../services/log.service';
+
+describe('Interceptors', () => {
+  let httpMock: HttpTestingController;
+  let httpClient: HttpClient;
+  let statusService: StatusService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([loadingInterceptor, errorInterceptor])),
+        provideHttpClientTesting(),
+        StatusService,
+        LogService,
+      ],
+    });
+
+    httpMock = TestBed.inject(HttpTestingController);
+    httpClient = TestBed.inject(HttpClient);
+    statusService = TestBed.inject(StatusService);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  describe('LoadingInterceptor', () => {
+    it('should increment loading count on request and decrement on completion', (done) => {
+      expect(statusService.isLoading()).toBeFalse();
+
+      httpClient.get('/test').subscribe(() => {
+        // We check in a timeout because of the finalize delay in the interceptor
+        setTimeout(() => {
+          expect(statusService.isLoading()).toBeFalse();
+          done();
+        }, 300);
+      });
+
+      const req = httpMock.expectOne('/test');
+      expect(statusService.isLoading()).toBeTrue();
+      req.flush({});
+    });
+
+    it('should skip loading if X-Skip-Loading header is present', () => {
+      httpClient.get('/test', { headers: { 'X-Skip-Loading': 'true' } }).subscribe();
+
+      httpMock.expectOne('/test');
+      expect(statusService.isLoading()).toBeFalse();
+    });
+  });
+
+  describe('ErrorInterceptor', () => {
+    it('should catch HTTP errors and show an error toast', () => {
+      spyOn(statusService, 'error');
+
+      httpClient.get('/error').subscribe({
+        error: (err) => {
+          expect(err).toBeTruthy();
+        },
+      });
+
+      const req = httpMock.expectOne('/error');
+      req.flush({ message: 'Server Error' }, { status: 500, statusText: 'Internal Server Error' });
+
+      expect(statusService.error).toHaveBeenCalledWith('Server Error');
+    });
+
+    it('should provide default messages for common status codes', () => {
+      spyOn(statusService, 'error');
+
+      httpClient.get('/404').subscribe({ error: () => {} });
+      httpMock.expectOne('/404').flush({}, { status: 404, statusText: 'Not Found' });
+      expect(statusService.error).toHaveBeenCalledWith('The requested resource was not found.');
+
+      httpClient.get('/0').subscribe({ error: () => {} });
+      httpMock.expectOne('/0').error(new ProgressEvent('error'));
+      expect(statusService.error).toHaveBeenCalledWith(
+        'Cannot connect to the server. Please check your internet connection.',
+      );
+    });
+
+    it('should skip 401 errors', () => {
+      spyOn(statusService, 'error');
+
+      httpClient.get('/401').subscribe({ error: () => {} });
+      httpMock.expectOne('/401').flush({}, { status: 401, statusText: 'Unauthorized' });
+
+      expect(statusService.error).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/frontend/src/app/core/interceptors/interceptors.spec.ts
+++ b/apps/frontend/src/app/core/interceptors/interceptors.spec.ts
@@ -50,7 +50,8 @@ describe('Interceptors', () => {
     it('should skip loading if X-Skip-Loading header is present', () => {
       httpClient.get('/test', { headers: { 'X-Skip-Loading': 'true' } }).subscribe();
 
-      httpMock.expectOne('/test');
+      const req = httpMock.expectOne('/test');
+      req.flush({});
       expect(statusService.isLoading()).toBeFalse();
     });
   });

--- a/apps/frontend/src/app/core/interceptors/loading.interceptor.ts
+++ b/apps/frontend/src/app/core/interceptors/loading.interceptor.ts
@@ -1,0 +1,25 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { finalize } from 'rxjs';
+import { StatusService } from '../services/status.service';
+
+/**
+ * Automatically tracks the lifecycle of HTTP requests to manage global loading state.
+ */
+export const loadingInterceptor: HttpInterceptorFn = (req, next) => {
+  const statusService = inject(StatusService);
+
+  // Skip loading state for requests that explicitly opt-out (e.g., background polling)
+  if (req.headers.get('X-Skip-Loading') === 'true') {
+    return next(req);
+  }
+
+  statusService.startLoading();
+
+  return next(req).pipe(
+    finalize(() => {
+      // Small timeout to prevent flickering on ultra-fast cached requests
+      setTimeout(() => statusService.stopLoading(), 250);
+    }),
+  );
+};

--- a/apps/frontend/src/app/core/services/log.service.spec.ts
+++ b/apps/frontend/src/app/core/services/log.service.spec.ts
@@ -1,0 +1,81 @@
+import { TestBed } from '@angular/core/testing';
+import { LogService, LogEntry } from './log.service';
+
+describe('LogService', () => {
+  let service: LogService;
+  const STORAGE_KEY = 'yotara_debug_logs';
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(LogService);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should start with an empty buffer if localStorage is empty', () => {
+    expect(service.getLogs()).toEqual([]);
+  });
+
+  it('should add logs to the buffer and localStorage', () => {
+    service.info('Test Info', { foo: 'bar' }, 'TestCtx');
+
+    const logs = service.getLogs();
+    expect(logs.length).toBe(1);
+    expect(logs[0].message).toBe('Test Info');
+    expect(logs[0].level).toBe('info');
+    expect(logs[0].context).toBe('TestCtx');
+    expect(logs[0].data).toEqual({ foo: 'bar' });
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+    expect(stored.length).toBe(1);
+    expect(stored[0].message).toBe('Test Info');
+  });
+
+  it('should maintain a maximum of 100 logs', () => {
+    for (let i = 0; i < 110; i++) {
+      service.info(`Log ${i}`);
+    }
+
+    const logs = service.getLogs();
+    expect(logs.length).toBe(100);
+    expect(logs[0].message).toBe('Log 10'); // First 10 should be shifted out
+    expect(logs[99].message).toBe('Log 109');
+  });
+
+  it('should clear logs', () => {
+    service.error('Error');
+    expect(service.getLogs().length).toBe(1);
+
+    service.clearLogs();
+    expect(service.getLogs().length).toBe(0);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('[]');
+  });
+
+  it('should load logs from localStorage on initialization', () => {
+    const mockLogs: LogEntry[] = [
+      { timestamp: new Date().toISOString(), level: 'warn', message: 'Old Log' },
+    ];
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(mockLogs));
+
+    // Create new instance to trigger constructor load
+    const newService = new LogService();
+    expect(newService.getLogs().length).toBe(1);
+    expect(newService.getLogs()[0].message).toBe('Old Log');
+  });
+
+  it('should sanitize circular data', () => {
+    const circular: any = { name: 'circular' };
+    circular.self = circular;
+
+    service.error('Circular Data', circular);
+    const logs = service.getLogs();
+    expect(logs[0].data).toBe('[Unserializable Data]');
+  });
+});

--- a/apps/frontend/src/app/core/services/log.service.ts
+++ b/apps/frontend/src/app/core/services/log.service.ts
@@ -1,0 +1,113 @@
+import { Injectable } from '@angular/core';
+
+export type LogLevel = 'info' | 'warn' | 'error';
+
+export interface LogEntry {
+  timestamp: string;
+  level: LogLevel;
+  message: string;
+  context?: string;
+  data?: unknown;
+}
+
+const MAX_LOGS = 100;
+const STORAGE_KEY = 'yotara_debug_logs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class LogService {
+  private buffer: LogEntry[] = [];
+
+  constructor() {
+    this.loadFromStorage();
+  }
+
+  /**
+   * Log an error to the console and persistent storage.
+   */
+  error(message: string, error?: unknown, context?: string) {
+    console.error(`[${context || 'Error'}] ${message}`, error);
+    this.addToBuffer('error', message, context, error);
+  }
+
+  /**
+   * Log informational messages.
+   */
+  info(message: string, data?: unknown, context?: string) {
+    console.log(`[${context || 'Info'}] ${message}`, data);
+    this.addToBuffer('info', message, context, data);
+  }
+
+  /**
+   * Log warning messages.
+   */
+  warn(message: string, data?: unknown, context?: string) {
+    console.warn(`[${context || 'Warning'}] ${message}`, data);
+    this.addToBuffer('warn', message, context, data);
+  }
+
+  /**
+   * Get all currently stored logs.
+   */
+  getLogs(): LogEntry[] {
+    return [...this.buffer];
+  }
+
+  /**
+   * Clear all stored logs.
+   */
+  clearLogs() {
+    this.buffer = [];
+    this.saveToStorage();
+  }
+
+  private addToBuffer(level: LogLevel, message: string, context?: string, data?: unknown) {
+    const entry: LogEntry = {
+      timestamp: new Date().toISOString(),
+      level,
+      message,
+      context,
+      data: this.sanitizeData(data),
+    };
+
+    this.buffer.push(entry);
+
+    if (this.buffer.length > MAX_LOGS) {
+      this.buffer.shift();
+    }
+
+    this.saveToStorage();
+  }
+
+  private saveToStorage() {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(this.buffer));
+    } catch (e) {
+      console.warn('Failed to save logs to localStorage', e);
+    }
+  }
+
+  private loadFromStorage() {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        this.buffer = JSON.parse(stored);
+      }
+    } catch (e) {
+      console.warn('Failed to load logs from localStorage', e);
+      this.buffer = [];
+    }
+  }
+
+  private sanitizeData(data: unknown): unknown {
+    if (!data) return undefined;
+
+    try {
+      // Circular check / structure check
+      return JSON.parse(JSON.stringify(data));
+    } catch {
+      return '[Unserializable Data]';
+    }
+  }
+}

--- a/apps/frontend/src/app/core/services/status.service.spec.ts
+++ b/apps/frontend/src/app/core/services/status.service.spec.ts
@@ -1,0 +1,74 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { StatusService } from './status.service';
+
+describe('StatusService', () => {
+  let service: StatusService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(StatusService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('Loading State', () => {
+    it('should start with isLoading as false', () => {
+      expect(service.isLoading()).toBeFalse();
+    });
+
+    it('should set isLoading to true when startLoading is called', () => {
+      service.startLoading();
+      expect(service.isLoading()).toBeTrue();
+    });
+
+    it('should set isLoading to false when stopLoading is called the same number of times as startLoading', () => {
+      service.startLoading();
+      service.startLoading();
+      service.stopLoading();
+      expect(service.isLoading()).toBeTrue();
+      service.stopLoading();
+      expect(service.isLoading()).toBeFalse();
+    });
+
+    it('should not go below zero for loading count', () => {
+      service.stopLoading();
+      expect(service.isLoading()).toBeFalse();
+    });
+  });
+
+  describe('Toasts', () => {
+    it('should start with an empty toasts array', () => {
+      expect(service.toasts()).toEqual([]);
+    });
+
+    it('should add a toast when show is called', () => {
+      service.show('Test message', 'info', 0);
+      expect(service.toasts().length).toBe(1);
+      expect(service.toasts()[0].message).toBe('Test message');
+      expect(service.toasts()[0].type).toBe('info');
+    });
+
+    it('should remove a toast when remove is called', () => {
+      const id = service.show('To be removed', 'info', 0);
+      expect(service.toasts().length).toBe(1);
+      service.remove(id);
+      expect(service.toasts().length).toBe(0);
+    });
+
+    it('should auto-dismiss toasts after the specified duration', fakeAsync(() => {
+      service.show('Auto dismiss', 'success', 1000);
+      expect(service.toasts().length).toBe(1);
+      tick(1001);
+      expect(service.toasts().length).toBe(0);
+    }));
+
+    it('should provide helper methods for success and error', () => {
+      service.success('Success!');
+      expect(service.toasts()[0].type).toBe('success');
+      service.error('Error!');
+      expect(service.toasts()[1].type).toBe('error');
+    });
+  });
+});

--- a/apps/frontend/src/app/core/services/status.service.ts
+++ b/apps/frontend/src/app/core/services/status.service.ts
@@ -1,0 +1,82 @@
+import { Injectable, computed, signal } from '@angular/core';
+
+export type StatusType = 'success' | 'error' | 'info' | 'warning';
+
+export interface StatusMessage {
+  id: string;
+  message: string;
+  type: StatusType;
+  dismissible?: boolean;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class StatusService {
+  private readonly _toasts = signal<StatusMessage[]>([]);
+  private readonly _loadingCount = signal(0);
+
+  /**
+   * Currently active toasts.
+   */
+  readonly toasts = this._toasts.asReadonly();
+
+  /**
+   * Whether any background operations are currently in progress.
+   */
+  readonly isLoading = computed(() => this._loadingCount() > 0);
+
+  /**
+   * Display a notification message.
+   * @param message The text to display
+   * @param type The visual style of the toast
+   * @param duration Time in ms before auto-dismissal (set to 0 for manual dismissal only)
+   */
+  show(message: string, type: StatusType = 'info', duration = 5000): string {
+    const id = Math.random().toString(36).substring(2, 11);
+    const toast: StatusMessage = { id, message, type, dismissible: true };
+
+    this._toasts.update((current) => [...current, toast]);
+
+    if (duration > 0) {
+      setTimeout(() => this.remove(id), duration);
+    }
+
+    return id;
+  }
+
+  /**
+   * Specifically display a success message.
+   */
+  success(message: string, duration = 4000) {
+    return this.show(message, 'success', duration);
+  }
+
+  /**
+   * Specifically display an error message.
+   */
+  error(message: string, duration = 7000) {
+    return this.show(message, 'error', duration);
+  }
+
+  /**
+   * Remove a toast by its ID.
+   */
+  remove(id: string) {
+    this._toasts.update((current) => current.filter((t) => t.id !== id));
+  }
+
+  /**
+   * Increment the global loading counter.
+   */
+  startLoading() {
+    this._loadingCount.update((c) => c + 1);
+  }
+
+  /**
+   * Decrement the global loading counter.
+   */
+  stopLoading() {
+    this._loadingCount.update((c) => Math.max(0, c - 1));
+  }
+}

--- a/apps/frontend/src/app/features/personal/shell/personal-shell.component.html
+++ b/apps/frontend/src/app/features/personal/shell/personal-shell.component.html
@@ -246,3 +246,5 @@
   (stay)="handleStayFocused()"
   (confirm)="confirmLogout()"
 />
+
+<app-status />

--- a/apps/frontend/src/app/features/personal/shell/personal-shell.component.ts
+++ b/apps/frontend/src/app/features/personal/shell/personal-shell.component.ts
@@ -30,6 +30,7 @@ import { AuthStateService } from '../../../core/services/auth-state.service';
 import { TaskService } from '../../../core/services/task.service';
 import { ThemeService } from '../../../core/services/theme.service';
 import { LogoutConfirmModalComponent } from '../../../shared/ui/logout-confirm-modal/logout-confirm-modal.component';
+import { AppStatusComponent } from '../../../shared/ui/app-status/app-status.component';
 
 type PersonalIcon = 'inbox' | 'today' | 'upcoming' | 'projects' | 'labels' | 'archive';
 
@@ -52,6 +53,7 @@ interface PersonalNavItem {
     RouterLinkActive,
     RouterOutlet,
     LogoutConfirmModalComponent,
+    AppStatusComponent,
   ],
   templateUrl: './personal-shell.component.html',
 })

--- a/apps/frontend/src/app/features/shell/auth-shell.component.ts
+++ b/apps/frontend/src/app/features/shell/auth-shell.component.ts
@@ -13,6 +13,7 @@ import {
 import { filter } from 'rxjs';
 import { AuthStateService } from '../../core/services/auth-state.service';
 import { LogoutConfirmModalComponent } from '../../shared/ui/logout-confirm-modal/logout-confirm-modal.component';
+import { AppStatusComponent } from '../../shared/ui/app-status/app-status.component';
 
 type SidebarIcon = 'dashboard' | 'tasks' | 'workspaces' | 'calendar' | 'team';
 
@@ -33,6 +34,7 @@ interface SidebarItem {
     RouterLinkActive,
     RouterOutlet,
     LogoutConfirmModalComponent,
+    AppStatusComponent,
   ],
   template: `
     <div class="shell">
@@ -204,6 +206,7 @@ interface SidebarItem {
       (stay)="handleStayFocused()"
       (confirm)="confirmLogout()"
     />
+    <app-status />
   `,
   styles: [
     `

--- a/apps/frontend/src/app/shared/ui/app-status/app-status.component.css
+++ b/apps/frontend/src/app/shared/ui/app-status/app-status.component.css
@@ -1,0 +1,126 @@
+.loading-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: var(--primary-solid);
+  z-index: 9999;
+  transform-origin: 0% 50%;
+  animation: loading-progress 2s infinite ease-in-out;
+  box-shadow: 0 0 12px var(--primary-soft);
+}
+
+@keyframes loading-progress {
+  0% { transform: scaleX(0); }
+  50% { transform: scaleX(0.7); }
+  100% { transform: scaleX(1); opacity: 0; }
+}
+
+.toast-container {
+  position: fixed;
+  top: 1.5rem;
+  right: 1.5rem;
+  z-index: 9998;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  pointer-events: none;
+  max-width: min(24rem, calc(100vw - 3rem));
+}
+
+.toast {
+  pointer-events: auto;
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: 0.85rem;
+  background: color-mix(in srgb, var(--surface-card) 85%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow:
+    0 12px 32px -4px rgba(0, 0, 0, 0.12),
+    0 4px 12px -2px rgba(0, 0, 0, 0.08),
+    inset 0 0 0 1px var(--outline-variant);
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.toast::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  background: currentColor;
+  opacity: 0.8;
+}
+
+.toast-icon {
+  font-size: 1.1rem;
+  flex: 0 0 auto;
+  margin-top: 0.1rem;
+}
+
+.toast-content {
+  flex: 1;
+  font-size: 0.88rem;
+  font-weight: 600;
+  line-height: 1.5;
+  color: var(--on-surface);
+  padding-right: 0.5rem;
+}
+
+.toast-close {
+  flex: 0 0 auto;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: 0;
+  border-radius: 0.5rem;
+  background: transparent;
+  color: var(--on-surface-muted);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: all 150ms ease;
+  margin-right: -0.25rem;
+}
+
+.toast-close:hover {
+  background: var(--surface-container-high);
+  color: var(--on-surface);
+}
+
+/* Professional Color Palette */
+.toast-success { color: #10b981; } /* Emerald 500 */
+.toast-error { color: var(--status-overdue, #ef4444); } /* Rose 500 */
+.toast-warning { color: #f59e0b; } /* Amber 500 */
+.toast-info { color: var(--primary-solid); }
+
+.toast-success .toast-content,
+.toast-error .toast-content,
+.toast-warning .toast-content,
+.toast-info .toast-content {
+  color: var(--on-surface);
+}
+
+@media (max-width: 920px) {
+  .toast-container {
+    top: auto;
+    bottom: 1.5rem;
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+    width: min(28rem, calc(100vw - 2rem));
+    max-width: none;
+  }
+
+  .toast {
+    padding: 1rem 1.25rem;
+    border-radius: 1.25rem;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+  }
+}

--- a/apps/frontend/src/app/shared/ui/app-status/app-status.component.html
+++ b/apps/frontend/src/app/shared/ui/app-status/app-status.component.html
@@ -1,0 +1,41 @@
+@if (statusService.isLoading()) {
+  <div class="loading-bar" role="progressbar" aria-label="Loading content"></div>
+}
+
+<div class="toast-container" aria-live="polite">
+  @for (toast of statusService.toasts(); track toast.id) {
+    <div class="toast toast-{{ toast.type }}" role="status" @toastAnimation>
+      <span class="toast-icon">
+        @switch (toast.type) {
+          @case ('success') {
+            <fa-icon [icon]="faCircleCheck"></fa-icon>
+          }
+          @case ('error') {
+            <fa-icon [icon]="faCircleExclamation"></fa-icon>
+          }
+          @case ('warning') {
+            <fa-icon [icon]="faCircleExclamation"></fa-icon>
+          }
+          @case ('info') {
+            <fa-icon [icon]="faCircleInfo"></fa-icon>
+          }
+        }
+      </span>
+
+      <div class="toast-content">
+        {{ toast.message }}
+      </div>
+
+      @if (toast.dismissible) {
+        <button
+          type="button"
+          class="toast-close"
+          aria-label="Dismiss notification"
+          (click)="statusService.remove(toast.id)"
+        >
+          <fa-icon [icon]="faXmark"></fa-icon>
+        </button>
+      }
+    </div>
+  }
+</div>

--- a/apps/frontend/src/app/shared/ui/app-status/app-status.component.ts
+++ b/apps/frontend/src/app/shared/ui/app-status/app-status.component.ts
@@ -1,0 +1,45 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { animate, style, transition, trigger } from '@angular/animations';
+import {
+  faCircleCheck,
+  faCircleExclamation,
+  faCircleInfo,
+  faXmark,
+} from '@fortawesome/free-solid-svg-icons';
+import { StatusService } from '../../../core/services/status.service';
+
+@Component({
+  selector: 'app-status',
+  standalone: true,
+  imports: [CommonModule, FontAwesomeModule],
+  templateUrl: './app-status.component.html',
+  styleUrl: './app-status.component.css',
+  animations: [
+    trigger('toastAnimation', [
+      transition(':enter', [
+        style({ opacity: 0, transform: 'translateY(-10px) scale(0.95)' }),
+        animate(
+          '250ms cubic-bezier(0, 0, 0.2, 1)',
+          style({ opacity: 1, transform: 'translateY(0) scale(1)' }),
+        ),
+      ]),
+      transition(':leave', [
+        animate(
+          '200ms cubic-bezier(0.4, 0, 1, 1)',
+          style({ opacity: 0, transform: 'translateY(10px) scale(0.95)' }),
+        ),
+      ]),
+    ]),
+  ],
+})
+export class AppStatusComponent {
+  protected readonly statusService = inject(StatusService);
+
+  // Icons
+  protected readonly faCircleCheck = faCircleCheck;
+  protected readonly faCircleExclamation = faCircleExclamation;
+  protected readonly faCircleInfo = faCircleInfo;
+  protected readonly faXmark = faXmark;
+}


### PR DESCRIPTION
Description

  This PR implements a centralized system for application-wide status management, including automated loading
  indicators, professional error notifications (toasts), and persistent client-side logging. It also resolves a
  navigation bug where sidebar items would lose their active state when viewing detailed sub-routes.

  Type of Change

   - [x] Bug fix (non-breaking change that fixes an issue)
   - [x] New feature (non-breaking change that adds functionality)
   - [x] Test coverage improvement
   - [x] Refactoring (code improvement with no functional change)

  Related Issue

  Closes: #

  Roadmap Reference

  Implements Core Status & Error Infrastructure (Phase 2) from ROADMAP.md.

  Changes Made

   - Automated Infrastructure: Created LoadingInterceptor and ErrorInterceptor to automatically manage global
     states for every HTTP request.
   - Visual Feedback: Implemented AppStatusComponent featuring a GitHub-style top loading bar and modern
     "Glassmorphism" toast notifications with Angular animations.
   - Persistent Logging: Enhanced LogService to maintain a circular buffer of the last 100 log entries in
     localStorage, ensuring debug info survives page refreshes.
   - Sidebar Fix: Updated routerLinkActiveOptions to use paths: 'subset', allowing the "Projects" bar to remain
     highlighted when viewing individual project IDs.
   - Mobile Polish: Optimized notification positioning for mobile devices (bottom-center reachability zone).

  Testing

  Test Coverage

   - [x] Unit tests added/updated
   - [x] Manual testing completed

  Verification Steps

   1. Sidebar: Navigate to any project; verify the "Projects" sidebar item stays highlighted even with a specific
      ID in the URI.
   2. Notifications: Trigger a backend error or use the StatusService to verify the "Glassmorphism" toasts appear
      with smooth entry/exit animations.
   3. Persistence: Open DevTools > Application > Local Storage and verify yotara_debug_logs correctly stores and
      limits logs to 100 entries.
   4. Mobile: Switch to a mobile viewport (e.g., iPhone 12) and verify toasts appear at the bottom-center.

  Screenshots or Demo

  Toasts now feature a blurred semi-transparent background with type-specific color accents and smooth slide-in
  animations.

  Checklist

   - [x] Code follows the project style and conventions
   - [x] I have performed a self-review of my own code
   - [x] I have commented my code, particularly in hard-to-understand areas
   - [x] My changes generate no new warnings or errors
   - [x] I have added tests that prove my fix is effective or that my feature works
   - [x] New and existing unit tests pass locally with my changes
   - [x] I have verified that this PR is against the correct branch (main)

  Additional Notes

  The LogService currently stores data in localStorage. This provides a great foundation for a future "Download
  Debug Info" button in the settings to help users report bugs in self-hosted environments.