### PR TITLE
feat(api): standardize app-owned SQLite timestamps as ISO strings

### DIFF
--- a/apps/api/TODO.md
+++ b/apps/api/TODO.md
@@ -28,9 +28,9 @@
   - [x] Ensure route schemas and normalization logic agree on required vs optional fields
   - [x] Prefer schema-driven validation over manual `if (!payload.title)` style checks where possible
 
-- [ ] Revisit timestamp storage consistency in SQLite:
-  - [ ] Standardize whether each table stores timestamps as ISO strings or epoch values
-  - [ ] Make schema and serialization choices consistent across `users`, `sessions`, `projects`, and `tasks`
+- [x] Revisit timestamp storage consistency in SQLite:
+  - [x] Standardize whether each table stores timestamps as ISO strings or epoch values
+  - [x] Make schema and serialization choices consistent across `users`, `sessions`, `projects`, and `tasks`
 
 ## Query and Data Access
 

--- a/apps/api/src/db/client.ts
+++ b/apps/api/src/db/client.ts
@@ -3,6 +3,7 @@ import { dirname, resolve } from 'node:path';
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import * as schema from './schema.js';
+import { nowIsoTimestamp, toIsoTimestamp } from '../lib/timestamps.js';
 
 const DEFAULT_DATABASE_URL = './data/yotara.db';
 const SQLITE_BOOTSTRAP_SQL = `
@@ -116,6 +117,108 @@ const SQLITE_BOOTSTRAP_SQL = `
   );
 `;
 
+function normalizeTextTimestamp(value: unknown, fallback: string): string {
+  if (value === null || value === undefined) {
+    return fallback;
+  }
+
+  const raw = typeof value === 'string' ? value.trim() : value;
+  if (raw === '') {
+    return fallback;
+  }
+
+  try {
+    return toIsoTimestamp(raw as string | number | Date);
+  } catch {
+    return fallback;
+  }
+}
+
+function normalizeNullableTimestamp(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const raw = typeof value === 'string' ? value.trim() : value;
+  if (raw === '') {
+    return null;
+  }
+
+  try {
+    return toIsoTimestamp(raw as string | number | Date);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeAppTimestampStorage(sqlite: Database.Database): void {
+  const fallbackNow = nowIsoTimestamp();
+
+  const projectRows = sqlite
+    .prepare(`SELECT id, created_at, updated_at FROM projects`)
+    .all() as Array<{ id: string; created_at: unknown; updated_at: unknown }>;
+  const updateProject = sqlite.prepare(
+    `UPDATE projects SET created_at = ?, updated_at = ? WHERE id = ?`,
+  );
+  for (const row of projectRows) {
+    updateProject.run(
+      normalizeTextTimestamp(row.created_at, fallbackNow),
+      normalizeTextTimestamp(row.updated_at, fallbackNow),
+      row.id,
+    );
+  }
+
+  const taskRows = sqlite
+    .prepare(`SELECT id, created_at, updated_at, archived_at, deleted_at, completed FROM tasks`)
+    .all() as Array<{
+    id: string;
+    created_at: unknown;
+    updated_at: unknown;
+    archived_at: unknown;
+    deleted_at: unknown;
+    completed: number;
+  }>;
+  const updateTask = sqlite.prepare(
+    `UPDATE tasks SET created_at = ?, updated_at = ?, archived_at = ?, deleted_at = ? WHERE id = ?`,
+  );
+  for (const row of taskRows) {
+    const updatedAt = normalizeTextTimestamp(row.updated_at, fallbackNow);
+    updateTask.run(
+      normalizeTextTimestamp(row.created_at, fallbackNow),
+      updatedAt,
+      row.archived_at === null ||
+        row.archived_at === undefined ||
+        String(row.archived_at).trim() === ''
+        ? row.completed === 1
+          ? updatedAt
+          : null
+        : normalizeNullableTimestamp(row.archived_at),
+      normalizeNullableTimestamp(row.deleted_at),
+      row.id,
+    );
+  }
+
+  const labelRows = sqlite.prepare(`SELECT id, created_at, updated_at FROM labels`).all() as Array<{
+    id: string;
+    created_at: unknown;
+    updated_at: unknown;
+  }>;
+  const updateLabel = sqlite.prepare(
+    `UPDATE labels SET created_at = ?, updated_at = ? WHERE id = ?`,
+  );
+  for (const row of labelRows) {
+    const createdAt = normalizeNullableTimestamp(row.created_at);
+    const updatedAt = normalizeNullableTimestamp(row.updated_at);
+    const fallbackLabelNow = fallbackNow;
+
+    updateLabel.run(
+      createdAt ?? updatedAt ?? fallbackLabelNow,
+      updatedAt ?? createdAt ?? fallbackLabelNow,
+      row.id,
+    );
+  }
+}
+
 function resolveDbPath(databaseUrl: string): string {
   if (databaseUrl === ':memory:') {
     return databaseUrl;
@@ -223,6 +326,8 @@ function ensureSqliteSchema(sqlite: Database.Database): void {
       FOREIGN KEY (label_id) REFERENCES labels(id) ON DELETE CASCADE
     )`);
   }
+
+  normalizeAppTimestampStorage(sqlite);
 }
 
 export function createDbClient(databaseUrl = process.env['DATABASE_URL'] ?? DEFAULT_DATABASE_URL) {

--- a/apps/api/src/db/client.ts
+++ b/apps/api/src/db/client.ts
@@ -161,11 +161,14 @@ function normalizeAppTimestampStorage(sqlite: Database.Database): void {
     `UPDATE projects SET created_at = ?, updated_at = ? WHERE id = ?`,
   );
   for (const row of projectRows) {
-    updateProject.run(
-      normalizeTextTimestamp(row.created_at, fallbackNow),
-      normalizeTextTimestamp(row.updated_at, fallbackNow),
-      row.id,
-    );
+    const createdAt = normalizeTextTimestamp(row.created_at, fallbackNow);
+    const updatedAt = normalizeTextTimestamp(row.updated_at, fallbackNow);
+
+    if (row.created_at === createdAt && row.updated_at === updatedAt) {
+      continue;
+    }
+
+    updateProject.run(createdAt, updatedAt, row.id);
   }
 
   const taskRows = sqlite
@@ -183,19 +186,27 @@ function normalizeAppTimestampStorage(sqlite: Database.Database): void {
   );
   for (const row of taskRows) {
     const updatedAt = normalizeTextTimestamp(row.updated_at, fallbackNow);
-    updateTask.run(
-      normalizeTextTimestamp(row.created_at, fallbackNow),
-      updatedAt,
+    const createdAt = normalizeTextTimestamp(row.created_at, fallbackNow);
+    const archivedAt =
       row.archived_at === null ||
-        row.archived_at === undefined ||
-        String(row.archived_at).trim() === ''
+      row.archived_at === undefined ||
+      String(row.archived_at).trim() === ''
         ? row.completed === 1
           ? updatedAt
           : null
-        : normalizeNullableTimestamp(row.archived_at),
-      normalizeNullableTimestamp(row.deleted_at),
-      row.id,
-    );
+        : normalizeNullableTimestamp(row.archived_at);
+    const deletedAt = normalizeNullableTimestamp(row.deleted_at);
+
+    if (
+      row.created_at === createdAt &&
+      row.updated_at === updatedAt &&
+      row.archived_at === archivedAt &&
+      row.deleted_at === deletedAt
+    ) {
+      continue;
+    }
+
+    updateTask.run(createdAt, updatedAt, archivedAt, deletedAt, row.id);
   }
 
   const labelRows = sqlite.prepare(`SELECT id, created_at, updated_at FROM labels`).all() as Array<{
@@ -209,13 +220,14 @@ function normalizeAppTimestampStorage(sqlite: Database.Database): void {
   for (const row of labelRows) {
     const createdAt = normalizeNullableTimestamp(row.created_at);
     const updatedAt = normalizeNullableTimestamp(row.updated_at);
-    const fallbackLabelNow = fallbackNow;
+    const nextCreatedAt = createdAt ?? updatedAt ?? fallbackNow;
+    const nextUpdatedAt = updatedAt ?? createdAt ?? fallbackNow;
 
-    updateLabel.run(
-      createdAt ?? updatedAt ?? fallbackLabelNow,
-      updatedAt ?? createdAt ?? fallbackLabelNow,
-      row.id,
-    );
+    if (row.created_at === nextCreatedAt && row.updated_at === nextUpdatedAt) {
+      continue;
+    }
+
+    updateLabel.run(nextCreatedAt, nextUpdatedAt, row.id);
   }
 }
 

--- a/apps/api/src/db/timestamp-migration.test.ts
+++ b/apps/api/src/db/timestamp-migration.test.ts
@@ -1,0 +1,242 @@
+import Database from 'better-sqlite3';
+import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { rmSync } from 'node:fs';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+function toIso(value: number) {
+  return new Date(value).toISOString();
+}
+
+function seedLegacyDatabase(databasePath: string) {
+  const sqlite = new Database(databasePath);
+  sqlite.pragma('foreign_keys = ON');
+
+  sqlite.exec(`
+    CREATE TABLE user (
+      id TEXT PRIMARY KEY NOT NULL,
+      name TEXT NOT NULL,
+      email TEXT NOT NULL,
+      emailVerified INTEGER NOT NULL,
+      image TEXT,
+      workspaceMode TEXT,
+      onboardingCompleted INTEGER NOT NULL DEFAULT 0,
+      archiveAutoDelete INTEGER NOT NULL DEFAULT 1,
+      captureBehavior TEXT NOT NULL DEFAULT 'quick',
+      createdAt INTEGER NOT NULL,
+      updatedAt INTEGER NOT NULL
+    );
+
+    CREATE TABLE projects (
+      id TEXT PRIMARY KEY NOT NULL,
+      owner_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      description TEXT,
+      color TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (owner_id) REFERENCES user(id) ON DELETE NO ACTION
+    );
+
+    CREATE TABLE tasks (
+      id TEXT PRIMARY KEY NOT NULL,
+      user_id TEXT,
+      title TEXT NOT NULL,
+      description TEXT,
+      status TEXT NOT NULL DEFAULT 'inbox',
+      priority TEXT NOT NULL DEFAULT 'medium',
+      completed INTEGER NOT NULL DEFAULT 0,
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      due_date TEXT,
+      simple_mode INTEGER NOT NULL DEFAULT 0,
+      bucket TEXT DEFAULT 'personal-sanctuary',
+      project_id TEXT,
+      deleted_at TEXT,
+      archived_at TEXT,
+      permanent_archive INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE SET NULL,
+      FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE SET NULL
+    );
+
+    CREATE TABLE labels (
+      id TEXT PRIMARY KEY NOT NULL,
+      user_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      color TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
+    );
+
+    CREATE TABLE task_labels (
+      task_id TEXT NOT NULL,
+      label_id TEXT NOT NULL,
+      PRIMARY KEY (task_id, label_id),
+      FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      FOREIGN KEY (label_id) REFERENCES labels(id) ON DELETE CASCADE
+    );
+  `);
+
+  const userId = `user-${randomUUID()}`;
+  const projectId = `project-${randomUUID()}`;
+  const taskId = `task-${randomUUID()}`;
+  const labelId = `label-${randomUUID()}`;
+  const createdAt = 1773652800000;
+  const updatedAt = 1773656400000;
+  const archivedAt = 1773660000000;
+
+  sqlite
+    .prepare(
+      `INSERT INTO user (id, name, email, emailVerified, image, workspaceMode, onboardingCompleted, archiveAutoDelete, captureBehavior, createdAt, updatedAt)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      userId,
+      'Legacy User',
+      'legacy@example.com',
+      0,
+      null,
+      null,
+      0,
+      1,
+      'quick',
+      createdAt,
+      updatedAt,
+    );
+
+  sqlite
+    .prepare(
+      `INSERT INTO projects (id, owner_id, name, description, color, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      projectId,
+      userId,
+      'Legacy Project',
+      'Seeded legacy project',
+      'sage',
+      createdAt,
+      updatedAt,
+    );
+
+  sqlite
+    .prepare(
+      `INSERT INTO tasks (id, user_id, title, description, status, priority, completed, sort_order, due_date, simple_mode, bucket, project_id, deleted_at, archived_at, permanent_archive, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      taskId,
+      userId,
+      'Legacy Task',
+      'Seeded legacy task',
+      'today',
+      'high',
+      1,
+      0,
+      null,
+      0,
+      'deep-work',
+      projectId,
+      '',
+      '',
+      0,
+      createdAt,
+      updatedAt,
+    );
+
+  sqlite
+    .prepare(
+      `INSERT INTO labels (id, user_id, name, color, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    )
+    .run(labelId, userId, 'Legacy Label', '#82d7a9', '', updatedAt);
+
+  sqlite.prepare(`INSERT INTO task_labels (task_id, label_id) VALUES (?, ?)`).run(taskId, labelId);
+  sqlite.close();
+
+  return { userId, projectId, taskId, labelId, createdAt, updatedAt, archivedAt };
+}
+
+function assertIsoTimestamp(value: unknown) {
+  assert.equal(typeof value, 'string');
+  assert.match(String(value), /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+}
+
+test('legacy timestamp rows are normalized to ISO text on startup', async () => {
+  const dbFile = join(tmpdir(), `yotara-timestamp-migration-${randomUUID()}.db`);
+  process.env['DATABASE_URL'] = dbFile;
+  process.env['BETTER_AUTH_SECRET'] = 'test-secret-with-enough-entropy-1234567890';
+  process.env['APP_BASE_URL'] = 'http://localhost:3000';
+
+  try {
+    const seeded = seedLegacyDatabase(dbFile);
+    const { sqlite } = await import('./client.js');
+
+    const projectRow = sqlite
+      .prepare(
+        `SELECT typeof(created_at) AS created_type, typeof(updated_at) AS updated_type, created_at, updated_at FROM projects WHERE id = ?`,
+      )
+      .get(seeded.projectId) as {
+      created_type: string;
+      updated_type: string;
+      created_at: string;
+      updated_at: string;
+    };
+    assert.equal(projectRow.created_type, 'text');
+    assert.equal(projectRow.updated_type, 'text');
+    assertIsoTimestamp(projectRow.created_at);
+    assertIsoTimestamp(projectRow.updated_at);
+    assert.equal(projectRow.created_at, toIso(seeded.createdAt));
+    assert.equal(projectRow.updated_at, toIso(seeded.updatedAt));
+
+    const taskRow = sqlite
+      .prepare(
+        `SELECT typeof(created_at) AS created_type, typeof(updated_at) AS updated_type, typeof(archived_at) AS archived_type, typeof(deleted_at) AS deleted_type, created_at, updated_at, archived_at, deleted_at FROM tasks WHERE id = ?`,
+      )
+      .get(seeded.taskId) as {
+      created_type: string;
+      updated_type: string;
+      archived_type: string;
+      deleted_type: string;
+      created_at: string;
+      updated_at: string;
+      archived_at: string | null;
+      deleted_at: string | null;
+    };
+    assert.equal(taskRow.created_type, 'text');
+    assert.equal(taskRow.updated_type, 'text');
+    assert.equal(taskRow.archived_type, 'text');
+    assert.equal(taskRow.deleted_type, 'null');
+    assertIsoTimestamp(taskRow.created_at);
+    assertIsoTimestamp(taskRow.updated_at);
+    assertIsoTimestamp(taskRow.archived_at);
+    assert.equal(taskRow.deleted_at, null);
+    assert.equal(taskRow.archived_at, toIso(seeded.updatedAt));
+
+    const labelRow = sqlite
+      .prepare(
+        `SELECT typeof(created_at) AS created_type, typeof(updated_at) AS updated_type, created_at, updated_at FROM labels WHERE id = ?`,
+      )
+      .get(seeded.labelId) as {
+      created_type: string;
+      updated_type: string;
+      created_at: string;
+      updated_at: string;
+    };
+    assert.equal(labelRow.created_type, 'text');
+    assert.equal(labelRow.updated_type, 'text');
+    assertIsoTimestamp(labelRow.created_at);
+    assertIsoTimestamp(labelRow.updated_at);
+    assert.equal(labelRow.created_at, toIso(seeded.updatedAt));
+    assert.equal(labelRow.updated_at, toIso(seeded.updatedAt));
+  } finally {
+    rmSync(dbFile, { force: true });
+    delete process.env['DATABASE_URL'];
+    delete process.env['BETTER_AUTH_SECRET'];
+    delete process.env['APP_BASE_URL'];
+  }
+});

--- a/apps/api/src/docs/openapi.test.ts
+++ b/apps/api/src/docs/openapi.test.ts
@@ -140,6 +140,10 @@ test('openapi spec includes representative response contracts and examples', asy
         .onboardingCompleted,
       false,
     );
+    assert.match(
+      spec.paths['/me'].get.responses['200'].content['application/json'].example.user.createdAt,
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+    );
     assert.ok(spec.paths['/tasks'].get.responses['200'].content['application/json'].schema);
     assert.equal(
       spec.paths['/auth/sign-in/email'].post.responses['401'].content['application/json'].example

--- a/apps/api/src/docs/openapi.ts
+++ b/apps/api/src/docs/openapi.ts
@@ -28,6 +28,15 @@ const nonEmptyTextSchema = {
   pattern: '.*\\S.*',
 } as const;
 
+const dateTimeSchema = {
+  type: 'string',
+  format: 'date-time',
+} as const;
+
+const authTimestampSchema = {
+  anyOf: [dateTimeSchema, { type: 'integer' }],
+} as const;
+
 const taskSchema = {
   $id: 'Task',
   type: 'object',
@@ -61,8 +70,8 @@ const taskSchema = {
       items: { type: 'string' },
     },
     order: { type: 'integer' },
-    createdAt: { type: 'string', format: 'date-time' },
-    updatedAt: { type: 'string', format: 'date-time' },
+    createdAt: dateTimeSchema,
+    updatedAt: dateTimeSchema,
   },
 } as const;
 
@@ -142,8 +151,8 @@ const labelSchema = {
     color: { type: 'string' },
     userId: { type: 'string' },
     taskCount: { type: 'integer', minimum: 0 },
-    createdAt: { type: 'string', format: 'date-time' },
-    updatedAt: { type: 'string', format: 'date-time' },
+    createdAt: dateTimeSchema,
+    updatedAt: dateTimeSchema,
   },
 } as const;
 
@@ -196,8 +205,41 @@ const projectSchema = {
     taskCount: { type: 'integer', minimum: 0 },
     completedTaskCount: { type: 'integer', minimum: 0 },
     openTaskCount: { type: 'integer', minimum: 0 },
-    createdAt: { type: 'string', format: 'date-time' },
-    updatedAt: { type: 'string', format: 'date-time' },
+    createdAt: dateTimeSchema,
+    updatedAt: dateTimeSchema,
+  },
+} as const;
+
+const appUserSchema = {
+  $id: 'AppUser',
+  type: 'object',
+  required: [
+    'id',
+    'email',
+    'name',
+    'image',
+    'emailVerified',
+    'workspaceMode',
+    'onboardingCompleted',
+    'archiveAutoDelete',
+    'captureBehavior',
+    'createdAt',
+    'updatedAt',
+  ],
+  properties: {
+    id: { type: 'string' },
+    email: { type: 'string', format: 'email' },
+    name: { type: 'string' },
+    image: { anyOf: [{ type: 'string', format: 'uri' }, { type: 'null' }] },
+    emailVerified: { type: 'boolean' },
+    workspaceMode: {
+      anyOf: [{ type: 'string', enum: ['personal', 'team'] }, { type: 'null' }],
+    },
+    onboardingCompleted: { type: 'boolean' },
+    archiveAutoDelete: { type: 'boolean' },
+    captureBehavior: { type: 'string', enum: ['quick', 'capture'] },
+    createdAt: dateTimeSchema,
+    updatedAt: dateTimeSchema,
   },
 } as const;
 
@@ -309,15 +351,9 @@ const sessionSchema = {
   properties: {
     id: { type: 'string' },
     userId: { type: 'string' },
-    expiresAt: {
-      anyOf: [{ type: 'string', format: 'date-time' }, { type: 'integer' }],
-    },
-    createdAt: {
-      anyOf: [{ type: 'string', format: 'date-time' }, { type: 'integer' }],
-    },
-    updatedAt: {
-      anyOf: [{ type: 'string', format: 'date-time' }, { type: 'integer' }],
-    },
+    expiresAt: authTimestampSchema,
+    createdAt: authTimestampSchema,
+    updatedAt: authTimestampSchema,
     token: { type: 'string' },
     ipAddress: { type: 'string' },
     userAgent: { type: 'string' },
@@ -329,7 +365,7 @@ const meResponseSchema = {
   type: 'object',
   required: ['user'],
   properties: {
-    user: { $ref: 'User#' },
+    user: { $ref: 'AppUser#' },
   },
 } as const;
 
@@ -436,6 +472,7 @@ const sharedSchemas = [
   updateLabelSchema,
   projectColorSchema,
   projectSchema,
+  appUserSchema,
   createProjectSchema,
   updateProjectSchema,
   projectsListResponseSchema,

--- a/apps/api/src/lib/public-user.ts
+++ b/apps/api/src/lib/public-user.ts
@@ -1,17 +1,32 @@
 import { users } from '../db/schema.js';
+import { toIsoTimestamp } from './timestamps.js';
 
-export function toPublicUser(user: typeof users.$inferSelect) {
+export type PublicUser = {
+  id: string;
+  email: string;
+  name: string;
+  image: string | null;
+  emailVerified: boolean;
+  workspaceMode: 'personal' | 'team' | null;
+  onboardingCompleted: boolean;
+  archiveAutoDelete: boolean;
+  captureBehavior: 'quick' | 'capture';
+  createdAt: string;
+  updatedAt: string;
+};
+
+export function toPublicUser(user: typeof users.$inferSelect): PublicUser {
   return {
     id: user.id,
     email: user.email,
     name: user.name,
     image: user.image,
     emailVerified: user.emailVerified,
-    createdAt: user.createdAt,
-    updatedAt: user.updatedAt,
     workspaceMode: user.workspaceMode,
     onboardingCompleted: user.onboardingCompleted,
     archiveAutoDelete: user.archiveAutoDelete,
     captureBehavior: user.captureBehavior,
+    createdAt: toIsoTimestamp(user.createdAt),
+    updatedAt: toIsoTimestamp(user.updatedAt),
   };
 }

--- a/apps/api/src/lib/timestamps.ts
+++ b/apps/api/src/lib/timestamps.ts
@@ -1,0 +1,20 @@
+export function nowIsoTimestamp() {
+  return new Date().toISOString();
+}
+
+export function toIsoTimestamp(value: Date | number | string): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (/^-?\d+(?:\.\d+)?$/.test(trimmed)) {
+      return new Date(Number(trimmed)).toISOString();
+    }
+
+    return new Date(trimmed).toISOString();
+  }
+
+  return new Date(value).toISOString();
+}

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -74,6 +74,15 @@ test('auth routes register and login with email/password', async () => {
     assert.equal(meAfterRegister.statusCode, 200);
     assert.equal(meAfterRegister.json().user.email, TEST_EMAIL);
     assert.equal(meAfterRegister.json().user.onboardingCompleted, false);
+    assert.equal(typeof meAfterRegister.json().user.createdAt, 'string');
+    assert.match(
+      meAfterRegister.json().user.createdAt,
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+    );
+    assert.match(
+      meAfterRegister.json().user.updatedAt,
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+    );
 
     const updateMeResponse = await ctx.app.inject({
       method: 'PATCH',
@@ -135,6 +144,7 @@ test('auth routes register and login with email/password', async () => {
     assert.equal(meAfterLogin.json().user.email, TEST_EMAIL);
     assert.equal(meAfterLogin.json().user.workspaceMode, 'personal');
     assert.equal(meAfterLogin.json().user.onboardingCompleted, true);
+    assert.equal(typeof meAfterLogin.json().user.createdAt, 'string');
 
     const NEW_PASSWORD = 'NewPassword123!';
 

--- a/apps/api/src/routes/labels.test.ts
+++ b/apps/api/src/routes/labels.test.ts
@@ -1,0 +1,120 @@
+import { randomUUID } from 'node:crypto';
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { eq } from 'drizzle-orm';
+import { labels } from '../db/schema.js';
+
+async function createAuthedApp() {
+  const dbFile = join(tmpdir(), `yotara-labels-test-${randomUUID()}.db`);
+  process.env['DATABASE_URL'] = dbFile;
+  process.env['BETTER_AUTH_SECRET'] = 'test-secret-with-enough-entropy-1234567890';
+  process.env['APP_BASE_URL'] = 'http://localhost:3000';
+
+  const { buildApp } = await import('../server.js');
+  const app = await buildApp();
+
+  return {
+    app,
+    cleanup() {
+      return Promise.resolve()
+        .then(() => app.close())
+        .finally(() => {
+          rmSync(dbFile, { force: true });
+          delete process.env['DATABASE_URL'];
+          delete process.env['BETTER_AUTH_SECRET'];
+          delete process.env['APP_BASE_URL'];
+        });
+    },
+  };
+}
+
+async function signUpAndGetCookie(email: string) {
+  const { auth } = await import('../lib/auth.js');
+  const response = await auth.api.signUpEmail({
+    body: {
+      email,
+      password: 'Password123!',
+      name: email.split('@')[0],
+    },
+    asResponse: true,
+  });
+
+  assert.equal(response.status, 200);
+  const cookie = response.headers.get('set-cookie');
+  assert.ok(cookie);
+  return cookie;
+}
+
+function assertIsoTimestamp(value: unknown) {
+  assert.equal(typeof value, 'string');
+  assert.match(String(value), /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+}
+
+test('labels store ISO timestamps and update their text rows consistently', async () => {
+  const ctx = await createAuthedApp();
+
+  try {
+    const cookie = await signUpAndGetCookie(`labels-${randomUUID()}@example.com`);
+
+    const createResponse = await ctx.app.inject({
+      method: 'POST',
+      url: '/labels',
+      headers: { cookie },
+      payload: {
+        name: 'Focus',
+        color: '#82d7a9',
+      },
+    });
+
+    assert.equal(createResponse.statusCode, 201);
+    const created = createResponse.json();
+    assert.equal(created.name, 'Focus');
+    assert.equal(created.color, '#82d7a9');
+    assertIsoTimestamp(created.createdAt);
+    assertIsoTimestamp(created.updatedAt);
+
+    const { db } = await import('../db/client.js');
+    const [storedLabel] = await db
+      .select({
+        createdAt: labels.createdAt,
+        updatedAt: labels.updatedAt,
+      })
+      .from(labels)
+      .where(eq(labels.id, created.id))
+      .limit(1);
+    assert.ok(storedLabel);
+    assertIsoTimestamp(storedLabel.createdAt);
+    assertIsoTimestamp(storedLabel.updatedAt);
+
+    const updateResponse = await ctx.app.inject({
+      method: 'PATCH',
+      url: `/labels/${created.id}`,
+      headers: { cookie },
+      payload: {
+        name: 'Deep Focus',
+      },
+    });
+
+    assert.equal(updateResponse.statusCode, 200);
+    assert.equal(updateResponse.json().name, 'Deep Focus');
+    assertIsoTimestamp(updateResponse.json().createdAt);
+    assertIsoTimestamp(updateResponse.json().updatedAt);
+
+    const [updatedLabel] = await db
+      .select({
+        createdAt: labels.createdAt,
+        updatedAt: labels.updatedAt,
+      })
+      .from(labels)
+      .where(eq(labels.id, created.id))
+      .limit(1);
+    assert.ok(updatedLabel);
+    assertIsoTimestamp(updatedLabel.createdAt);
+    assertIsoTimestamp(updatedLabel.updatedAt);
+  } finally {
+    await ctx.cleanup();
+  }
+});

--- a/apps/api/src/routes/projects.test.ts
+++ b/apps/api/src/routes/projects.test.ts
@@ -4,6 +4,8 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { eq } from 'drizzle-orm';
+import { projects } from '../db/schema.js';
 
 async function createAuthedApp() {
   const dbFile = join(tmpdir(), `yotara-projects-test-${randomUUID()}.db`);
@@ -47,6 +49,11 @@ async function signUpAndGetCookie(email: string) {
   return cookie;
 }
 
+function assertIsoTimestamp(value: unknown) {
+  assert.equal(typeof value, 'string');
+  assert.match(String(value), /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+}
+
 test('projects routes require auth and scope project data to the current user', async () => {
   const ctx = await createAuthedApp();
 
@@ -76,6 +83,21 @@ test('projects routes require auth and scope project data to the current user', 
     assert.equal(created.taskCount, 0);
     assert.equal(created.completedTaskCount, 0);
     assert.equal(created.openTaskCount, 0);
+    assertIsoTimestamp(created.createdAt);
+    assertIsoTimestamp(created.updatedAt);
+
+    const { db } = await import('../db/client.js');
+    const [storedProject] = await db
+      .select({
+        createdAt: projects.createdAt,
+        updatedAt: projects.updatedAt,
+      })
+      .from(projects)
+      .where(eq(projects.id, created.id))
+      .limit(1);
+    assert.ok(storedProject);
+    assertIsoTimestamp(storedProject.createdAt);
+    assertIsoTimestamp(storedProject.updatedAt);
 
     const ownerList = await ctx.app.inject({
       method: 'GET',
@@ -158,6 +180,8 @@ test('projects validate payloads and support updates', async () => {
     assert.equal(updateResponse.json().name, 'Website Refresh Phase 1');
     assert.equal(updateResponse.json().description, undefined);
     assert.equal(updateResponse.json().color, 'forest');
+    assertIsoTimestamp(updateResponse.json().createdAt);
+    assertIsoTimestamp(updateResponse.json().updatedAt);
 
     const emptyNamePatchResponse = await ctx.app.inject({
       method: 'PATCH',

--- a/apps/api/src/routes/tasks.test.ts
+++ b/apps/api/src/routes/tasks.test.ts
@@ -55,6 +55,11 @@ function daysAgoIso(days: number) {
   return date.toISOString();
 }
 
+function assertIsoTimestamp(value: unknown) {
+  assert.equal(typeof value, 'string');
+  assert.match(String(value), /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+}
+
 test('tasks routes require auth and scope data to the current user', async () => {
   const ctx = await createAuthedApp();
 
@@ -86,6 +91,22 @@ test('tasks routes require auth and scope data to the current user', async () =>
     assert.ok(created.projectId);
     assert.equal(created.simpleMode, true);
     assert.equal(created.dueDate, undefined);
+    assertIsoTimestamp(created.createdAt);
+    assertIsoTimestamp(created.updatedAt);
+
+    const { db } = await import('../db/client.js');
+    const [storedTask] = await db
+      .select({
+        createdAt: tasks.createdAt,
+        updatedAt: tasks.updatedAt,
+        archivedAt: tasks.archivedAt,
+      })
+      .from(tasks)
+      .where(eq(tasks.id, created.id))
+      .limit(1);
+    assert.ok(storedTask);
+    assertIsoTimestamp(storedTask.createdAt);
+    assertIsoTimestamp(storedTask.updatedAt);
 
     const blankTitleResponse = await ctx.app.inject({
       method: 'POST',
@@ -266,10 +287,10 @@ test('tasks pagination validates query bounds and deleted tasks cannot be update
 
 test('temporary archived tasks are cleaned up in the database while permanent archives stay', async () => {
   const ctx = await createAuthedApp();
-  const { db } = await import('../db/client.js');
 
   try {
     const userCookie = await signUpAndGetCookie(`archive-${randomUUID()}@example.com`);
+    const { db } = await import('../db/client.js');
 
     const disableCleanupResponse = await ctx.app.inject({
       method: 'PATCH',
@@ -306,6 +327,22 @@ test('temporary archived tasks are cleaned up in the database while permanent ar
     });
     assert.equal(completeTemporary.statusCode, 200);
     assert.equal(completeTemporary.json().permanentArchive, false);
+    assertIsoTimestamp(completeTemporary.json().createdAt);
+    assertIsoTimestamp(completeTemporary.json().updatedAt);
+
+    const storedTemporary = await db
+      .select({
+        createdAt: tasks.createdAt,
+        updatedAt: tasks.updatedAt,
+        archivedAt: tasks.archivedAt,
+      })
+      .from(tasks)
+      .where(eq(tasks.id, temporaryTask.id))
+      .limit(1);
+    assert.equal(storedTemporary.length, 1);
+    assertIsoTimestamp(storedTemporary[0].createdAt);
+    assertIsoTimestamp(storedTemporary[0].updatedAt);
+    assertIsoTimestamp(storedTemporary[0].archivedAt);
 
     await db
       .update(tasks)

--- a/apps/api/src/services/label-service.ts
+++ b/apps/api/src/services/label-service.ts
@@ -3,6 +3,7 @@ import { and, asc, eq, inArray, sql } from 'drizzle-orm';
 import type { CreateLabelDto, Label, UpdateLabelDto } from '@yotara/shared';
 import { db } from '../db/client.js';
 import { labels, taskLabels } from '../db/schema.js';
+import { nowIsoTimestamp } from '../lib/timestamps.js';
 
 const DEFAULT_LABELS = [
   { name: 'Urgent', color: '#d44d3c' },
@@ -39,7 +40,7 @@ export async function seedDefaultLabelsForOwner(ownerId: string) {
     return;
   }
 
-  const now = new Date().toISOString();
+  const now = nowIsoTimestamp();
   await db.insert(labels).values(
     DEFAULT_LABELS.map((label) => ({
       id: randomUUID(),
@@ -82,7 +83,7 @@ export async function getLabelForOwner(labelId: string, ownerId: string) {
 }
 
 export async function createLabelForOwner(ownerId: string, body: CreateLabelDto) {
-  const now = new Date().toISOString();
+  const now = nowIsoTimestamp();
   const id = randomUUID();
   const name = body.name.trim();
   const color = body.color?.trim() || pickLabelColor(name);
@@ -114,7 +115,7 @@ export async function updateLabelForOwner(ownerId: string, labelId: string, body
     .set({
       name,
       color,
-      updatedAt: new Date().toISOString(),
+      updatedAt: nowIsoTimestamp(),
     })
     .where(eq(labels.id, labelId));
 

--- a/apps/api/src/services/project-service.ts
+++ b/apps/api/src/services/project-service.ts
@@ -3,6 +3,7 @@ import { and, eq, isNull, sql } from 'drizzle-orm';
 import type { CreateProjectDto, UpdateProjectDto } from '@yotara/shared';
 import { db } from '../db/client.js';
 import { projects, tasks } from '../db/schema.js';
+import { nowIsoTimestamp } from '../lib/timestamps.js';
 import {
   normalizeProjectCreatePayload,
   normalizeProjectUpdatePayload,
@@ -66,7 +67,7 @@ export async function seedDefaultProjectsForOwner(ownerId: string) {
     .from(projects)
     .where(eq(projects.ownerId, ownerId));
   const existingNames = new Set(existing.map((project) => project.name.toLowerCase()));
-  const now = new Date().toISOString();
+  const now = nowIsoTimestamp();
   const missingProjects = DEFAULT_PROJECTS.filter(
     (project) => !existingNames.has(project.name.toLowerCase()),
   );
@@ -118,7 +119,7 @@ export async function getProjectForOwner(projectId: string, ownerId: string) {
 
 export async function createProjectForOwner(ownerId: string, body: CreateProjectDto) {
   const payload = normalizeProjectCreatePayload(body);
-  const now = new Date().toISOString();
+  const now = nowIsoTimestamp();
   const id = randomUUID();
 
   await db.insert(projects).values({
@@ -156,7 +157,7 @@ export async function updateProjectForOwner(
           ? (patch.description ?? null)
           : (current.description ?? null),
       color: patch.color ?? current.color ?? null,
-      updatedAt: new Date().toISOString(),
+      updatedAt: nowIsoTimestamp(),
     })
     .where(eq(projects.id, projectId));
 

--- a/apps/api/src/services/task-service.ts
+++ b/apps/api/src/services/task-service.ts
@@ -9,6 +9,7 @@ import type {
 } from '@yotara/shared';
 import { db } from '../db/client.js';
 import { tasks, users } from '../db/schema.js';
+import { nowIsoTimestamp } from '../lib/timestamps.js';
 import { getTaskLabels, syncTaskLabels } from './label-service.js';
 import { getDefaultProjectForOwner } from './project-service.js';
 
@@ -156,7 +157,7 @@ export async function getTaskForOwner(taskId: string, ownerId: string) {
 
 export async function createTaskForOwner(ownerId: string, body: CreateTaskDto) {
   const payload = normalizeCreatePayload(body);
-  const now = new Date().toISOString();
+  const now = nowIsoTimestamp();
   const id = randomUUID();
   const defaultProject = payload.projectId ? null : await getDefaultProjectForOwner(ownerId);
   const projectId = payload.projectId ?? defaultProject?.id ?? null;
@@ -205,9 +206,9 @@ export async function updateTaskForOwner(
     (completed && !current.completed ? !archiveAutoDelete : current.permanentArchive);
   const nextArchivedAt =
     completed && !current.completed
-      ? new Date().toISOString()
+      ? nowIsoTimestamp()
       : completed
-        ? (current.archivedAt ?? new Date().toISOString())
+        ? (current.archivedAt ?? nowIsoTimestamp())
         : null;
   const nextProjectId =
     body.projectId === null
@@ -231,7 +232,7 @@ export async function updateTaskForOwner(
       status: normalizeStatusOnCompletion(status, completed),
       archivedAt: nextArchivedAt,
       permanentArchive: completed ? nextPermanentArchive : false,
-      updatedAt: new Date().toISOString(),
+      updatedAt: nowIsoTimestamp(),
     })
     .where(eq(tasks.id, taskId));
 

--- a/apps/frontend/src/app/core/services/search.service.ts
+++ b/apps/frontend/src/app/core/services/search.service.ts
@@ -3,6 +3,7 @@ import type { Label, Project, Task } from '@yotara/shared';
 import { LabelService } from './label.service';
 import { ProjectService } from './project.service';
 import { TaskService } from './task.service';
+import { parseCalendarDate } from '../../shared/utils/timestamps';
 
 export type SearchTab = 'all' | 'tasks' | 'projects' | 'labels';
 
@@ -395,16 +396,7 @@ function formatDueDate(value?: string | null) {
 }
 
 function toCalendarDate(value?: string | null) {
-  if (!value) {
-    return null;
-  }
-
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) {
-    return null;
-  }
-
-  return new Date(parsed.getFullYear(), parsed.getMonth(), parsed.getDate());
+  return parseCalendarDate(value);
 }
 
 function startOfToday() {

--- a/apps/frontend/src/app/core/services/task.service.ts
+++ b/apps/frontend/src/app/core/services/task.service.ts
@@ -16,6 +16,7 @@ import { environment } from '../../../environments/environment';
 import { AuthStateService } from './auth-state.service';
 import { LabelService } from './label.service';
 import { ProjectService } from './project.service';
+import { parseCalendarDate } from '../../shared/utils/timestamps';
 
 export type UpcomingBucket = 'This Week' | 'Next Week' | 'Later';
 
@@ -256,23 +257,7 @@ export class TaskService {
 }
 
 function toCalendarDate(value?: string | null) {
-  if (!value) {
-    return null;
-  }
-
-  const dateOnlyMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
-  if (dateOnlyMatch) {
-    const [, year, month, day] = dateOnlyMatch;
-    return new Date(Number(year), Number(month) - 1, Number(day));
-  }
-
-  const parsed = new Date(value);
-
-  if (Number.isNaN(parsed.getTime())) {
-    return null;
-  }
-
-  return new Date(parsed.getFullYear(), parsed.getMonth(), parsed.getDate());
+  return parseCalendarDate(value);
 }
 
 function startOfToday() {

--- a/apps/frontend/src/app/features/personal/components/personal-task-card.component.ts
+++ b/apps/frontend/src/app/features/personal/components/personal-task-card.component.ts
@@ -6,6 +6,7 @@ import { faBoxArchive, faRotateLeft, faTrash } from '@fortawesome/free-solid-svg
 import { LabelService } from '../../../core/services/label.service';
 import { TaskService } from '../../../core/services/task.service';
 import { ConfirmDialogComponent } from '../../../shared/ui/confirm-dialog/confirm-dialog.component';
+import { parseCalendarDate } from '../../../shared/utils/timestamps';
 
 @Component({
   selector: 'app-personal-task-card',
@@ -460,9 +461,9 @@ export class PersonalTaskCardComponent {
   }
 
   protected dateLabel() {
-    const parsed = new Date(this.task.dueDate ?? '');
+    const parsed = parseCalendarDate(this.task.dueDate);
 
-    if (Number.isNaN(parsed.getTime())) {
+    if (!parsed) {
       return '';
     }
 

--- a/apps/frontend/src/app/features/personal/components/personal-task-modal.component.ts
+++ b/apps/frontend/src/app/features/personal/components/personal-task-modal.component.ts
@@ -22,6 +22,7 @@ import {
 } from '@yotara/shared';
 import { LabelService } from '../../../core/services/label.service';
 import { DatePickerComponent } from '../../../shared/ui/date-picker/date-picker.component';
+import { parseCalendarDate } from '../../../shared/utils/timestamps';
 import { parseTaskCommand } from '../utils/task-command-parser';
 
 type SavePayload =
@@ -144,9 +145,8 @@ export class PersonalTaskModalComponent implements OnDestroy {
       return true;
     }
 
-    // Basic date validation: check if it's a valid date format
-    const dateObj = new Date(dueDate);
-    if (isNaN(dateObj.getTime())) {
+    const dateObj = parseCalendarDate(dueDate);
+    if (!dateObj) {
       this.dueDateError.set('Please enter a valid date');
       return false;
     }
@@ -324,27 +324,6 @@ function toDateInputValue(value?: string | null) {
 function normalizeDateInputValue(value: string) {
   const date = parseCalendarDate(value);
   return date ? formatDateInputValue(date) : undefined;
-}
-
-function parseCalendarDate(value?: string | null) {
-  if (!value) {
-    return null;
-  }
-
-  const dateOnlyMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
-  if (dateOnlyMatch) {
-    const [, year, month, day] = dateOnlyMatch;
-    // Use local date constructor to avoid timezone shifts
-    return new Date(Number(year), Number(month) - 1, Number(day));
-  }
-
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) {
-    return null;
-  }
-
-  // If it's a full ISO string, we want the local date representation of that moment
-  return new Date(parsed.getFullYear(), parsed.getMonth(), parsed.getDate());
 }
 
 function formatDateInputValue(date: Date) {

--- a/apps/frontend/src/app/features/personal/pages/task-list-page/task-list-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/task-list-page/task-list-page.component.ts
@@ -23,6 +23,7 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faPlus, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { ElementRef } from '@angular/core';
 import { parseTaskCommand } from '../../utils/task-command-parser';
+import { parseCalendarDate } from '../../../../shared/utils/timestamps';
 
 export type TaskListViewMode = 'inbox' | 'today' | 'upcoming' | 'search';
 export type TaskSortOption = 'date' | 'alpha';
@@ -221,8 +222,10 @@ export class TaskListPageComponent implements OnInit {
       }
 
       // Default: date (newest created for inbox, or by dueDate)
-      const dateA = new Date(taskA.dueDate || taskA.createdAt).getTime();
-      const dateB = new Date(taskB.dueDate || taskB.createdAt).getTime();
+      const dateA =
+        parseCalendarDate(taskA.dueDate)?.getTime() ?? new Date(taskA.createdAt).getTime();
+      const dateB =
+        parseCalendarDate(taskB.dueDate)?.getTime() ?? new Date(taskB.createdAt).getTime();
       return dateB - dateA;
     });
 

--- a/apps/frontend/src/app/shared/ui/date-picker/date-picker.component.ts
+++ b/apps/frontend/src/app/shared/ui/date-picker/date-picker.component.ts
@@ -26,6 +26,7 @@ import {
 } from '@spartan-ng/brain/calendar';
 import { provideNativeDateAdapter } from '@spartan-ng/brain/date-time';
 import { BrnPopover, BrnPopoverImports } from '@spartan-ng/brain/popover';
+import { parseCalendarDate } from '../../utils/timestamps';
 
 @Component({
   selector: 'app-date-picker',
@@ -374,28 +375,6 @@ export class DatePickerComponent implements OnChanges {
     this.valueChange.emit('');
     this.popover()?.close();
   }
-}
-
-function parseCalendarDate(value?: string | null) {
-  if (!value) {
-    return null;
-  }
-
-  // Handle YYYY-MM-DD
-  const dateOnlyMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
-  if (dateOnlyMatch) {
-    const [, year, month, day] = dateOnlyMatch;
-    // Use local date constructor to avoid timezone shifts
-    return new Date(Number(year), Number(month) - 1, Number(day));
-  }
-
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) {
-    return null;
-  }
-
-  // If it's a full ISO string, we want the local date representation of that moment
-  return new Date(parsed.getFullYear(), parsed.getMonth(), parsed.getDate());
 }
 
 function startOfDay(date: Date) {

--- a/apps/frontend/src/app/shared/utils/timestamps.spec.ts
+++ b/apps/frontend/src/app/shared/utils/timestamps.spec.ts
@@ -1,0 +1,25 @@
+import { parseCalendarDate } from './timestamps';
+
+describe('parseCalendarDate', () => {
+  it('parses date-only strings as local calendar dates', () => {
+    const parsed = parseCalendarDate('2026-05-20');
+
+    expect(parsed).toBeTruthy();
+    expect(parsed?.getFullYear()).toBe(2026);
+    expect(parsed?.getMonth()).toBe(4);
+    expect(parsed?.getDate()).toBe(20);
+  });
+
+  it('parses full ISO strings to local calendar dates', () => {
+    const parsed = parseCalendarDate('2026-05-20T12:30:00.000Z');
+
+    expect(parsed).toBeTruthy();
+    expect(parsed?.getFullYear()).toBe(2026);
+    expect(parsed?.getMonth()).toBe(4);
+    expect(parsed?.getDate()).toBe(20);
+  });
+
+  it('returns null for invalid dates', () => {
+    expect(parseCalendarDate('invalid-date')).toBeNull();
+  });
+});

--- a/apps/frontend/src/app/shared/utils/timestamps.ts
+++ b/apps/frontend/src/app/shared/utils/timestamps.ts
@@ -1,0 +1,18 @@
+export function parseCalendarDate(value?: string | null): Date | null {
+  if (!value) {
+    return null;
+  }
+
+  const dateOnlyMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (dateOnlyMatch) {
+    const [, year, month, day] = dateOnlyMatch;
+    return new Date(Number(year), Number(month) - 1, Number(day));
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return new Date(parsed.getFullYear(), parsed.getMonth(), parsed.getDate());
+}


### PR DESCRIPTION
## Description

This branch standardizes timestamp handling across both the frontend and backend.

On the backend, Yotara-owned SQLite tables now store timestamps as ISO-8601 UTC strings, keeping app data consistent, human-readable, and easy to sort lexicographically in SQLite. Better Auth tables are left untouched.

On the frontend, calendar/date-picker parsing is centralized into a small shared helper so date-only and ISO timestamp strings are handled consistently in one place. This reduces duplicated parsing logic and keeps UI code aligned with the backend’s string-based timestamp contract.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Test coverage improvement
- [ ] Performance improvement
- [x] Refactoring (code improvement with no functional change)

## Related Issue

Closes: #

## Roadmap Reference

Implements the SQLite timestamp standardization work and supports frontend timestamp normalization for calendar/date-picker flows.

## Changes Made

- Added a shared frontend `parseCalendarDate()` helper for date-only and ISO timestamp strings.
- Replaced duplicated calendar parsing logic in the date picker, task modal, and related task/search display paths.
- Standardized app-owned backend SQLite timestamps to ISO strings.
- Added backend normalization/backfill logic and updated API contracts/tests to match the new timestamp shape.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing completed

### Verification Steps

1. Run frontend typecheck.
2. Run backend typecheck and API tests.
3. Verify date picker, task modal, and timestamp-backed API responses still behave correctly.

## Screenshots or Demo

N/A

## Checklist

- [x] Code follows the project style and conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have verified that this PR is against the correct branch (`main`)

## Additional Notes

The branch deliberately keeps Better Auth timestamps as integers while standardizing Yotara domain timestamps and frontend calendar handling around ISO strings.