### PR TITLE
test(frontend): update specs to use PreferencesStore instead of direc…

### DIFF
--- a/apps/frontend/src/app/features/onboarding/pages/start-screen/start-screen.component.spec.ts
+++ b/apps/frontend/src/app/features/onboarding/pages/start-screen/start-screen.component.spec.ts
@@ -3,12 +3,14 @@ import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { StartScreenComponent } from './start-screen.component';
 import { AuthStateService } from '../../../../core/services/auth-state.service';
 import { LogService } from '../../../../core/services/log.service';
+import { PreferencesStore } from '../../../../core/services/preferences-store.service';
 
 describe('StartScreenComponent', () => {
   let fixture: ComponentFixture<StartScreenComponent>;
   let component: StartScreenComponent;
   let authState: jasmine.SpyObj<AuthStateService>;
   let router: jasmine.SpyObj<Router>;
+  let preferences: PreferencesStore;
   let activatedRoute: { snapshot: { queryParamMap: ReturnType<typeof convertToParamMap> } };
 
   beforeEach(async () => {
@@ -34,6 +36,7 @@ describe('StartScreenComponent', () => {
 
     fixture = TestBed.createComponent(StartScreenComponent);
     component = fixture.componentInstance;
+    preferences = TestBed.inject(PreferencesStore);
     fixture.detectChanges();
   });
 
@@ -87,8 +90,8 @@ describe('StartScreenComponent', () => {
     await component.continue();
 
     expect(authState.completeOnboarding).toHaveBeenCalledOnceWith('personal');
-    expect(localStorage.getItem('workspaceType')).toBe('personal');
-    expect(localStorage.getItem('onboardingCompleted')).toBe('true');
+    expect(preferences.getWorkspaceType()).toBe('personal');
+    expect(preferences.isOnboardingCompleted()).toBeTrue();
     expect(router.navigateByUrl).toHaveBeenCalledOnceWith('/inbox');
     expect(component.error()).toBe('');
     expect(component.loading()).toBeFalse();

--- a/apps/frontend/src/app/features/personal/components/personal-task-card.component.spec.ts
+++ b/apps/frontend/src/app/features/personal/components/personal-task-card.component.spec.ts
@@ -4,11 +4,13 @@ import { provideMarkdown } from 'ngx-markdown';
 import { PersonalTaskCardComponent } from './personal-task-card.component';
 import { Task } from '@yotara/shared';
 import { TaskService } from '../../../core/services/task.service';
+import { PreferencesStore } from '../../../core/services/preferences-store.service';
 
 describe('PersonalTaskCardComponent', () => {
   let component: PersonalTaskCardComponent;
   let fixture: ComponentFixture<PersonalTaskCardComponent>;
   let taskServiceSpy: jasmine.SpyObj<TaskService>;
+  let preferences: PreferencesStore;
 
   const mockTask: Task = {
     id: 'task-1',
@@ -36,6 +38,7 @@ describe('PersonalTaskCardComponent', () => {
 
     fixture = TestBed.createComponent(PersonalTaskCardComponent);
     component = fixture.componentInstance;
+    preferences = TestBed.inject(PreferencesStore);
   });
 
   describe('Component initialization', () => {
@@ -309,7 +312,7 @@ describe('PersonalTaskCardComponent', () => {
     });
 
     it('should skip the confirm dialog when localStorage skip flag is set', async () => {
-      localStorage.setItem('yotara_skipCompleteConfirm', 'true');
+      preferences.setSkipCompleteConfirm(true);
       component.task = mockTask;
       fixture.detectChanges();
 
@@ -322,7 +325,7 @@ describe('PersonalTaskCardComponent', () => {
     });
 
     it('should save skip preference to localStorage when checkbox is checked and confirmed', async () => {
-      localStorage.clear();
+      preferences.setSkipCompleteConfirm(false);
       component.task = mockTask;
       fixture.detectChanges();
 
@@ -340,12 +343,12 @@ describe('PersonalTaskCardComponent', () => {
       await confirmButton.nativeElement.click();
       fixture.detectChanges();
 
-      expect(localStorage.getItem('yotara_skipCompleteConfirm')).toBe('true');
+      expect(preferences.getSkipCompleteConfirm()).toBeTrue();
       expect(taskServiceSpy.updateTask).toHaveBeenCalledWith('task-1', { completed: true });
     });
 
     it('should not save skip preference when checkbox is unchecked and confirmed', async () => {
-      localStorage.clear();
+      preferences.setSkipCompleteConfirm(false);
       component.task = mockTask;
       fixture.detectChanges();
 
@@ -357,7 +360,7 @@ describe('PersonalTaskCardComponent', () => {
       await confirmButton.nativeElement.click();
       fixture.detectChanges();
 
-      expect(localStorage.getItem('yotara_skipCompleteConfirm')).toBeNull();
+      expect(preferences.getSkipCompleteConfirm()).toBeFalse();
     });
   });
 

--- a/apps/frontend/src/app/features/personal/pages/settings-page.component.spec.ts
+++ b/apps/frontend/src/app/features/personal/pages/settings-page.component.spec.ts
@@ -9,6 +9,7 @@ import { ProjectService } from '../../../core/services/project.service';
 import { LabelService } from '../../../core/services/label.service';
 import { AuthStateService } from '../../../core/services/auth-state.service';
 import { ThemeService } from '../../../core/services/theme.service';
+import { PreferencesStore } from '../../../core/services/preferences-store.service';
 
 const mockProjects: Project[] = [
   {
@@ -123,6 +124,7 @@ function findButtonByText(
 describe('SettingsPageComponent', () => {
   let fixture: ComponentFixture<SettingsPageComponent>;
   let comp: any;
+  let preferences: PreferencesStore;
 
   beforeEach(() => {
     localStorage.clear();
@@ -186,6 +188,7 @@ describe('SettingsPageComponent', () => {
 
     fixture = TestBed.createComponent(SettingsPageComponent);
     comp = fixture.componentInstance as any;
+    preferences = TestBed.inject(PreferencesStore);
     fixture.detectChanges();
   });
 
@@ -441,7 +444,7 @@ describe('SettingsPageComponent', () => {
     });
 
     it('reflects localStorage key when already set before component creation', () => {
-      localStorage.setItem('yotara_skipCompleteConfirm', 'true');
+      preferences.setSkipCompleteConfirm(true);
       fixture = TestBed.createComponent(SettingsPageComponent);
       comp = fixture.componentInstance as any;
       fixture.detectChanges();
@@ -453,12 +456,12 @@ describe('SettingsPageComponent', () => {
       getCompleteConfirmToggle()?.click();
       fixture.detectChanges();
 
-      expect(localStorage.getItem('yotara_skipCompleteConfirm')).toBe('true');
+      expect(preferences.getSkipCompleteConfirm()).toBeTrue();
       expect(getCompleteConfirmToggle()?.checked).toBeTrue();
     });
 
     it('removes from localStorage when toggled off', () => {
-      localStorage.setItem('yotara_skipCompleteConfirm', 'true');
+      preferences.setSkipCompleteConfirm(true);
       fixture = TestBed.createComponent(SettingsPageComponent);
       comp = fixture.componentInstance as any;
       fixture.detectChanges();
@@ -466,7 +469,7 @@ describe('SettingsPageComponent', () => {
       getCompleteConfirmToggle()?.click();
       fixture.detectChanges();
 
-      expect(localStorage.getItem('yotara_skipCompleteConfirm')).toBe('false');
+      expect(preferences.getSkipCompleteConfirm()).toBeFalse();
       expect(getCompleteConfirmToggle()?.checked).toBeFalse();
     });
   });


### PR DESCRIPTION


Description

  Consolidate scattered localStorage access into a single PreferencesStore service, replacing inline
  magic strings and direct localStorage calls across four components.

  Type of Change

  - [X]  Refactoring (code improvement with no functional change)

  Changes Made

  - Created PreferencesStore service with typed getters/setters for 4 preferences keys (skip complete
  confirm, insight dismissed, onboarding completed, workspace type)
  - Migrated start-screen.component.ts, personal-task-card.component.ts, settings-page.component.ts, and
   task-list-page.component.ts to use PreferencesStore
  - Removed inline SKIP_COMPLETE_KEY, INSIGHT_DISMISSED_KEY constants from individual components
  - Updated specs to inject PreferencesStore instead of reading/writing localStorage directly
  - Updated ARCHITECTURE.md to note the new service

  Testing

  - [X]  Unit tests added/updated
  - [X]  Manual testing completed

  All 393+ frontend tests pass. Confirmed preferences persist across page reloads via manual testing
  (skip-complete toggle, insight dismiss, onboarding flow).

  Checklist

  - [X]  Code follows the project style and conventions
  - [X]  I have performed a self-review of my own code
  - [X]  My changes generate no new warnings or errors
  - [X]  New and existing unit tests pass locally with my changes
  - [X]  I have verified that this PR is against the correct branch (main)

  Additional Notes

  The remaining direct localStorage usage in theme.service.ts and log.service.ts are intentionally not
  migrated — theme persistence and debug log buffering are distinct concerns that don't belong in a
  preferences store.