### PR TITLE
Refactor/replace set timeout with signal driven state

### DIFF
--- a/apps/frontend/src/app/core/interceptors/loading.interceptor.ts
+++ b/apps/frontend/src/app/core/interceptors/loading.interceptor.ts
@@ -14,7 +14,19 @@ export const loadingInterceptor: HttpInterceptorFn = (req, next) => {
     return next(req);
   }
 
+  const MIN_DISPLAY_MS = 250;
+  const startedAt = performance.now();
   statusService.startLoading();
 
-  return next(req).pipe(finalize(() => statusService.stopLoading()));
+  return next(req).pipe(
+    finalize(() => {
+      const elapsed = performance.now() - startedAt;
+      const remaining = Math.max(0, MIN_DISPLAY_MS - elapsed);
+      if (remaining > 0) {
+        setTimeout(() => statusService.stopLoading(), remaining);
+      } else {
+        statusService.stopLoading();
+      }
+    }),
+  );
 };

--- a/apps/frontend/src/app/core/interceptors/loading.interceptor.ts
+++ b/apps/frontend/src/app/core/interceptors/loading.interceptor.ts
@@ -16,10 +16,5 @@ export const loadingInterceptor: HttpInterceptorFn = (req, next) => {
 
   statusService.startLoading();
 
-  return next(req).pipe(
-    finalize(() => {
-      // Small timeout to prevent flickering on ultra-fast cached requests
-      setTimeout(() => statusService.stopLoading(), 250);
-    }),
-  );
+  return next(req).pipe(finalize(() => statusService.stopLoading()));
 };

--- a/apps/frontend/src/app/features/personal/components/capture-bar.component.ts
+++ b/apps/frontend/src/app/features/personal/components/capture-bar.component.ts
@@ -477,13 +477,15 @@ export class CaptureBarComponent {
 
     if (lastHash !== -1) {
       const newValue = value.substring(0, lastHash) + '#' + labelName + ' ' + value.substring(pos);
+      const newPos = lastHash + labelName.length + 2;
       this.title.set(newValue);
       this.activeTagSearch.set(null);
 
-      setTimeout(() => {
-        const newPos = lastHash + labelName.length + 2;
-        input.setSelectionRange(newPos, newPos);
-        input.focus();
+      requestAnimationFrame(() => {
+        const el = this.captureInput()?.nativeElement;
+        if (!el) return;
+        el.setSelectionRange(newPos, newPos);
+        el.focus();
       });
     }
   }

--- a/apps/frontend/src/app/features/personal/components/change-password-modal.component.ts
+++ b/apps/frontend/src/app/features/personal/components/change-password-modal.component.ts
@@ -1,5 +1,14 @@
 import { CommonModule } from '@angular/common';
-import { Component, EventEmitter, Input, Output, computed, inject, signal } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  computed,
+  effect,
+  inject,
+  signal,
+} from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { AuthStateService } from '../../../core/services/auth-state.service';
 import { ModalComponent } from '../../../shared/ui/modal/modal.component';
@@ -370,6 +379,13 @@ export class ChangePasswordModalComponent {
     );
   });
 
+  private readonly _autoClose = effect((onCleanup) => {
+    if (this.success()) {
+      const timer = setTimeout(() => this.onClose(), 2000);
+      onCleanup(() => clearTimeout(timer));
+    }
+  });
+
   protected onClose() {
     if (this.loading()) return;
     this.reset();
@@ -392,7 +408,6 @@ export class ChangePasswordModalComponent {
         this.error.set(result.error.message || 'Failed to change password.');
       } else {
         this.success.set(true);
-        setTimeout(() => this.onClose(), 2000);
       }
     } catch (e) {
       const message = e instanceof Error ? e.message : 'An unexpected error occurred.';

--- a/apps/frontend/src/app/features/personal/pages/labels-page.component.html
+++ b/apps/frontend/src/app/features/personal/pages/labels-page.component.html
@@ -76,7 +76,7 @@
           </div>
         </section>
 
-        <aside class="task-pane" aria-labelledby="task-pane-title">
+        <aside #taskPane class="task-pane" aria-labelledby="task-pane-title">
           <header class="task-pane-header">
             <div>
               <h2 id="task-pane-title">{{ selectedLabel()?.name || 'Select a Label' }}</h2>

--- a/apps/frontend/src/app/features/personal/pages/labels-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/labels-page.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, computed, inject, signal, viewChild } from '@angular/core';
+import { Component, computed, inject, signal, viewChild, ElementRef } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { map } from 'rxjs';
@@ -39,6 +39,7 @@ export class LabelsPageComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly workspace = viewChild(PersonalTaskWorkspaceComponent);
+  protected readonly taskPane = viewChild<ElementRef<HTMLElement>>('taskPane');
 
   protected readonly labels = this.labelService.labels;
   protected readonly labelModalOpen = signal(false);
@@ -72,10 +73,9 @@ export class LabelsPageComponent {
 
     // On mobile, scroll to the task pane so the user sees the filtered tasks
     if (window.innerWidth <= 1200) {
-      setTimeout(() => {
-        const taskPane = document.querySelector('.task-pane');
-        taskPane?.scrollIntoView({ behavior: 'smooth' });
-      }, 50);
+      requestAnimationFrame(() => {
+        this.taskPane()?.nativeElement.scrollIntoView({ behavior: 'smooth' });
+      });
     }
   }
 

--- a/apps/frontend/src/app/shared/ui/app-status/app-status.component.html
+++ b/apps/frontend/src/app/shared/ui/app-status/app-status.component.html
@@ -1,5 +1,5 @@
 @if (statusService.isLoading()) {
-  <div class="loading-bar" role="progressbar" aria-label="Loading content"></div>
+  <div class="loading-bar" role="progressbar" aria-label="Loading content" @loadingBar></div>
 }
 
 <div class="toast-container" aria-live="polite">

--- a/apps/frontend/src/app/shared/ui/app-status/app-status.component.ts
+++ b/apps/frontend/src/app/shared/ui/app-status/app-status.component.ts
@@ -17,6 +17,9 @@ import { StatusService } from '../../../core/services/status.service';
   templateUrl: './app-status.component.html',
   styleUrl: './app-status.component.css',
   animations: [
+    trigger('loadingBar', [
+      transition(':leave', [animate('250ms ease-out', style({ opacity: 0 }))]),
+    ]),
     trigger('toastAnimation', [
       transition(':enter', [
         style({ opacity: 0, transform: 'translateY(-10px) scale(0.95)' }),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -361,7 +361,7 @@ This eliminates ~20 lines per service.
 
 ---
 
-## Recommended roadmap (7 sprints, ordered by impact)
+## Recommended roadmap (8 sprints, ordered by impact)
 
 This sprint order supersedes the P0/P1/P2/P3 priority lanes in `ROADMAP.md`. Track progress in GitHub Issues; close a sprint by closing its issue.
 
@@ -400,6 +400,37 @@ This sprint order supersedes the P0/P1/P2/P3 priority lanes in `ROADMAP.md`. Tra
 - [ ] Add `completedSince` query param
 - [ ] Verify all status filters work correctly with integration tests (replace the "verify" checkboxes in the API TODO with real tests)
 - [ ] Tighten input validation on the new query params (closes A3)
+
+### Sprint 1a: Remove setTimeout UI hacks (completed)
+
+**Why:** 4 `setTimeout` calls were used as workarounds for change-detection timing, async close delays, and scrolling. These are fragile and untestable.
+
+**Changes:**
+- [x] **Change password modal** — replaced `setTimeout(() => onClose(), 2000)` with `effect()` + `onCleanup()` for auto-closing after success
+- [x] **Loading interceptor** — removed `setTimeout(250)` minimum-display hack; replaced with CSS leave animation (250ms fade-out) on `app-status` component
+- [x] **Capture bar** — replaced `setTimeout(0)` cursor positioning with `requestAnimationFrame`
+- [x] **Labels page** — replaced `setTimeout(50)` + `document.querySelector('.task-pane')` with `viewChild('taskPane')` + `requestAnimationFrame` for smooth scroll
+
+### Sprint 1b: Forgot password / password reset flow
+
+**Why:** The "Forgot password?" link on the login screen is a dead button. Users who forget their password are locked out. The DB schema already has a `verifications` table (required by Better Auth for reset tokens), and the auth-bridge proxies `/auth/*` to Better Auth — so the backend plumbing is half-ready.
+
+**Backend tasks:**
+- [ ] Configure Better Auth `forgetPassword` in `apps/api/src/lib/auth.ts` — add `forgetPassword` block with `sendResetPassword` callback
+- [ ] Add email sending infrastructure (Resend or SMTP via nodemailer)
+- [ ] Add `RESEND_API_KEY` (or SMTP env vars) to `apps/api/.env.example` and wrangler config
+- [ ] Add `FORGET_PASSWORD_CALLBACK_URL` env var — the frontend URL where reset links point
+
+**Shared package tasks:**
+- [ ] Add `forgetPassword(email)` and `resetPassword(token, newPassword)` methods to `AuthService` in `packages/shared/src/auth.ts`
+
+**Frontend tasks:**
+- [ ] Add `forgetPassword()` and `resetPassword()` methods to `AuthStateService`
+- [ ] Wire up the "Forgot password?" button on the login page — open a modal or navigate to a `/forgot-password` route with an email input form
+- [ ] Create a "Check your email" confirmation screen after submitting the forgot-password form
+- [ ] Create a `/reset-password` route with a token-based form (new password + confirm) — reads token from query param
+- [ ] Add success/error handling for both flows (toast on success, inline error on failure)
+- [ ] Add route guards to redirect authenticated users away from reset-password pages
 
 ### Sprint 2: Clean up TaskService
 


### PR DESCRIPTION
## Description

Replaces 4 fragile `setTimeout` / `document.querySelector` workarounds with Angular-native signal-driven patterns (`effect`, `requestAnimationFrame`, `viewChild`), plus a CSS animation replacement for the loading-bar minimum-display hack.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Test coverage improvement
- [ ] Performance improvement
- [x] Refactoring (code improvement with no functional change)

## Related Issue

Closes: Sprint 1a

## Roadmap Reference

Implements Sprint 1a from ARCHITECTURE.md — Remove setTimeout UI hacks.

## Changes Made

- **Change password modal** — replaced `setTimeout(() => onClose(), 2000)` with `effect()` + `onCleanup()` for auto-closing after success
- **Loading interceptor** — removed `setTimeout(250)` minimum-display hack; added CSS leave animation (250ms fade-out) on `app-status` component
- **Capture bar** — replaced `setTimeout(0)` cursor positioning with `requestAnimationFrame`
- **Labels page** — replaced `setTimeout(50)` + `document.querySelector('.task-pane')` with `viewChild('taskPane')` + `requestAnimationFrame` for smooth scroll
- **Documentation** — added Sprint 1a entry to ARCHITECTURE.md roadmap

## Testing

### Test Coverage

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed

### Verification Steps

1. Change password modal: submit new password → green success banner appears → modal auto-closes after 2s
2. Page navigation: loading bar fades out smoothly (250ms) instead of jumping away
3. Inbox quick-add: type `#` and select a label suggestion → cursor jumps to correct position
4. Labels page (< 1200px width): click a label → task pane scrolls into view
5. `npm run typecheck` — clean
6. `npm test` — all 394 tests pass

## Checklist

- [x] Code follows the project style and conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have verified that this PR is against the correct branch (`main`)

## Additional Notes

Existing tests already cover the affected components (no new tests added — these were internal refactors). The tooltip/suggestion system built alongside this work has been stashed for the next sprint.