### PR TITLE
fix(api): replace as any cast on status query param with TaskStatus type

### DIFF
--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -1,5 +1,11 @@
 import type { FastifyInstance } from 'fastify';
-import type { CreateTaskDto, PaginatedResponse, Task, UpdateTaskDto } from '@yotara/shared';
+import type {
+  CreateTaskDto,
+  PaginatedResponse,
+  Task,
+  TaskStatus,
+  UpdateTaskDto,
+} from '@yotara/shared';
 import {
   authCookieSecurity,
   errorResponseSchema,
@@ -41,7 +47,7 @@ export default async function taskRoutes(fastify: FastifyInstance) {
       includeSubtasks?: boolean;
       parentId?: string;
       export?: boolean;
-      status?: string;
+      status?: TaskStatus;
       completed?: string;
       overdue?: string;
     };
@@ -88,7 +94,7 @@ export default async function taskRoutes(fastify: FastifyInstance) {
       const parentId = request.query.parentId;
 
       const filters = {
-        status: request.query.status as any,
+        status: request.query.status,
         completed:
           request.query.completed === 'true'
             ? true


### PR DESCRIPTION
The request.query.status was cast with 'as any' to bypass the string vs TaskStatus type mismatch. The Fastify schema already validates status against the allowed enum values at runtime, so the correct fix is to type the query parameter as TaskStatus and drop the cast entirely.

# Description

Removes the `as any` cast on `request.query.status` by typing the query parameter as `TaskStatus`. Fastify's schema already validates `status` against the allowed enum values at runtime, so the cast was only suppressing a TypeScript type mismatch.

# Type of Change

* [x] Refactoring (code improvement with no functional change)
* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update
* [ ] Test coverage improvement
* [ ] Performance improvement

# Changes Made

* Replaced `status?: string` with `status?: TaskStatus` in the route's `Querystring` type.
* Removed the `as any` cast from the status filter assignment.

# Testing

## Test Coverage

* [ ] Unit tests added/updated
* [ ] Integration tests added/updated
* [x] Manual testing completed

## Verification Steps

1. `pnpm lint` passes (0 errors).
2. `pnpm typecheck` passes.
3. Invalid values such as `?status=garbage` still return a Fastify `400` validation error (unchanged behavior).

# Checklist

* [x] Code follows the project style and conventions.
* [x] I have performed a self-review of my code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings or errors.
* [ ] I have added tests that prove my fix is effective or that my feature works.
* [ ] New and existing unit tests pass locally with my changes.
* [ ] Any dependent changes have been merged and published.
* [x] I have verified that this PR is against the correct branch (`main`).
