### PR TITLE
fix: Mobile fix for sidebar menu

### DIFF
--- a/apps/frontend/src/app/features/personal/shell/personal-shell.component.css
+++ b/apps/frontend/src/app/features/personal/shell/personal-shell.component.css
@@ -630,10 +630,6 @@
     backdrop-filter: blur(4px);
   }
 
-  .sidebar-toggle {
-    display: none;
-  }
-
   .menu-toggle {
     display: grid;
   }

--- a/apps/frontend/src/app/features/personal/shell/personal-shell.component.css
+++ b/apps/frontend/src/app/features/personal/shell/personal-shell.component.css
@@ -601,7 +601,8 @@
 /* --- Responsive --- */
 
 @media (width <= 920px) {
-  .personal-shell {
+  .personal-shell,
+  .personal-shell.sidebar-collapsed {
     grid-template-columns: 1fr;
   }
 
@@ -627,6 +628,10 @@
     border: 0;
     background: rgb(0 0 0 / 25%);
     backdrop-filter: blur(4px);
+  }
+
+  .sidebar-toggle {
+    display: none;
   }
 
   .menu-toggle {

--- a/apps/frontend/src/app/features/personal/shell/personal-shell.component.html
+++ b/apps/frontend/src/app/features/personal/shell/personal-shell.component.html
@@ -43,6 +43,7 @@
             }"
             class="nav-item"
             [title]="sidebarCollapsed() ? item.label : ''"
+            (click)="closeMobileMenu()"
           >
             <span class="nav-icon" aria-hidden="true">
               @switch (item.icon) {


### PR DESCRIPTION
## Description
Fixes a CSS specificity bug where toggling sidebar collapse state on mobile 
breaks the layout by overriding the mobile grid to `5.2rem 1fr` instead of `1fr`.
## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
## Related Issue
N/A
## Changes Made
- `apps/frontend/src/app/features/personal/shell/personal-shell.component.css`:
  - Added `.personal-shell.sidebar-collapsed` to the mobile `≤920px` media 
    query so the grid stays `1fr` regardless of collapse state
  - Hid the desktop-only `.sidebar-toggle` chevron button on mobile
## Testing
### Verification Steps
1. On desktop, collapse the sidebar via the chevron button
2. Resize browser to ≤920px width (mobile viewport)
3. Open the mobile menu with the hamburger button
4. Tap any nav item — layout should remain intact with no 5rem gap
## Checklist
- [x] Code follows the project style and conventions
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have verified that this PR is against the correct branch (`main`)