### PR TITLE
chore: add code coverage with c8 and Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,32 @@ jobs:
       - name: Test
         run: pnpm test
 
+  coverage:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Collect coverage
+        run: pnpm test:coverage
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          directory: .
+          fail_ci_if_error: false
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+coverage
 out-tsc
 package-lock.json
 apps/api/data/*.db

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 <br />
 
 <a href="https://github.com/apauldev/Yotara/actions"><img src="https://img.shields.io/github/actions/workflow/status/apauldev/Yotara/ci.yml?branch=main&style=for-the-badge&logo=githubactions&logoColor=white&label=CI&color=3E7B63" alt="CI" /></a>
+<a href="https://codecov.io/gh/apauldev/Yotara"><img src="https://img.shields.io/codecov/c/github/apauldev/Yotara?style=for-the-badge&logo=codecov&logoColor=white&color=7BA58D" alt="Coverage" /></a>
 <a href="https://github.com/apauldev/Yotara/releases"><img src="https://img.shields.io/github/v/release/apauldev/Yotara?style=for-the-badge&logo=github&color=173F35" alt="Release" /></a>
 <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-7BA58D?style=for-the-badge&logo=opensourceinitiative&logoColor=white" alt="License" /></a>
 <a href="https://github.com/apauldev/Yotara/security"><img src="https://img.shields.io/badge/security-CodeQL-1C5D4B?style=for-the-badge&logo=github&logoColor=white" alt="Security" /></a>

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,6 +10,7 @@
     "lint": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test src/**/*.test.ts",
+    "test:coverage": "c8 --reporter=lcov --reporter=text tsx --test src/**/*.test.ts",
     "docs:check": "tsx --test src/docs/openapi.test.ts",
     "docs:export": "tsx src/scripts/export-openapi.ts",
     "db:generate": "drizzle-kit generate",
@@ -31,6 +32,7 @@
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22",
+    "c8": "^11.0.0",
     "drizzle-kit": "^0.31.9",
     "rimraf": "^6.0.1",
     "tsx": "^4.21.0",

--- a/apps/frontend/angular.json
+++ b/apps/frontend/angular.json
@@ -71,6 +71,7 @@
           "options": {
             "polyfills": ["zone.js", "zone.js/testing"],
             "tsConfig": "tsconfig.spec.json",
+
             "assets": [
               {
                 "glob": "**/*",
@@ -78,7 +79,8 @@
               }
             ],
             "styles": ["src/styles.css"],
-            "scripts": []
+            "scripts": [],
+            "karmaConfig": "karma.conf.js"
           }
         }
       }

--- a/apps/frontend/karma.conf.js
+++ b/apps/frontend/karma.conf.js
@@ -1,0 +1,31 @@
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma'),
+    ],
+    client: {
+      jasmine: {},
+    },
+    jasmineHtmlReporter: {
+      suppressAll: true,
+    },
+    reporters: ['progress', 'kjhtml'],
+    browsers: ['Chrome'],
+    restartOnFileChange: true,
+    coverageReporter: {
+      dir: require('path').join(__dirname, './coverage/frontend'),
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'lcovonly', file: 'lcov.info' },
+        { type: 'text-summary' },
+      ],
+    },
+  });
+};

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -8,6 +8,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test --watch=false --browsers ChromeHeadless",
+    "test:coverage": "ng test --watch=false --browsers ChromeHeadless --code-coverage --karma-config karma.conf.js",
     "lint": "tsc -p tsconfig.app.json --noEmit && stylelint \"src/**/*.css\"",
     "lint:css": "stylelint \"src/**/*.css\"",
     "lint:css:fix": "stylelint \"src/**/*.css\" --fix",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,7 @@ export default [
       '**/*.config.mjs',
       'scripts/**',
       'tailwind.config.js',
+      '**/karma.conf.js',
     ],
   },
   js.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "format:check": "prettier --check .",
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r test",
+    "test:coverage": "pnpm -r test:coverage",
     "prepare": "husky install && pnpm version:gen",
     "dev:frontend": "pnpm --filter @yotara/frontend dev",
     "dev:api": "pnpm --filter @yotara/api dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@types/node':
         specifier: ^22
         version: 22.19.13
+      c8:
+        specifier: ^11.0.0
+        version: 11.0.0
       drizzle-kit:
         specifier: ^0.31.9
         version: 0.31.9
@@ -1074,6 +1077,10 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@better-auth/core@1.5.4':
     resolution: {integrity: sha512-k5AdwPRQETZn0vdB60EB9CDxxfllpJXKqVxTjyXIUSRz7delNGlU0cR/iRP3VfVJwvYR1NbekphBDNo+KGoEzQ==}
@@ -4120,6 +4127,16 @@ packages:
       magicast: ^0.3.5
     peerDependenciesMeta:
       magicast:
+        optional: true
+
+  c8@11.0.0:
+    resolution: {integrity: sha512-e/uRViGHSVIJv7zsaDKM7VRn2390TgHXqUSvYwPHBQaU6L7E9L0n9JbdkwdYPvshDT0KymBmmlwSpms3yBaMNg==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+    peerDependencies:
+      monocart-coverage-reports: ^2
+    peerDependenciesMeta:
+      monocart-coverage-reports:
         optional: true
 
   cacache@20.0.3:
@@ -8492,6 +8509,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  test-exclude@8.0.0:
+    resolution: {integrity: sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==}
+    engines: {node: 20 || >=22}
+
   text-extensions@1.9.0:
     resolution: {integrity: sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==}
     engines: {node: '>=0.10'}
@@ -8769,6 +8790,10 @@ packages:
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
+
+  v8-to-istanbul@9.3.0:
+    resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
+    engines: {node: '>=10.12.0'}
 
   valibot@1.2.0:
     resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
@@ -10287,6 +10312,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)':
     dependencies:
@@ -13648,6 +13675,20 @@ snapshots:
       perfect-debounce: 1.0.0
       pkg-types: 2.3.1
       rc9: 2.1.2
+
+  c8@11.0.0:
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@istanbuljs/schema': 0.1.3
+      find-up: 5.0.0
+      foreground-child: 3.3.1
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      test-exclude: 8.0.0
+      v8-to-istanbul: 9.3.0
+      yargs: 17.7.2
+      yargs-parser: 21.1.1
 
   cacache@20.0.3:
     dependencies:
@@ -18401,6 +18442,12 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
+  test-exclude@8.0.0:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 13.0.6
+      minimatch: 10.2.4
+
   text-extensions@1.9.0: {}
 
   thenify-all@1.6.0:
@@ -18639,6 +18686,12 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@8.3.2: {}
+
+  v8-to-istanbul@9.3.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/istanbul-lib-coverage': 2.0.6
+      convert-source-map: 2.0.0
 
   valibot@1.2.0(typescript@5.9.3):
     optionalDependencies:


### PR DESCRIPTION
Description
Adds code coverage collection and reporting to CI without blocking builds. Uses Node 22's built-in coverage (via c8) for the API and karma-coverage for the frontend. Uploads to Codecov, which posts PR comments with diff coverage and provides the README badge.
Type of Change
- Test coverage improvement
Changes Made
- Added test:coverage script to API (c8 --reporter=lcov --reporter=text), frontend (karma-coverage with lcovonly reporter), and root workspace
- Created apps/frontend/karma.conf.js with lcov output alongside default HTML reporter
- Added coverage job to CI with continue-on-error: true -- collects coverage and uploads to Codecov but never blocks the PR
- Added coverage/ to .gitignore
- Added Codecov badge to README header
- Installed c8 devDependency for API
Testing
- pnpm test still passes (400 frontend, API tests)
- pnpm test:coverage generates lcov.info for both apps
- Regular test command unchanged -- coverage only on explicit test:coverage run