### PR TITLE
refactor(frontend): centralize localStorage access in PreferencesStore

### DIFF
--- a/apps/frontend/src/app/core/services/preferences-store.service.ts
+++ b/apps/frontend/src/app/core/services/preferences-store.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PreferencesStore {
+  readonly SKIP_COMPLETE_KEY = 'yotara_skipCompleteConfirm';
+  readonly INSIGHT_DISMISSED_KEY = 'yotara_insightDismissed';
+  readonly ONBOARDING_COMPLETED = 'onboardingCompleted';
+  readonly WORKSPACE_TYPE = 'workspaceType';
+
+  getSkipCompleteConfirm(): boolean {
+    return localStorage.getItem(this.SKIP_COMPLETE_KEY) === 'true';
+  }
+
+  setSkipCompleteConfirm(value: boolean): void {
+    localStorage.setItem(this.SKIP_COMPLETE_KEY, value ? 'true' : 'false');
+  }
+
+  isInsightDismissed(): boolean {
+    return localStorage.getItem(this.INSIGHT_DISMISSED_KEY) === 'true';
+  }
+
+  setInsightDismissed(value: boolean): void {
+    localStorage.setItem(this.INSIGHT_DISMISSED_KEY, value ? 'true' : 'false');
+  }
+
+  isOnboardingCompleted(): boolean {
+    return localStorage.getItem(this.ONBOARDING_COMPLETED) === 'true';
+  }
+
+  setOnboardingCompleted(): void {
+    localStorage.setItem(this.ONBOARDING_COMPLETED, 'true');
+  }
+
+  getWorkspaceType(): string {
+    return localStorage.getItem(this.WORKSPACE_TYPE) ?? '';
+  }
+
+  setWorkspaceType(value: string): void {
+    localStorage.setItem(this.WORKSPACE_TYPE, value);
+  }
+}

--- a/apps/frontend/src/app/features/onboarding/pages/start-screen/start-screen.component.ts
+++ b/apps/frontend/src/app/features/onboarding/pages/start-screen/start-screen.component.ts
@@ -2,6 +2,7 @@ import { Component, inject, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AuthStateService } from '../../../../core/services/auth-state.service';
 import { LogService } from '../../../../core/services/log.service';
+import { PreferencesStore } from '../../../../core/services/preferences-store.service';
 
 type WorkspaceType = 'personal' | 'team';
 
@@ -24,6 +25,7 @@ export class StartScreenComponent {
   private router = inject(Router);
   private route = inject(ActivatedRoute);
   private logService = inject(LogService);
+  private preferences = inject(PreferencesStore);
 
   selectedWorkspace = signal<WorkspaceType>('team');
   loading = signal(false);
@@ -60,8 +62,8 @@ export class StartScreenComponent {
 
     try {
       await this.authState.completeOnboarding(workspace);
-      localStorage.setItem('workspaceType', workspace);
-      localStorage.setItem('onboardingCompleted', 'true');
+      this.preferences.setWorkspaceType(workspace);
+      this.preferences.setOnboardingCompleted();
       await this.router.navigateByUrl(this.authState.getPostAuthRedirectUrl());
     } catch (error) {
       this.logService.error('Failed to complete onboarding', error, 'StartScreen');

--- a/apps/frontend/src/app/features/personal/components/personal-task-card.component.ts
+++ b/apps/frontend/src/app/features/personal/components/personal-task-card.component.ts
@@ -5,6 +5,7 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faBoxArchive, faRotate, faRotateLeft, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { MarkdownComponent } from 'ngx-markdown';
 import { LabelService } from '../../../core/services/label.service';
+import { PreferencesStore } from '../../../core/services/preferences-store.service';
 import { TaskService } from '../../../core/services/task.service';
 import { ConfirmDialogComponent } from '../../../shared/ui/confirm-dialog/confirm-dialog.component';
 import { parseCalendarDate } from '../../../shared/utils/timestamps';
@@ -545,7 +546,7 @@ import { parseCalendarDate } from '../../../shared/utils/timestamps';
 export class PersonalTaskCardComponent {
   private readonly taskService = inject(TaskService);
   private readonly labelService = inject(LabelService);
-  private readonly SKIP_COMPLETE_KEY = 'yotara_skipCompleteConfirm';
+  private readonly preferences = inject(PreferencesStore);
 
   protected readonly completeConfirmOpen = signal(false);
   protected readonly completing = signal(false);
@@ -653,7 +654,7 @@ export class PersonalTaskCardComponent {
   requestComplete(event: MouseEvent) {
     event.stopPropagation();
 
-    if (localStorage.getItem(this.SKIP_COMPLETE_KEY) === 'true') {
+    if (this.preferences.getSkipCompleteConfirm()) {
       this.completeTask();
       return;
     }
@@ -684,7 +685,7 @@ export class PersonalTaskCardComponent {
       this.completeConfirmOpen.set(false);
 
       if (this.dontShowAgain) {
-        localStorage.setItem(this.SKIP_COMPLETE_KEY, 'true');
+        this.preferences.setSkipCompleteConfirm(true);
       }
     } finally {
       this.completing.set(false);

--- a/apps/frontend/src/app/features/personal/pages/settings-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/settings-page.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, computed, inject, signal } from '@angular/core';
 import { APP_VERSION } from '../../../core/constants/version';
+import { PreferencesStore } from '../../../core/services/preferences-store.service';
 import { ThemeService, Theme } from '../../../core/services/theme.service';
 import { PageHeaderComponent } from '../../../shared/components/page-header/page-header.component';
 import { ChangePasswordModalComponent } from '../components/change-password-modal.component';
@@ -704,16 +705,11 @@ export class SettingsPageComponent {
   protected readonly isLoggingOut = signal(false);
   protected readonly isSavingArchiveCleanup = signal(false);
   protected readonly isSavingCaptureBehavior = signal(false);
-  private readonly SKIP_COMPLETE_KEY = 'yotara_skipCompleteConfirm';
+  private readonly preferences = inject(PreferencesStore);
 
-  protected readonly skipCompleteConfirm = signal(
-    localStorage.getItem('yotara_skipCompleteConfirm') === 'true',
-  );
-  private readonly INSIGHT_DISMISSED_KEY = 'yotara_insightDismissed';
+  protected readonly skipCompleteConfirm = signal(this.preferences.getSkipCompleteConfirm());
 
-  protected readonly showInsights = signal(
-    localStorage.getItem('yotara_insightDismissed') !== 'true',
-  );
+  protected readonly showInsights = signal(!this.preferences.isInsightDismissed());
 
   protected readonly exportFormat = signal<'csv' | 'json'>('csv');
 
@@ -934,13 +930,13 @@ export class SettingsPageComponent {
   protected onSkipCompleteConfirmChange(event: Event) {
     const checked = (event.target as HTMLInputElement).checked;
     this.skipCompleteConfirm.set(checked);
-    localStorage.setItem(this.SKIP_COMPLETE_KEY, checked ? 'true' : 'false');
+    this.preferences.setSkipCompleteConfirm(checked);
   }
 
   protected onShowInsightsChange(event: Event) {
     const checked = (event.target as HTMLInputElement).checked;
     this.showInsights.set(checked);
-    localStorage.setItem(this.INSIGHT_DISMISSED_KEY, checked ? 'false' : 'true');
+    this.preferences.setInsightDismissed(!checked);
   }
 
   protected async onLogout() {

--- a/apps/frontend/src/app/features/personal/pages/task-list-page/task-list-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/task-list-page/task-list-page.component.ts
@@ -1,6 +1,7 @@
 import { Component, computed, inject, signal, viewChild, OnInit, effect } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Task } from '@yotara/shared';
+import { PreferencesStore } from '../../../../core/services/preferences-store.service';
 import { ProjectService } from '../../../../core/services/project.service';
 import {
   TaskService,
@@ -59,6 +60,7 @@ export class TaskListPageComponent implements OnInit {
   protected readonly authState = inject(AuthStateService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly preferences = inject(PreferencesStore);
 
   protected readonly faPlus = faPlus;
   protected readonly faSun = faSun;
@@ -201,10 +203,7 @@ export class TaskListPageComponent implements OnInit {
   protected readonly activeInsightType = signal<InsightType>(
     Math.random() > 0.5 ? 'clarity' : 'journal',
   );
-  private readonly INSIGHT_DISMISSED_KEY = 'yotara_insightDismissed';
-  protected readonly insightPanelVisible = signal(
-    localStorage.getItem('yotara_insightDismissed') !== 'true',
-  );
+  protected readonly insightPanelVisible = signal(!this.preferences.isInsightDismissed());
   private readonly statusService = inject(StatusService);
 
   protected readonly insightPrompt = computed(() =>
@@ -279,7 +278,7 @@ export class TaskListPageComponent implements OnInit {
 
   protected dismissInsight() {
     this.insightPanelVisible.set(false);
-    localStorage.setItem(this.INSIGHT_DISMISSED_KEY, 'true');
+    this.preferences.setInsightDismissed(true);
     this.statusService.show('Insights can be re-enabled in Settings.', 'info', 4000);
   }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -370,8 +370,8 @@ This sprint order supersedes the P0/P1/P2/P3 priority lanes in `ROADMAP.md`. Tra
 **Why:** Closes the highest-leverage runtime anti-patterns (A1–A3, A7) and stops the docs from drifting again. Cheap, high-confidence work that compounds.
 
 - [x] Migrate 26 `console.error` sites to `LogService`; add ESLint `no-console` rule
-- [ ] Replace `throw new Error('string')` in services with typed errors; add Fastify `setErrorHandler`
-- [ ] Fix `as any` on `request.query.status` at the trust boundary
+- [x] Replace `throw new Error('string')` in services with typed errors; add Fastify `setErrorHandler`
+- [x] Fix `as any` on `request.query.status` at the trust boundary
 - [ ] Add `PreferencesStore` (or extend `ThemeService`'s pattern) and migrate the three `localStorage` magic-string keys
 - [ ] Replace the 4 problematic `setTimeout` UI hacks with signal-driven state
 - [ ] Fix the UTC vs local timezone bug; add `?tz=` to per-view queries


### PR DESCRIPTION
Extract all magic-string localStorage keys into a single PreferencesStore service and migrate four components (start-screen, personal-task-card, settings-page, task-list-page) to inject it instead of calling localStorage directly.

Unifies the pattern that ThemeService already uses for its own storage.

Description

  Centralizes all magic-string localStorage keys into a single PreferencesStore injectable, then
  migrates four components to use it instead of raw localStorage calls. This eliminates the last
  anti-pattern from the Sprint 0 checklist that has a production-code scope — the remaining checklist
  items (setTimeout hacks, UTC timezone) are separate concerns.

  Type of Change

  - [ ]  Bug fix (non-breaking change that fixes an issue)
  - [ ]  New feature (non-breaking change that adds functionality)
  - [ ]  Breaking change (fix or feature that would cause existing functionality to change)
  - [ ]  Documentation update
  - [ ]  Test coverage improvement
  - [ ]  Performance improvement
  - [X]  Refactoring (code improvement with no functional change)

  Related Issue

  Closes: #

  Roadmap Reference

  Implements "Add PreferencesStore and migrate the three localStorage magic-string keys" from Sprint 0
  in docs/ARCHITECTURE.md.

  Changes Made

  - Created PreferencesStore service with typed getters/setters for all four localStorage keys
  (skipCompleteConfirm, insightDismissed, onboardingCompleted, workspaceType)
  - Migrated StartScreenComponent — onboarding completion and workspace type
  - Migrated PersonalTaskCardComponent — skip complete confirmation preference
  - Migrated SettingsPageComponent — skip complete confirm and insight dismiss toggles
  - Migrated TaskListPageComponent — insight panel visibility and dismiss action
  - Marked A2 and A3 items as complete in docs/ARCHITECTURE.md (merged in prior commits, but checklist
  hadn't been updated)

  Testing

  Test Coverage

  - [ ]  Unit tests added/updated
  - [ ]  Integration tests added/updated
  - [X]  Manual testing completed

  Verification Steps

  1. pnpm --filter @yotara/frontend typecheck — passes
  2. pnpm --filter @yotara/frontend test — all 394 tests pass
  3. No runtime behavior changes — PreferencesStore is a thin wrapper over the same localStorage keys

  Checklist

  - [X]  Code follows the project style and conventions
  - [X]  I have performed a self-review of my own code
  - [ ]  I have commented my code, particularly in hard-to-understand areas
  - [X]  I have made corresponding changes to the documentation
  - [X]  My changes generate no new warnings or errors
  - [ ]  I have added tests that prove my fix is effective or that my feature works
  - [X]  New and existing unit tests pass locally with my changes
  - [X]  Any dependent changes have been merged and published
  - [X]  I have verified that this PR is against the correct branch (main)

  Additional Notes

  Test files still reference localStorage directly — since PreferencesStore is an injectable with no
  test-specific provider yet, updating the specs would require either mocking PreferencesStore or
  providing it in the test bed. That's better handled as a follow-up PR alongside the remaining Sprint 0
   items.