### PR TITLE
docs(ARCHITECTURE): mark Sprint 0 items complete, add Sprint 1-6 issues

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -372,8 +372,8 @@ This sprint order supersedes the P0/P1/P2/P3 priority lanes in `ROADMAP.md`. Tra
 - [x] Migrate 26 `console.error` sites to `LogService`; add ESLint `no-console` rule
 - [x] Replace `throw new Error('string')` in services with typed errors; add Fastify `setErrorHandler`
 - [x] Fix `as any` on `request.query.status` at the trust boundary
-- [ ] Add `PreferencesStore` (or extend `ThemeService`'s pattern) and migrate the three `localStorage` magic-string keys
-- [ ] Replace the 4 problematic `setTimeout` UI hacks with signal-driven state
+- [x] Add `PreferencesStore` (or extend `ThemeService`'s pattern) and migrate the three `localStorage` magic-string keys
+- [x] Replace the 4 problematic `setTimeout` UI hacks with signal-driven state
 - [ ] Fix the UTC vs local timezone bug; add `?tz=` to per-view queries
 - [x] Add a `no-restricted-syntax` ESLint rule against `as any` (warn-only, applied to all `.ts` files)
 - [x] Add "Superseded" notices to `ROADMAP.md`, `docs/project-plan.md`, `apps/frontend/TODO.md`, and `apps/api/TODO.md`


### PR DESCRIPTION
- Marked PreferencesStore and setTimeout hacks as done in Sprint 0
- Created 10 sprint tracking issues (#170-#179)
- Created 9 good-first-issue items (#180-#188)
- Closed #60 (error handling strategy - core work complete)
