### PR TITLE
refactor: remove expand loop, stale signals, and client-side date helpers from TaskService

### DIFF
--- a/apps/api/src/lib/timezone.test.ts
+++ b/apps/api/src/lib/timezone.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { todayInTimezone, startOfDayInUtc } from './timezone.js';
+
+describe('todayInTimezone', () => {
+  it('returns UTC date when tz is undefined', () => {
+    const result = todayInTimezone(undefined);
+    assert.match(result, /^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('returns UTC date when tz is empty string', () => {
+    const result = todayInTimezone('');
+    assert.match(result, /^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('returns date in the specified timezone', () => {
+    const result = todayInTimezone('UTC');
+    assert.match(result, /^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('falls back to UTC for invalid timezone', () => {
+    const result = todayInTimezone('Not/A/Timezone');
+    assert.match(result, /^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe('startOfDayInUtc', () => {
+  it('returns UTC midnight ISO for a valid date with UTC tz', () => {
+    const result = startOfDayInUtc('2026-06-18', 'UTC');
+    assert.ok(result.startsWith('2026-06-18T00:00:00'));
+    assert.ok(result.endsWith('Z'));
+  });
+
+  it('converts timezone-aware start of day to UTC', () => {
+    const result = startOfDayInUtc('2026-06-18', 'America/New_York');
+    assert.ok(result.startsWith('2026-06-18T04:00:00'));
+    assert.ok(result.endsWith('Z'));
+  });
+
+  it('falls back to UTC for invalid timezone', () => {
+    const result = startOfDayInUtc('2026-06-18', 'Invalid/Zone');
+    assert.ok(result.includes('2026-06-18'));
+  });
+
+  it('falls back to UTC when tz is undefined', () => {
+    const result = startOfDayInUtc('2026-06-18', undefined);
+    assert.ok(result.includes('2026-06-18'));
+  });
+});

--- a/apps/api/src/lib/timezone.ts
+++ b/apps/api/src/lib/timezone.ts
@@ -1,0 +1,25 @@
+import { DateTime } from 'luxon';
+
+/**
+ * Compute today's date (YYYY-MM-DD) in a given IANA timezone.
+ * Falls back to UTC if the timezone is invalid or undefined.
+ */
+export function todayInTimezone(tz?: string): string {
+  if (!tz) {
+    return DateTime.now().setZone('UTC').toFormat('yyyy-MM-dd');
+  }
+  const dt = DateTime.now().setZone(tz);
+  const zone = dt.isValid ? tz : 'UTC';
+  return DateTime.now().setZone(zone).toFormat('yyyy-MM-dd');
+}
+
+/**
+ * Compute the start of a given date (YYYY-MM-DD) in the specified timezone
+ * and return it as a UTC ISO timestamp (e.g. 2026-06-18T04:00:00.000Z).
+ * Falls back to UTC if the timezone is invalid or undefined.
+ */
+export function startOfDayInUtc(dateStr: string, tz?: string): string {
+  const zone = tz && DateTime.now().setZone(tz).isValid ? tz : 'UTC';
+  const dt = DateTime.fromFormat(dateStr, 'yyyy-MM-dd', { zone }).startOf('day');
+  return dt.toUTC().toISO() || dt.toUTC().toString();
+}

--- a/apps/api/src/routes/tasks.test.ts
+++ b/apps/api/src/routes/tasks.test.ts
@@ -682,3 +682,35 @@ test('tasks timezone-aware queries (overdue, view, completedSince)', async () =>
     await ctx.cleanup();
   }
 });
+
+test('tasks export endpoint returns all tasks without pagination limit', async () => {
+  const ctx = await createAuthedApp();
+
+  try {
+    const cookie = await signUpAndGetCookie(`export-owner-${randomUUID()}@example.com`);
+
+    // Create 3 tasks
+    for (let i = 0; i < 3; i++) {
+      const res = await ctx.app.inject({
+        method: 'POST',
+        url: '/tasks',
+        headers: { cookie },
+        payload: { title: `Export task ${i}` },
+      });
+      assert.equal(res.statusCode, 201);
+    }
+
+    // Request with export=true should return all tasks
+    const exportRes = await ctx.app.inject({
+      method: 'GET',
+      url: '/tasks?export=true',
+      headers: { cookie },
+    });
+    assert.equal(exportRes.statusCode, 200);
+    const exportData = exportRes.json();
+    assert.equal(exportData.data.length, 3);
+    assert.equal(exportData.meta.total, 3);
+  } finally {
+    await ctx.cleanup();
+  }
+});

--- a/apps/api/src/routes/tasks.test.ts
+++ b/apps/api/src/routes/tasks.test.ts
@@ -553,6 +553,15 @@ test('tasks timezone-aware queries (overdue, view, completedSince)', async () =>
     });
     assert.equal(tOverdue.statusCode, 201);
 
+    // Create overdue task with status='today' (should not appear in view=today)
+    const tOverdueToday = await ctx.app.inject({
+      method: 'POST',
+      url: '/tasks',
+      headers: { cookie },
+      payload: { title: 'Overdue today-status task', status: 'today', dueDate: yesterdayStr },
+    });
+    assert.equal(tOverdueToday.statusCode, 201);
+
     // Create today task
     const tToday = await ctx.app.inject({
       method: 'POST',
@@ -588,8 +597,9 @@ test('tasks timezone-aware queries (overdue, view, completedSince)', async () =>
     });
     assert.equal(overdueRes.statusCode, 200);
     const overdueTasksList = overdueRes.json().data;
-    assert.equal(overdueTasksList.length, 1);
-    assert.equal(overdueTasksList[0].title, 'Overdue task');
+    assert.equal(overdueTasksList.length, 2);
+    assert.ok(overdueTasksList.some((t: any) => t.title === 'Overdue task'));
+    assert.ok(overdueTasksList.some((t: any) => t.title === 'Overdue today-status task'));
 
     // 2. Test view=today
     const todayRes = await ctx.app.inject({
@@ -603,6 +613,8 @@ test('tasks timezone-aware queries (overdue, view, completedSince)', async () =>
     assert.ok(todayTasksList.some((t: any) => t.title === 'Today task'));
     assert.ok(!todayTasksList.some((t: any) => t.title === 'Upcoming task'));
     assert.ok(!todayTasksList.some((t: any) => t.title === 'Overdue task'));
+    // Overdue task with status='today' must not appear in view=today
+    assert.ok(!todayTasksList.some((t: any) => t.title === 'Overdue today-status task'));
 
     // 3. Test view=upcoming
     const upcomingRes = await ctx.app.inject({

--- a/apps/api/src/routes/tasks.test.ts
+++ b/apps/api/src/routes/tasks.test.ts
@@ -6,6 +6,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { eq } from 'drizzle-orm';
 import { tasks } from '../db/schema.js';
+import { DateTime } from 'luxon';
 
 async function createAuthedApp() {
   const dbFile = join(tmpdir(), `yotara-test-${randomUUID()}.db`);
@@ -527,6 +528,133 @@ test('tasks support owned project assignment and reject foreign project referenc
     });
     assert.equal(listResponse.statusCode, 200);
     assert.equal(listResponse.json().data[0].projectId, undefined);
+  } finally {
+    await ctx.cleanup();
+  }
+});
+
+test('tasks timezone-aware queries (overdue, view, completedSince)', async () => {
+  const ctx = await createAuthedApp();
+
+  try {
+    const cookie = await signUpAndGetCookie(`tz-owner-${randomUUID()}@example.com`);
+
+    const todayUtc = DateTime.now().setZone('UTC');
+    const todayStr = todayUtc.toFormat('yyyy-MM-dd');
+    const yesterdayStr = todayUtc.minus({ days: 1 }).toFormat('yyyy-MM-dd');
+    const tomorrowStr = todayUtc.plus({ days: 1 }).toFormat('yyyy-MM-dd');
+
+    // Create overdue task
+    const tOverdue = await ctx.app.inject({
+      method: 'POST',
+      url: '/tasks',
+      headers: { cookie },
+      payload: { title: 'Overdue task', dueDate: yesterdayStr },
+    });
+    assert.equal(tOverdue.statusCode, 201);
+
+    // Create today task
+    const tToday = await ctx.app.inject({
+      method: 'POST',
+      url: '/tasks',
+      headers: { cookie },
+      payload: { title: 'Today task', dueDate: todayStr },
+    });
+    assert.equal(tToday.statusCode, 201);
+
+    // Create upcoming task
+    const tUpcoming = await ctx.app.inject({
+      method: 'POST',
+      url: '/tasks',
+      headers: { cookie },
+      payload: { title: 'Upcoming task', dueDate: tomorrowStr },
+    });
+    assert.equal(tUpcoming.statusCode, 201);
+
+    // Create inbox task without due date
+    const tInboxNoDate = await ctx.app.inject({
+      method: 'POST',
+      url: '/tasks',
+      headers: { cookie },
+      payload: { title: 'Inbox task no date', status: 'inbox' },
+    });
+    assert.equal(tInboxNoDate.statusCode, 201);
+
+    // 1. Test overdue filter
+    const overdueRes = await ctx.app.inject({
+      method: 'GET',
+      url: `/tasks?overdue=true&tz=UTC`,
+      headers: { cookie },
+    });
+    assert.equal(overdueRes.statusCode, 200);
+    const overdueTasksList = overdueRes.json().data;
+    assert.equal(overdueTasksList.length, 1);
+    assert.equal(overdueTasksList[0].title, 'Overdue task');
+
+    // 2. Test view=today
+    const todayRes = await ctx.app.inject({
+      method: 'GET',
+      url: `/tasks?view=today&tz=UTC`,
+      headers: { cookie },
+    });
+    assert.equal(todayRes.statusCode, 200);
+    const todayTasksList = todayRes.json().data;
+    // Should return Today task (based on dueDate = today)
+    assert.ok(todayTasksList.some((t: any) => t.title === 'Today task'));
+    assert.ok(!todayTasksList.some((t: any) => t.title === 'Upcoming task'));
+    assert.ok(!todayTasksList.some((t: any) => t.title === 'Overdue task'));
+
+    // 3. Test view=upcoming
+    const upcomingRes = await ctx.app.inject({
+      method: 'GET',
+      url: `/tasks?view=upcoming&tz=UTC`,
+      headers: { cookie },
+    });
+    assert.equal(upcomingRes.statusCode, 200);
+    const upcomingTasksList = upcomingRes.json().data;
+    assert.ok(upcomingTasksList.some((t: any) => t.title === 'Upcoming task'));
+    assert.ok(!upcomingTasksList.some((t: any) => t.title === 'Today task'));
+
+    // 4. Test view=inbox (should return status='inbox' with no date OR overdue tasks)
+    const inboxRes = await ctx.app.inject({
+      method: 'GET',
+      url: `/tasks?view=inbox&tz=UTC`,
+      headers: { cookie },
+    });
+    assert.equal(inboxRes.statusCode, 200);
+    const inboxTasksList = inboxRes.json().data;
+    assert.ok(inboxTasksList.some((t: any) => t.title === 'Inbox task no date'));
+    assert.ok(inboxTasksList.some((t: any) => t.title === 'Overdue task'));
+    assert.ok(!inboxTasksList.some((t: any) => t.title === 'Today task'));
+    assert.ok(!inboxTasksList.some((t: any) => t.title === 'Upcoming task'));
+
+    // 5. Test completedSince filter
+    // Complete the today task
+    const completeRes = await ctx.app.inject({
+      method: 'PATCH',
+      url: `/tasks/${tToday.json().id}`,
+      headers: { cookie },
+      payload: { completed: true },
+    });
+    assert.equal(completeRes.statusCode, 200);
+
+    const completedRes = await ctx.app.inject({
+      method: 'GET',
+      url: `/tasks?completedSince=${todayStr}&tz=UTC`,
+      headers: { cookie },
+    });
+    assert.equal(completedRes.statusCode, 200);
+    const completedTasksList = completedRes.json().data;
+    assert.ok(completedTasksList.some((t: any) => t.title === 'Today task'));
+
+    // completedSince tomorrow should NOT return it
+    const completedResTomorrow = await ctx.app.inject({
+      method: 'GET',
+      url: `/tasks?completedSince=${tomorrowStr}&tz=UTC`,
+      headers: { cookie },
+    });
+    assert.equal(completedResTomorrow.statusCode, 200);
+    assert.equal(completedResTomorrow.json().data.length, 0);
   } finally {
     await ctx.cleanup();
   }

--- a/apps/api/src/routes/tasks.test.ts
+++ b/apps/api/src/routes/tasks.test.ts
@@ -580,6 +580,15 @@ test('tasks timezone-aware queries (overdue, view, completedSince)', async () =>
     });
     assert.equal(tUpcoming.statusCode, 201);
 
+    // Create upcoming task with dueDate=today (should not appear in view=upcoming)
+    const tUpcomingToday = await ctx.app.inject({
+      method: 'POST',
+      url: '/tasks',
+      headers: { cookie },
+      payload: { title: 'Upcoming today-due task', status: 'upcoming', dueDate: todayStr },
+    });
+    assert.equal(tUpcomingToday.statusCode, 201);
+
     // Create inbox task without due date
     const tInboxNoDate = await ctx.app.inject({
       method: 'POST',
@@ -626,6 +635,8 @@ test('tasks timezone-aware queries (overdue, view, completedSince)', async () =>
     const upcomingTasksList = upcomingRes.json().data;
     assert.ok(upcomingTasksList.some((t: any) => t.title === 'Upcoming task'));
     assert.ok(!upcomingTasksList.some((t: any) => t.title === 'Today task'));
+    // Upcoming task with dueDate=today must not appear in view=upcoming
+    assert.ok(!upcomingTasksList.some((t: any) => t.title === 'Upcoming today-due task'));
 
     // 4. Test view=inbox (should return status='inbox' with no date OR overdue tasks)
     const inboxRes = await ctx.app.inject({

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -66,7 +66,7 @@ export default async function taskRoutes(fastify: FastifyInstance) {
           type: 'object',
           properties: {
             page: { type: 'integer', minimum: 1, default: 1 },
-            pageSize: { type: 'integer', minimum: 1, maximum: 100, default: 50 },
+            pageSize: { type: 'integer', minimum: 1, maximum: 1000, default: 50 },
             includeSubtasks: { type: 'boolean', default: false },
             parentId: { type: 'string' },
             export: { type: 'boolean', default: false },
@@ -95,7 +95,7 @@ export default async function taskRoutes(fastify: FastifyInstance) {
       const userId = request.userId;
       const isExport = request.query.export === true;
       const page = Math.max(1, request.query.page ?? 1);
-      const pageSize = isExport ? 10000 : Math.min(100, Math.max(1, request.query.pageSize ?? 50));
+      const pageSize = isExport ? 10000 : Math.min(1000, Math.max(1, request.query.pageSize ?? 50));
       const includeSubtasks = isExport ? true : String(request.query.includeSubtasks) === 'true';
       const parentId = request.query.parentId;
 

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -50,6 +50,9 @@ export default async function taskRoutes(fastify: FastifyInstance) {
       status?: TaskStatus;
       completed?: string;
       overdue?: string;
+      tz?: string;
+      view?: 'today' | 'inbox' | 'upcoming';
+      completedSince?: string;
     };
     Reply: PaginatedResponse<Task[]> | { message: string };
   }>(
@@ -70,6 +73,9 @@ export default async function taskRoutes(fastify: FastifyInstance) {
             status: { type: 'string', enum: ['inbox', 'today', 'upcoming', 'done', 'archived'] },
             completed: { type: 'string', enum: ['true', 'false'] },
             overdue: { type: 'string', enum: ['true', 'false'] },
+            tz: { type: 'string' },
+            view: { type: 'string', enum: ['today', 'inbox', 'upcoming'] },
+            completedSince: { type: 'string' },
           },
         },
         response: {
@@ -102,6 +108,9 @@ export default async function taskRoutes(fastify: FastifyInstance) {
               ? false
               : undefined,
         overdue: request.query.overdue === 'true',
+        tz: request.query.tz,
+        view: request.query.view,
+        completedSince: request.query.completedSince,
       };
 
       return listTasksForOwner(userId, page, pageSize, includeSubtasks, parentId, filters);

--- a/apps/api/src/services/task-service.ts
+++ b/apps/api/src/services/task-service.ts
@@ -184,7 +184,13 @@ export async function listTasksForOwner(
           whereClause = and(
             whereClause,
             eq(tasks.completed, false),
-            or(eq(tasks.status, 'upcoming'), sql`date(${tasks.dueDate}) > ${today}`),
+            or(
+              and(
+                eq(tasks.status, 'upcoming'),
+                or(isNull(tasks.dueDate), sql`date(${tasks.dueDate}) > ${today}`),
+              ),
+              sql`date(${tasks.dueDate}) > ${today}`,
+            ),
           );
           break;
       }

--- a/apps/api/src/services/task-service.ts
+++ b/apps/api/src/services/task-service.ts
@@ -161,7 +161,13 @@ export async function listTasksForOwner(
           whereClause = and(
             whereClause,
             eq(tasks.completed, false),
-            or(eq(tasks.status, 'today'), sql`date(${tasks.dueDate}) = ${today}`),
+            or(
+              and(
+                eq(tasks.status, 'today'),
+                or(isNull(tasks.dueDate), sql`date(${tasks.dueDate}) >= ${today}`),
+              ),
+              sql`date(${tasks.dueDate}) = ${today}`,
+            ),
           );
           break;
         case 'inbox':

--- a/apps/api/src/services/task-service.ts
+++ b/apps/api/src/services/task-service.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { and, asc, eq, isNotNull, isNull, sql } from 'drizzle-orm';
+import { and, asc, eq, isNotNull, isNull, or, sql } from 'drizzle-orm';
 import type {
   CreateTaskDto,
   PaginatedResponse,
@@ -13,6 +13,7 @@ import { db } from '../db/client.js';
 import { tasks, users } from '../db/schema.js';
 import { DateTime } from 'luxon';
 import { nowIsoTimestamp } from '../lib/timestamps.js';
+import { todayInTimezone, startOfDayInUtc } from '../lib/timezone.js';
 import { AppError, BadRequestError, NotFoundError } from '../lib/app-error.js';
 import { getTaskLabels, syncTaskLabels } from './label-service.js';
 import { getDefaultProjectForOwner } from './project-service.js';
@@ -109,6 +110,9 @@ export interface TaskFilters {
   completed?: boolean;
   overdue?: boolean; // dueDate < now AND completed = false
   hasDueDate?: boolean;
+  tz?: string;
+  view?: 'today' | 'inbox' | 'upcoming';
+  completedSince?: string;
 }
 
 export async function listTasksForOwner(
@@ -143,10 +147,48 @@ export async function listTasksForOwner(
         : and(whereClause, isNull(tasks.dueDate));
     }
     if (filters.overdue) {
+      const today = todayInTimezone(filters.tz);
       whereClause = and(
         whereClause,
         eq(tasks.completed, false),
-        sql`date(${tasks.dueDate}) < date('now')`,
+        sql`date(${tasks.dueDate}) < ${today}`,
+      );
+    }
+    if (filters.view) {
+      const today = todayInTimezone(filters.tz);
+      switch (filters.view) {
+        case 'today':
+          whereClause = and(
+            whereClause,
+            eq(tasks.completed, false),
+            or(eq(tasks.status, 'today'), sql`date(${tasks.dueDate}) = ${today}`),
+          );
+          break;
+        case 'inbox':
+          whereClause = and(
+            whereClause,
+            eq(tasks.completed, false),
+            or(
+              and(eq(tasks.status, 'inbox'), or(isNull(tasks.dueDate), sql`${tasks.dueDate} = ''`)),
+              sql`date(${tasks.dueDate}) < ${today}`,
+            ),
+          );
+          break;
+        case 'upcoming':
+          whereClause = and(
+            whereClause,
+            eq(tasks.completed, false),
+            or(eq(tasks.status, 'upcoming'), sql`date(${tasks.dueDate}) > ${today}`),
+          );
+          break;
+      }
+    }
+    if (filters.completedSince) {
+      const startOfTodayUtc = startOfDayInUtc(filters.completedSince, filters.tz);
+      whereClause = and(
+        whereClause,
+        eq(tasks.completed, true),
+        sql`${tasks.archivedAt} >= ${startOfTodayUtc}`,
       );
     }
   }

--- a/apps/frontend/src/app/core/services/search.service.spec.ts
+++ b/apps/frontend/src/app/core/services/search.service.spec.ts
@@ -114,7 +114,7 @@ describe('SearchService', () => {
         },
         {
           provide: TaskService,
-          useValue: { tasks },
+          useValue: { allActiveTasks: tasks },
         },
         {
           provide: LabelService,
@@ -406,7 +406,7 @@ describe('SearchService', () => {
         {
           provide: TaskService,
           useValue: {
-            tasks: signal([]),
+            allActiveTasks: signal([]),
             getArchivedTasks: () => of(paginatedArchive(archiveTasks)),
           },
         },
@@ -430,7 +430,7 @@ describe('SearchService', () => {
         {
           provide: TaskService,
           useValue: {
-            tasks: signal([]),
+            allActiveTasks: signal([]),
             getArchivedTasks: () => of(paginatedArchive([])),
           },
         },
@@ -472,7 +472,7 @@ describe('SearchService', () => {
         {
           provide: TaskService,
           useValue: {
-            tasks: signal([]),
+            allActiveTasks: signal([]),
             getArchivedTasks: () => of(paginatedArchive(archiveTasks)),
           },
         },

--- a/apps/frontend/src/app/core/services/search.service.ts
+++ b/apps/frontend/src/app/core/services/search.service.ts
@@ -49,7 +49,7 @@ export class SearchService {
 
   search(query: string): SearchResults {
     const normalizedQuery = normalize(query);
-    const tasks = this.taskService.tasks();
+    const tasks = this.taskService.allActiveTasks();
     const projects = this.projectService.projects();
     const labels = this.labelService.labels();
     const projectById = new Map(projects.map((project) => [project.id, project] as const));

--- a/apps/frontend/src/app/core/services/task.service.spec.ts
+++ b/apps/frontend/src/app/core/services/task.service.spec.ts
@@ -15,7 +15,7 @@ describe('TaskService', () => {
   let projectServiceStub: { projects: ReturnType<typeof signal>; refreshProjects: jasmine.Spy };
 
   const ACTIVE_URL =
-    'http://localhost:3000/tasks?page=1&pageSize=100&completed=false&includeSubtasks=true';
+    'http://localhost:3000/tasks?page=1&pageSize=1000&completed=false&includeSubtasks=true';
   const COMPLETED_URL =
     'http://localhost:3000/tasks?page=1&pageSize=100&completed=true&includeSubtasks=true';
 
@@ -43,6 +43,45 @@ describe('TaskService', () => {
         hasPreviousPage: false,
       },
     };
+  }
+
+  function flushDefaultViews(http: HttpTestingController) {
+    // Flush per-view requests
+    const viewMatch = http.match(
+      (req) =>
+        req.url.includes('/tasks') &&
+        (req.url.includes('view=') ||
+          req.url.includes('overdue=') ||
+          req.url.includes('completedSince=')),
+    );
+    viewMatch.forEach((req) => {
+      if (!req.cancelled) {
+        req.flush(paginated([]));
+      }
+    });
+    // Flush allActiveTasks request
+    const activeMatch = http.match((req) => req.url.includes(ACTIVE_URL));
+    activeMatch.forEach((req) => {
+      if (!req.cancelled) {
+        req.flush(paginated([]));
+      }
+    });
+    // Flush recentlyCompleted request
+    const completedMatch = http.match((req) => req.url.includes(COMPLETED_URL));
+    completedMatch.forEach((req) => {
+      if (!req.cancelled) {
+        req.flush(paginated([]));
+      }
+    });
+  }
+
+  function flushView(http: HttpTestingController, query: string, tasks: Task[] = []) {
+    const match = http.match((req) => req.url.includes(query));
+    match.forEach((req) => {
+      if (!req.cancelled) {
+        req.flush(paginated(tasks));
+      }
+    });
   }
 
   function flushCompletedTasks(http: HttpTestingController, tasks: Task[] = []) {
@@ -88,7 +127,9 @@ describe('TaskService', () => {
   });
 
   afterEach(() => {
-    TestBed.inject(HttpTestingController).verify();
+    const http = TestBed.inject(HttpTestingController);
+    flushDefaultViews(http);
+    http.verify();
     TestBed.resetTestingModule();
   });
 
@@ -98,7 +139,7 @@ describe('TaskService', () => {
 
     tick();
 
-    expect(service.tasks()).toEqual([]);
+    expect(service.allActiveTasks()).toEqual([]);
     http.expectNone(ACTIVE_URL);
     http.expectNone(COMPLETED_URL);
   }));
@@ -110,7 +151,7 @@ describe('TaskService', () => {
     initialized.set(true);
     tick();
 
-    expect(service.tasks()).toEqual([]);
+    expect(service.allActiveTasks()).toEqual([]);
     http.expectNone(ACTIVE_URL);
     http.expectNone(COMPLETED_URL);
   }));
@@ -143,13 +184,13 @@ describe('TaskService', () => {
     flushCompletedTasks(http);
     tick();
 
-    expect(service.tasks().map((task) => task.id)).toEqual(['user-1-task']);
+    expect(service.allActiveTasks().map((task) => task.id)).toEqual(['user-1-task']);
 
     currentUserId.set(null);
     isAuthenticated.set(false);
     tick();
 
-    expect(service.tasks()).toEqual([]);
+    expect(service.allActiveTasks()).toEqual([]);
     http.expectNone(ACTIVE_URL);
 
     isAuthenticated.set(true);
@@ -175,7 +216,7 @@ describe('TaskService', () => {
     flushCompletedTasks(http);
     tick();
 
-    expect(service.tasks().map((task) => task.id)).toEqual(['user-2-task']);
+    expect(service.allActiveTasks().map((task) => task.id)).toEqual(['user-2-task']);
   }));
 
   it('returns an empty list when the tasks endpoint responds with 401', fakeAsync(() => {
@@ -195,9 +236,8 @@ describe('TaskService', () => {
     completedReq.flush({ message: 'Unauthorized' }, { status: 401, statusText: 'Unauthorized' });
     tick();
 
-    expect(service.tasks()).toEqual([]);
-    expect(service.pendingTasks()).toEqual([]);
-    expect(service.completedTasks()).toEqual([]);
+    expect(service.allActiveTasks()).toEqual([]);
+    expect(service.recentlyCompleted()).toEqual([]);
   }));
 
   it('derives inbox, overdue, today, and upcoming selectors from the fetched tasks', fakeAsync(() => {
@@ -322,6 +362,36 @@ describe('TaskService', () => {
     http.expectOne(COMPLETED_URL).flush(paginated(completedTasks));
     tick();
 
+    // Flush today view
+    flushView(http, 'view=today', [
+      activeTasks.find((t) => t.id === 'today-1')!,
+      activeTasks.find((t) => t.id === 'inbox-due-today')!,
+    ]);
+
+    // Flush overdue view
+    flushView(http, 'overdue=true', [
+      activeTasks.find((t) => t.id === 'overdue-1')!,
+      activeTasks.find((t) => t.id === 'upcoming-overdue')!,
+    ]);
+
+    // Flush inbox view
+    flushView(http, 'view=inbox', [
+      activeTasks.find((t) => t.id === 'inbox-1')!,
+      activeTasks.find((t) => t.id === 'overdue-1')!,
+      activeTasks.find((t) => t.id === 'upcoming-overdue')!,
+    ]);
+
+    // Flush upcoming view
+    flushView(http, 'view=upcoming', [
+      activeTasks.find((t) => t.id === 'upcoming-1')!,
+      activeTasks.find((t) => t.id === 'inbox-due-upcoming')!,
+    ]);
+
+    // Flush completedSince view
+    flushView(http, 'completedSince=', completedTasks);
+
+    tick();
+
     expect(service.inboxTasks().map((task) => task.id)).toEqual([
       'inbox-1',
       'overdue-1',
@@ -337,7 +407,7 @@ describe('TaskService', () => {
       'upcoming-1',
       'inbox-due-upcoming',
     ]);
-    expect(service.archivedTasks().map((task) => task.id)).toEqual(['done-1']);
+    expect(service.recentlyCompleted().map((task) => task.id)).toEqual(['done-1']);
     expect(service.upcomingTaskGroups()).toEqual([
       {
         label: 'This Week',
@@ -384,6 +454,26 @@ describe('TaskService', () => {
     flushCompletedTasks(http);
     tick();
 
+    flushView(http, 'view=today', [
+      {
+        id: 'date-only-today',
+        title: 'Date-only today',
+        status: 'inbox',
+        priority: 'medium',
+        completed: false,
+        dueDate: todayDateOnly,
+        simpleMode: false,
+        bucket: 'personal-sanctuary',
+        order: 0,
+        createdAt: dayOffset(0),
+        updatedAt: dayOffset(0),
+      },
+    ]);
+
+    flushView(http, 'view=inbox', []);
+
+    tick();
+
     expect(service.todayTasks().map((task) => task.id)).toEqual(['date-only-today']);
     expect(service.inboxTasks()).toEqual([]);
   }));
@@ -428,7 +518,7 @@ describe('TaskService', () => {
     http.expectOne(COMPLETED_URL).flush(paginated(completedTasks));
     tick();
 
-    expect(service.archivedTasks().map((task) => task.id)).toEqual(['recent-done', 'old-done']);
+    expect(service.recentlyCompleted().map((task) => task.id)).toEqual(['recent-done', 'old-done']);
   }));
 
   it('creates a task and refreshes the fetched list', fakeAsync(() => {
@@ -493,6 +583,23 @@ describe('TaskService', () => {
     flushCompletedTasks(http);
     tick();
 
+    flushView(http, 'view=inbox', [
+      {
+        id: 'created-1',
+        title: 'New capture',
+        status: 'inbox',
+        priority: 'medium',
+        completed: false,
+        simpleMode: true,
+        bucket: 'personal-sanctuary',
+        order: 0,
+        createdAt: dayOffset(0),
+        updatedAt: dayOffset(0),
+      },
+    ]);
+
+    tick();
+
     expect(createdTask?.id).toBe('created-1');
     expect(service.inboxTasks().map((task) => task.id)).toEqual(['created-1']);
     expect(labelServiceStub.refreshLabels).toHaveBeenCalled();
@@ -555,6 +662,24 @@ describe('TaskService', () => {
       ]),
     );
     flushCompletedTasks(http);
+    tick();
+
+    flushView(http, 'view=inbox', [
+      {
+        id: 'task-1',
+        title: 'Refined task',
+        status: 'inbox',
+        priority: 'medium',
+        completed: false,
+        simpleMode: false,
+        dueDate: '2026-04-08',
+        bucket: 'deep-work',
+        order: 0,
+        createdAt: dayOffset(0),
+        updatedAt: dayOffset(0),
+      },
+    ]);
+
     tick();
 
     expect(service.inboxTasks()[0]?.bucket).toBe('deep-work');
@@ -628,62 +753,6 @@ describe('TaskService', () => {
     tick();
 
     expect(service.recentlyCompleted().map((t) => t.id)).toEqual(['completed-1', 'completed-2']);
-  }));
-
-  it('stops paginating when the server returns an empty page despite hasNextPage', fakeAsync(() => {
-    const service = TestBed.inject(TaskService);
-    const http = TestBed.inject(HttpTestingController);
-
-    initialized.set(true);
-    isAuthenticated.set(true);
-    currentUserId.set('user-1');
-    tick();
-
-    http.expectOne(ACTIVE_URL).flush({
-      data: [
-        {
-          id: 't1',
-          title: 'Only task',
-          status: 'inbox' as const,
-          priority: 'medium' as const,
-          completed: false,
-          simpleMode: true,
-          bucket: 'personal-sanctuary' as const,
-          order: 0,
-          createdAt: dayOffset(0),
-          updatedAt: dayOffset(0),
-        },
-      ],
-      meta: {
-        total: 1,
-        page: 1,
-        pageSize: 100,
-        totalPages: 1,
-        hasNextPage: true,
-        hasPreviousPage: false,
-      },
-    });
-
-    http
-      .expectOne(
-        'http://localhost:3000/tasks?page=2&pageSize=100&completed=false&includeSubtasks=true',
-      )
-      .flush({
-        data: [],
-        meta: {
-          total: 1,
-          page: 2,
-          pageSize: 100,
-          totalPages: 1,
-          hasNextPage: false,
-          hasPreviousPage: true,
-        },
-      });
-
-    flushCompletedTasks(http);
-    tick();
-
-    expect(service.tasks().map((t) => t.id)).toEqual(['t1']);
   }));
 
   it('deletes a task and refreshes the list', fakeAsync(() => {

--- a/apps/frontend/src/app/core/services/task.service.spec.ts
+++ b/apps/frontend/src/app/core/services/task.service.spec.ts
@@ -891,5 +891,71 @@ describe('TaskService', () => {
 
       expect(service.error()).toBeNull();
     }));
+
+    it('sets error state when overdueTasks fetch fails', fakeAsync(() => {
+      const service = TestBed.inject(TaskService);
+      const http = TestBed.inject(HttpTestingController);
+
+      initialized.set(true);
+      isAuthenticated.set(true);
+      currentUserId.set('user-1');
+      tick();
+
+      http.expectOne(ACTIVE_URL).flush(paginated([]));
+      http.expectOne(COMPLETED_URL).flush(paginated([]));
+
+      const overdueReq = http.match((req) => req.url.includes('overdue=true'))[0];
+      overdueReq.error(new ProgressEvent('error'));
+      tick();
+
+      flushDefaultViews(http);
+
+      expect(service.overdueTasks()).toEqual([]);
+      expect(service.error()).toBe('Could not load overdue tasks right now.');
+    }));
+
+    it('sets error state when inboxTasks fetch fails', fakeAsync(() => {
+      const service = TestBed.inject(TaskService);
+      const http = TestBed.inject(HttpTestingController);
+
+      initialized.set(true);
+      isAuthenticated.set(true);
+      currentUserId.set('user-1');
+      tick();
+
+      http.expectOne(ACTIVE_URL).flush(paginated([]));
+      http.expectOne(COMPLETED_URL).flush(paginated([]));
+
+      const inboxReq = http.match((req) => req.url.includes('view=inbox'))[0];
+      inboxReq.error(new ProgressEvent('error'));
+      tick();
+
+      flushDefaultViews(http);
+
+      expect(service.inboxTasks()).toEqual([]);
+      expect(service.error()).toBe('Could not load inbox tasks right now.');
+    }));
+
+    it('sets error state when upcomingTasks fetch fails', fakeAsync(() => {
+      const service = TestBed.inject(TaskService);
+      const http = TestBed.inject(HttpTestingController);
+
+      initialized.set(true);
+      isAuthenticated.set(true);
+      currentUserId.set('user-1');
+      tick();
+
+      http.expectOne(ACTIVE_URL).flush(paginated([]));
+      http.expectOne(COMPLETED_URL).flush(paginated([]));
+
+      const upcomingReq = http.match((req) => req.url.includes('view=upcoming'))[0];
+      upcomingReq.error(new ProgressEvent('error'));
+      tick();
+
+      flushDefaultViews(http);
+
+      expect(service.upcomingTasks()).toEqual([]);
+      expect(service.error()).toBe('Could not load upcoming tasks right now.');
+    }));
   });
 });

--- a/apps/frontend/src/app/core/services/task.service.spec.ts
+++ b/apps/frontend/src/app/core/services/task.service.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { signal } from '@angular/core';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpErrorResponse } from '@angular/common/http';
 import { TaskService } from './task.service';
 import { AuthStateService } from './auth-state.service';
 import { LabelService } from './label.service';

--- a/apps/frontend/src/app/core/services/task.service.spec.ts
+++ b/apps/frontend/src/app/core/services/task.service.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { signal } from '@angular/core';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
 import { TaskService } from './task.service';
 import { AuthStateService } from './auth-state.service';
 import { LabelService } from './label.service';
@@ -784,4 +785,111 @@ describe('TaskService', () => {
     expect(labelServiceStub.refreshLabels).toHaveBeenCalled();
     expect(projectServiceStub.refreshProjects).toHaveBeenCalled();
   }));
+
+  describe('error handling', () => {
+    it('sets error state when allActiveTasks fetch fails with a network error', fakeAsync(() => {
+      const service = TestBed.inject(TaskService);
+      const http = TestBed.inject(HttpTestingController);
+
+      initialized.set(true);
+      isAuthenticated.set(true);
+      currentUserId.set('user-1');
+      tick();
+
+      const req = http.expectOne(ACTIVE_URL);
+      req.error(new ProgressEvent('error'));
+      tick();
+
+      expect(service.allActiveTasks()).toEqual([]);
+      expect(service.error()).toBe('Could not load tasks right now.');
+    }));
+
+    it('sets error state when allActiveTasks fetch fails with a 500', fakeAsync(() => {
+      const service = TestBed.inject(TaskService);
+      const http = TestBed.inject(HttpTestingController);
+
+      initialized.set(true);
+      isAuthenticated.set(true);
+      currentUserId.set('user-1');
+      tick();
+
+      const req = http.expectOne(ACTIVE_URL);
+      req.flush(
+        { message: 'Internal Server Error' },
+        { status: 500, statusText: 'Internal Server Error' },
+      );
+      tick();
+
+      expect(service.allActiveTasks()).toEqual([]);
+      expect(service.error()).toBe('Could not load tasks right now.');
+    }));
+
+    it('does not set error state when allActiveTasks fetch fails with a 401', fakeAsync(() => {
+      const service = TestBed.inject(TaskService);
+      const http = TestBed.inject(HttpTestingController);
+
+      initialized.set(true);
+      isAuthenticated.set(true);
+      currentUserId.set('user-1');
+      tick();
+
+      const req = http.expectOne(ACTIVE_URL);
+      req.flush({ message: 'Unauthorized' }, { status: 401, statusText: 'Unauthorized' });
+      tick();
+
+      expect(service.allActiveTasks()).toEqual([]);
+      expect(service.error()).toBeNull();
+    }));
+
+    it('sets error state when todayTasks fetch fails', fakeAsync(() => {
+      const service = TestBed.inject(TaskService);
+      const http = TestBed.inject(HttpTestingController);
+
+      initialized.set(true);
+      isAuthenticated.set(true);
+      currentUserId.set('user-1');
+      tick();
+
+      // Flush allActiveTasks and recentlyCompleted first
+      http.expectOne(ACTIVE_URL).flush(paginated([]));
+      http.expectOne(COMPLETED_URL).flush(paginated([]));
+
+      // Now fail the todayTasks request
+      const todayReq = http.match((req) => req.url.includes('view=today'))[0];
+      todayReq.error(new ProgressEvent('error'));
+      tick();
+
+      // Flush remaining view requests
+      flushDefaultViews(http);
+
+      expect(service.todayTasks()).toEqual([]);
+      expect(service.error()).toBe('Could not load today tasks right now.');
+    }));
+
+    it('clears error state on successful load after a failure', fakeAsync(() => {
+      const service = TestBed.inject(TaskService);
+      const http = TestBed.inject(HttpTestingController);
+
+      initialized.set(true);
+      isAuthenticated.set(true);
+      currentUserId.set('user-1');
+      tick();
+
+      // First load fails
+      http.expectOne(ACTIVE_URL).error(new ProgressEvent('error'));
+      tick();
+      expect(service.error()).toBe('Could not load tasks right now.');
+
+      // Trigger a refresh
+      service.refreshTasks();
+      tick();
+
+      // Second load succeeds
+      http.expectOne(ACTIVE_URL).flush(paginated([]));
+      flushDefaultViews(http);
+      tick();
+
+      expect(service.error()).toBeNull();
+    }));
+  });
 });

--- a/apps/frontend/src/app/core/services/task.service.ts
+++ b/apps/frontend/src/app/core/services/task.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, computed, inject, signal } from '@angular/core';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { CreateTaskDto, PaginatedResponse, Task, UpdateTaskDto } from '@yotara/shared';
 import { LogService } from './log.service';
@@ -7,12 +7,10 @@ import {
   catchError,
   combineLatest,
   distinctUntilChanged,
-  expand,
   finalize,
   firstValueFrom,
   map,
   of,
-  reduce,
   switchMap,
 } from 'rxjs';
 import { environment } from '../../../environments/environment';
@@ -20,6 +18,8 @@ import { AuthStateService } from './auth-state.service';
 import { LabelService } from './label.service';
 import { ProjectService } from './project.service';
 import { parseCalendarDate, startOfToday } from '../../shared/utils/timestamps';
+import { getUserTimezone } from '../../shared/utils/timezone';
+import { DateTime } from 'luxon';
 
 export type UpcomingBucket = 'This Week' | 'Next Week' | 'Later';
 
@@ -40,61 +40,6 @@ export class TaskService {
   private loadingState = signal(false);
   private creatingState = signal(false);
   private errorState = signal<string | null>(null);
-
-  private fetchActiveTasks$() {
-    return this.http
-      .get<
-        PaginatedResponse<Task[]>
-      >(`${this.baseUrl}/tasks?page=1&pageSize=100&completed=false&includeSubtasks=true`, { withCredentials: true })
-      .pipe(
-        expand((response) => {
-          if (response.meta.hasNextPage && response.data.length > 0) {
-            return this.http.get<PaginatedResponse<Task[]>>(
-              `${this.baseUrl}/tasks?page=${response.meta.page + 1}&pageSize=100&completed=false&includeSubtasks=true`,
-              { withCredentials: true },
-            );
-          }
-          return of();
-        }),
-        reduce((acc, response) => [...acc, ...response.data], [] as Task[]),
-      );
-  }
-
-  readonly tasks = toSignal(
-    combineLatest([
-      toObservable(this.authState.initialized).pipe(distinctUntilChanged()),
-      toObservable(this.authState.currentUserId).pipe(distinctUntilChanged()),
-      toObservable(this.refreshState),
-    ]).pipe(
-      switchMap(([initialized, currentUserId]) => {
-        if (!initialized || !currentUserId) {
-          this.errorState.set(null);
-          return of([] as Task[]);
-        }
-
-        this.loadingState.set(true);
-        this.errorState.set(null);
-
-        return this.fetchActiveTasks$().pipe(
-          map((tasks) => tasks.sort((left, right) => left.order - right.order)),
-          catchError((error: unknown) => {
-            if (error instanceof HttpErrorResponse && error.status === 401) {
-              this.errorState.set(null);
-              return of([] as Task[]);
-            }
-
-            this.logService.error('Failed to load tasks', error, 'TaskService');
-            this.errorState.set('Could not load your tasks right now.');
-            return of([] as Task[]);
-          }),
-          finalize(() => {
-            this.loadingState.set(false);
-          }),
-        );
-      }),
-    ),
-    { initialValue: [] as Task[] },
-  );
 
   readonly recentlyCompleted = toSignal(
     combineLatest([
@@ -125,40 +70,193 @@ export class TaskService {
   readonly error = this.errorState.asReadonly();
   readonly revision = this.refreshState.asReadonly();
 
-  readonly activeTasks = computed(() =>
-    this.tasks().filter((task) => !task.completed && task.status !== 'archived' && !task.parentId),
-  );
-  readonly pendingTasks = computed(() =>
-    this.tasks().filter((task) => !task.completed && !task.parentId),
-  );
-  readonly completedTasks = computed(() => this.recentlyCompleted());
-  readonly archivedTasks = computed(() => this.recentlyCompleted());
-
   getArchivedTasks(page: number, pageSize: number) {
     return this.http.get<PaginatedResponse<Task[]>>(
       `${this.baseUrl}/tasks?page=${page}&pageSize=${pageSize}&completed=true&includeSubtasks=true`,
       { withCredentials: true },
     );
   }
-  readonly inboxTasks = computed(() =>
-    this.activeTasks().filter(
-      (task) =>
-        this.isTaskOverdue(task) || (task.status === 'inbox' && !this.hasScheduledDate(task)),
+  fetchTodayTasks$() {
+    const tz = getUserTimezone();
+    return this.http.get<PaginatedResponse<Task[]>>(
+      `${this.baseUrl}/tasks?view=today&tz=${tz}&includeSubtasks=true&pageSize=100`,
+      { withCredentials: true },
+    );
+  }
+
+  fetchOverdueTasks$() {
+    const tz = getUserTimezone();
+    return this.http.get<PaginatedResponse<Task[]>>(
+      `${this.baseUrl}/tasks?overdue=true&tz=${tz}&includeSubtasks=true&pageSize=100`,
+      { withCredentials: true },
+    );
+  }
+
+  fetchInboxTasks$() {
+    const tz = getUserTimezone();
+    return this.http.get<PaginatedResponse<Task[]>>(
+      `${this.baseUrl}/tasks?view=inbox&tz=${tz}&includeSubtasks=true&pageSize=100`,
+      { withCredentials: true },
+    );
+  }
+
+  fetchUpcomingTasks$() {
+    const tz = getUserTimezone();
+    return this.http.get<PaginatedResponse<Task[]>>(
+      `${this.baseUrl}/tasks?view=upcoming&tz=${tz}&includeSubtasks=true&pageSize=100`,
+      { withCredentials: true },
+    );
+  }
+
+  fetchTodayCompletedTasks$() {
+    const tz = getUserTimezone();
+    const today = DateTime.now().setZone(tz).toFormat('yyyy-MM-dd');
+    return this.http.get<PaginatedResponse<Task[]>>(
+      `${this.baseUrl}/tasks?completedSince=${today}&tz=${tz}&includeSubtasks=true&pageSize=100`,
+      { withCredentials: true },
+    );
+  }
+
+  /** Fetch all active tasks including subtasks (for subtask maps, labels, search). */
+  fetchAllActiveTasks$() {
+    return this.http
+      .get<
+        PaginatedResponse<Task[]>
+      >(`${this.baseUrl}/tasks?page=1&pageSize=1000&completed=false&includeSubtasks=true`, { withCredentials: true })
+      .pipe(map((response) => response.data));
+  }
+
+  /** Signal of all active tasks for subtask maps, labels, and search. */
+  readonly allActiveTasks = toSignal(
+    combineLatest([
+      toObservable(this.authState.initialized).pipe(distinctUntilChanged()),
+      toObservable(this.authState.currentUserId).pipe(distinctUntilChanged()),
+      toObservable(this.refreshState),
+    ]).pipe(
+      switchMap(([initialized, currentUserId]) => {
+        if (!initialized || !currentUserId) {
+          this.loadingState.set(false);
+          return of([] as Task[]);
+        }
+        this.loadingState.set(true);
+        return this.fetchAllActiveTasks$().pipe(
+          catchError(() => of([] as Task[])),
+          finalize(() => this.loadingState.set(false)),
+        );
+      }),
     ),
+    { initialValue: [] as Task[] },
   );
-  readonly overdueTasks = computed(() =>
-    this.activeTasks().filter((task) => this.isTaskOverdue(task)),
-  );
-  readonly todayTasks = computed(() =>
-    this.activeTasks().filter((task) => this.isTaskToday(task) && !this.isTaskOverdue(task)),
-  );
-  readonly todayCompletedTasks = computed(() =>
-    this.completedTasks().filter(
-      (task) => (this.isTaskToday(task) || this.isTaskOverdue(task)) && !task.parentId,
+
+  readonly todayTasks = toSignal(
+    combineLatest([
+      toObservable(this.authState.initialized).pipe(distinctUntilChanged()),
+      toObservable(this.authState.currentUserId).pipe(distinctUntilChanged()),
+      toObservable(this.refreshState),
+    ]).pipe(
+      switchMap(([initialized, currentUserId]) => {
+        if (!initialized || !currentUserId) {
+          return of([] as Task[]);
+        }
+        return this.fetchTodayTasks$().pipe(
+          map((response) =>
+            response.data
+              .filter((task) => !task.parentId)
+              .sort((left, right) => left.order - right.order),
+          ),
+          catchError(() => of([] as Task[])),
+        );
+      }),
     ),
+    { initialValue: [] as Task[] },
   );
-  readonly upcomingTasks = computed(() =>
-    this.activeTasks().filter((task) => this.isTaskUpcoming(task)),
+
+  readonly overdueTasks = toSignal(
+    combineLatest([
+      toObservable(this.authState.initialized).pipe(distinctUntilChanged()),
+      toObservable(this.authState.currentUserId).pipe(distinctUntilChanged()),
+      toObservable(this.refreshState),
+    ]).pipe(
+      switchMap(([initialized, currentUserId]) => {
+        if (!initialized || !currentUserId) {
+          return of([] as Task[]);
+        }
+        return this.fetchOverdueTasks$().pipe(
+          map((response) =>
+            response.data
+              .filter((task) => !task.parentId)
+              .sort((left, right) => left.order - right.order),
+          ),
+          catchError(() => of([] as Task[])),
+        );
+      }),
+    ),
+    { initialValue: [] as Task[] },
+  );
+
+  readonly inboxTasks = toSignal(
+    combineLatest([
+      toObservable(this.authState.initialized).pipe(distinctUntilChanged()),
+      toObservable(this.authState.currentUserId).pipe(distinctUntilChanged()),
+      toObservable(this.refreshState),
+    ]).pipe(
+      switchMap(([initialized, currentUserId]) => {
+        if (!initialized || !currentUserId) {
+          return of([] as Task[]);
+        }
+        return this.fetchInboxTasks$().pipe(
+          map((response) =>
+            response.data
+              .filter((task) => !task.parentId)
+              .sort((left, right) => left.order - right.order),
+          ),
+          catchError(() => of([] as Task[])),
+        );
+      }),
+    ),
+    { initialValue: [] as Task[] },
+  );
+
+  readonly upcomingTasks = toSignal(
+    combineLatest([
+      toObservable(this.authState.initialized).pipe(distinctUntilChanged()),
+      toObservable(this.authState.currentUserId).pipe(distinctUntilChanged()),
+      toObservable(this.refreshState),
+    ]).pipe(
+      switchMap(([initialized, currentUserId]) => {
+        if (!initialized || !currentUserId) {
+          return of([] as Task[]);
+        }
+        return this.fetchUpcomingTasks$().pipe(
+          map((response) =>
+            response.data
+              .filter((task) => !task.parentId)
+              .sort((left, right) => left.order - right.order),
+          ),
+          catchError(() => of([] as Task[])),
+        );
+      }),
+    ),
+    { initialValue: [] as Task[] },
+  );
+
+  readonly todayCompletedTasks = toSignal(
+    combineLatest([
+      toObservable(this.authState.initialized).pipe(distinctUntilChanged()),
+      toObservable(this.authState.currentUserId).pipe(distinctUntilChanged()),
+      toObservable(this.refreshState),
+    ]).pipe(
+      switchMap(([initialized, currentUserId]) => {
+        if (!initialized || !currentUserId) {
+          return of([] as Task[]);
+        }
+        return this.fetchTodayCompletedTasks$().pipe(
+          map((response) => response.data.filter((task) => !task.parentId)),
+          catchError(() => of([] as Task[])),
+        );
+      }),
+    ),
+    { initialValue: [] as Task[] },
   );
   readonly upcomingTaskGroups = computed<UpcomingTaskGroup[]>(() => {
     const buckets: Record<UpcomingBucket, Task[]> = {
@@ -283,32 +381,6 @@ export class TaskService {
     return new Intl.DateTimeFormat('en-US', options ?? { month: 'short', day: 'numeric' }).format(
       dt.toJSDate(),
     );
-  }
-
-  isTaskOverdue(task: Task) {
-    const dueDate = parseCalendarDate(task.dueDate);
-    const today = startOfToday();
-
-    return !!dueDate && dueDate < today && !task.completed;
-  }
-
-  isTaskToday(task: Task) {
-    const dueDate = parseCalendarDate(task.dueDate);
-    return task.status === 'today' || (!!dueDate && dueDate.equals(startOfToday()));
-  }
-
-  isTaskUpcoming(task: Task) {
-    if (task.completed || this.isTaskOverdue(task) || this.isTaskToday(task)) {
-      return false;
-    }
-
-    const dueDate = parseCalendarDate(task.dueDate);
-    return task.status === 'upcoming' || (!!dueDate && dueDate > startOfToday());
-  }
-
-  private hasScheduledDate(task: Task) {
-    const dueDate = parseCalendarDate(task.dueDate);
-    return !!dueDate && dueDate >= startOfToday();
   }
 
   upcomingBucketForTask(task: Task): UpcomingBucket {

--- a/apps/frontend/src/app/core/services/task.service.ts
+++ b/apps/frontend/src/app/core/services/task.service.ts
@@ -92,7 +92,7 @@ export class TaskService {
   fetchTodayTasks$() {
     const tz = getUserTimezone();
     return this.http.get<PaginatedResponse<Task[]>>(
-      `${this.baseUrl}/tasks?view=today&tz=${tz}&includeSubtasks=true&pageSize=100`,
+      `${this.baseUrl}/tasks?view=today&tz=${tz}&pageSize=100`,
       { withCredentials: true },
     );
   }
@@ -100,7 +100,7 @@ export class TaskService {
   fetchOverdueTasks$() {
     const tz = getUserTimezone();
     return this.http.get<PaginatedResponse<Task[]>>(
-      `${this.baseUrl}/tasks?overdue=true&tz=${tz}&includeSubtasks=true&pageSize=100`,
+      `${this.baseUrl}/tasks?overdue=true&tz=${tz}&pageSize=100`,
       { withCredentials: true },
     );
   }
@@ -108,7 +108,7 @@ export class TaskService {
   fetchInboxTasks$() {
     const tz = getUserTimezone();
     return this.http.get<PaginatedResponse<Task[]>>(
-      `${this.baseUrl}/tasks?view=inbox&tz=${tz}&includeSubtasks=true&pageSize=100`,
+      `${this.baseUrl}/tasks?view=inbox&tz=${tz}&pageSize=100`,
       { withCredentials: true },
     );
   }
@@ -116,7 +116,7 @@ export class TaskService {
   fetchUpcomingTasks$() {
     const tz = getUserTimezone();
     return this.http.get<PaginatedResponse<Task[]>>(
-      `${this.baseUrl}/tasks?view=upcoming&tz=${tz}&includeSubtasks=true&pageSize=100`,
+      `${this.baseUrl}/tasks?view=upcoming&tz=${tz}&pageSize=100`,
       { withCredentials: true },
     );
   }
@@ -125,7 +125,7 @@ export class TaskService {
     const tz = getUserTimezone();
     const today = DateTime.now().setZone(tz).toFormat('yyyy-MM-dd');
     return this.http.get<PaginatedResponse<Task[]>>(
-      `${this.baseUrl}/tasks?completedSince=${today}&tz=${tz}&includeSubtasks=true&pageSize=100`,
+      `${this.baseUrl}/tasks?completedSince=${today}&tz=${tz}&pageSize=100`,
       { withCredentials: true },
     );
   }

--- a/apps/frontend/src/app/core/services/task.service.ts
+++ b/apps/frontend/src/app/core/services/task.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, computed, inject, signal } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { CreateTaskDto, PaginatedResponse, Task, UpdateTaskDto } from '@yotara/shared';
 import { LogService } from './log.service';
@@ -41,6 +41,18 @@ export class TaskService {
   private creatingState = signal(false);
   private errorState = signal<string | null>(null);
 
+  private handleLoadError(context: string) {
+    return (error: unknown) => {
+      if (error instanceof HttpErrorResponse && error.status === 401) {
+        return of([] as Task[]);
+      }
+
+      this.logService.error(`Failed to load ${context}`, error, 'TaskService');
+      this.errorState.set(`Could not load ${context} right now.`);
+      return of([] as Task[]);
+    };
+  }
+
   readonly recentlyCompleted = toSignal(
     combineLatest([
       toObservable(this.authState.initialized).pipe(distinctUntilChanged()),
@@ -51,6 +63,7 @@ export class TaskService {
         if (!initialized || !currentUserId) {
           return of([] as Task[]);
         }
+        this.errorState.set(null);
 
         return this.http
           .get<
@@ -58,7 +71,7 @@ export class TaskService {
           >(`${this.baseUrl}/tasks?page=1&pageSize=100&completed=true&includeSubtasks=true`, { withCredentials: true })
           .pipe(
             map((response) => response.data),
-            catchError(() => of([] as Task[])),
+            catchError(this.handleLoadError('recently completed tasks')),
           );
       }),
     ),
@@ -139,8 +152,9 @@ export class TaskService {
           return of([] as Task[]);
         }
         this.loadingState.set(true);
+        this.errorState.set(null);
         return this.fetchAllActiveTasks$().pipe(
-          catchError(() => of([] as Task[])),
+          catchError(this.handleLoadError('tasks')),
           finalize(() => this.loadingState.set(false)),
         );
       }),
@@ -158,13 +172,14 @@ export class TaskService {
         if (!initialized || !currentUserId) {
           return of([] as Task[]);
         }
+        this.errorState.set(null);
         return this.fetchTodayTasks$().pipe(
           map((response) =>
             response.data
               .filter((task) => !task.parentId)
               .sort((left, right) => left.order - right.order),
           ),
-          catchError(() => of([] as Task[])),
+          catchError(this.handleLoadError('today tasks')),
         );
       }),
     ),
@@ -181,13 +196,14 @@ export class TaskService {
         if (!initialized || !currentUserId) {
           return of([] as Task[]);
         }
+        this.errorState.set(null);
         return this.fetchOverdueTasks$().pipe(
           map((response) =>
             response.data
               .filter((task) => !task.parentId)
               .sort((left, right) => left.order - right.order),
           ),
-          catchError(() => of([] as Task[])),
+          catchError(this.handleLoadError('overdue tasks')),
         );
       }),
     ),
@@ -204,13 +220,14 @@ export class TaskService {
         if (!initialized || !currentUserId) {
           return of([] as Task[]);
         }
+        this.errorState.set(null);
         return this.fetchInboxTasks$().pipe(
           map((response) =>
             response.data
               .filter((task) => !task.parentId)
               .sort((left, right) => left.order - right.order),
           ),
-          catchError(() => of([] as Task[])),
+          catchError(this.handleLoadError('inbox tasks')),
         );
       }),
     ),
@@ -227,13 +244,14 @@ export class TaskService {
         if (!initialized || !currentUserId) {
           return of([] as Task[]);
         }
+        this.errorState.set(null);
         return this.fetchUpcomingTasks$().pipe(
           map((response) =>
             response.data
               .filter((task) => !task.parentId)
               .sort((left, right) => left.order - right.order),
           ),
-          catchError(() => of([] as Task[])),
+          catchError(this.handleLoadError('upcoming tasks')),
         );
       }),
     ),
@@ -250,9 +268,10 @@ export class TaskService {
         if (!initialized || !currentUserId) {
           return of([] as Task[]);
         }
+        this.errorState.set(null);
         return this.fetchTodayCompletedTasks$().pipe(
           map((response) => response.data.filter((task) => !task.parentId)),
-          catchError(() => of([] as Task[])),
+          catchError(this.handleLoadError('completed tasks')),
         );
       }),
     ),

--- a/apps/frontend/src/app/features/personal/pages/labels-page.component.spec.ts
+++ b/apps/frontend/src/app/features/personal/pages/labels-page.component.spec.ts
@@ -49,7 +49,7 @@ describe('LabelsPageComponent', () => {
         {
           provide: TaskService,
           useValue: {
-            tasks,
+            allActiveTasks: tasks,
             error: signal(null),
             createTask: jasmine.createSpy('createTask').and.resolveTo(undefined),
             updateTask: jasmine.createSpy('updateTask').and.resolveTo(undefined),

--- a/apps/frontend/src/app/features/personal/pages/labels-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/labels-page.component.ts
@@ -55,7 +55,7 @@ export class LabelsPageComponent {
   protected readonly filteredTasks = computed(() => {
     const labelId = this.selectedLabelId();
     if (!labelId) return [];
-    return this.taskService.tasks().filter((task) => task.labels?.includes(labelId));
+    return this.taskService.allActiveTasks().filter((task) => task.labels?.includes(labelId));
   });
 
   constructor() {

--- a/apps/frontend/src/app/features/personal/pages/search-page/search-page.component.spec.ts
+++ b/apps/frontend/src/app/features/personal/pages/search-page/search-page.component.spec.ts
@@ -104,7 +104,7 @@ describe('SearchPageComponent', () => {
         {
           provide: TaskService,
           useValue: {
-            tasks: mockTasks,
+            allActiveTasks: mockTasks,
             recentlyCompleted: signal([]),
             error: signal<string | null>(null),
             creating: signal(false),

--- a/apps/frontend/src/app/features/personal/pages/search-page/search-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/search-page/search-page.component.ts
@@ -61,7 +61,7 @@ export class SearchPageComponent {
   protected readonly currentPage = signal(1);
 
   protected readonly subtasksByParent = computed(() => {
-    const all = this.taskService.tasks();
+    const all = this.taskService.allActiveTasks();
     const map = new Map<string, Task[]>();
     for (const task of all) {
       if (task.parentId) {

--- a/apps/frontend/src/app/features/personal/pages/task-list-page/task-list-page.component.html
+++ b/apps/frontend/src/app/features/personal/pages/task-list-page/task-list-page.component.html
@@ -73,7 +73,7 @@
             <app-section-header title="Overdue" size="lg" tone="accent" />
 
             <app-task-stack
-              [tasks]="taskService.overdueTasks().filter((t) => !t.parentId)"
+              [tasks]="taskService.overdueTasks()"
               [subtasksByParent]="subtasksByParent()"
               [taskCard]="overdueTaskCardTpl"
             />
@@ -123,7 +123,7 @@
               @if (taskService.todayCompletedTasks().length > 0) {
                 <div class="completed-stack">
                   <app-task-stack
-                    [tasks]="taskService.todayCompletedTasks().filter((t) => !t.parentId)"
+                    [tasks]="taskService.todayCompletedTasks()"
                     [subtasksByParent]="subtasksByParent()"
                     [taskCard]="completedTaskCardTpl"
                   />

--- a/apps/frontend/src/app/features/personal/pages/task-list-page/task-list-page.component.spec.ts
+++ b/apps/frontend/src/app/features/personal/pages/task-list-page/task-list-page.component.spec.ts
@@ -28,7 +28,7 @@ describe('TaskListPageComponent', () => {
       loading: signal(false),
       creating: signal(false),
       error: signal<string | null>(null),
-      tasks: signal([]),
+      allActiveTasks: signal([]),
       inboxTasks: signal([]),
       todayTasks: signal([]),
       todayCompletedTasks: signal([]),
@@ -282,7 +282,7 @@ describe('TaskListPageComponent', () => {
 
     it('keeps the existing list visible while refreshing inbox tasks', () => {
       mockTaskService.loading = signal(true);
-      mockTaskService.tasks.set([
+      mockTaskService.allActiveTasks.set([
         {
           id: '1',
           title: 'Visible task',

--- a/apps/frontend/src/app/features/personal/pages/task-list-page/task-list-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/task-list-page/task-list-page.component.ts
@@ -122,7 +122,7 @@ export class TaskListPageComponent implements OnInit {
 
   // --- Inbox Logic ---
   protected readonly subtasksByParent = computed(() => {
-    const all = this.taskService.tasks();
+    const all = this.taskService.allActiveTasks();
     const subtasksByParentMap = new Map<string, Task[]>();
     for (const task of all) {
       if (task.parentId) {
@@ -189,7 +189,7 @@ export class TaskListPageComponent implements OnInit {
   });
 
   protected readonly showInitialLoading = computed(
-    () => this.taskService.loading() && this.taskService.tasks().length === 0,
+    () => this.taskService.loading() && this.taskService.allActiveTasks().length === 0,
   );
 
   protected readonly defaultCaptureProjectId = computed(() => {

--- a/apps/frontend/src/app/features/tasks/pages/tasks-page/tasks-page.component.ts
+++ b/apps/frontend/src/app/features/tasks/pages/tasks-page/tasks-page.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 import { TaskService } from '../../../../core/services/task.service';
 import { TaskListComponent } from '../../components/task-list/task-list.component';
 
@@ -7,10 +7,14 @@ import { TaskListComponent } from '../../components/task-list/task-list.componen
   standalone: true,
   imports: [TaskListComponent],
   template: `
-    <app-task-list heading="Pending" [tasks]="taskService.pendingTasks()" [showStatus]="true" />
-    <app-task-list heading="Completed" [tasks]="taskService.completedTasks()" />
+    <app-task-list heading="Pending" [tasks]="pendingTasks()" [showStatus]="true" />
+    <app-task-list heading="Completed" [tasks]="taskService.recentlyCompleted()" />
   `,
 })
 export class TasksPageComponent {
   protected taskService = inject(TaskService);
+
+  protected readonly pendingTasks = computed(() =>
+    this.taskService.allActiveTasks().filter((task) => !task.parentId),
+  );
 }

--- a/apps/frontend/src/app/shared/utils/timezone.spec.ts
+++ b/apps/frontend/src/app/shared/utils/timezone.spec.ts
@@ -1,0 +1,15 @@
+import { getUserTimezone } from './timezone';
+
+describe('getUserTimezone', () => {
+  it('returns a non-empty string', () => {
+    const tz = getUserTimezone();
+    expect(tz).toBeTruthy();
+    expect(typeof tz).toBe('string');
+  });
+
+  it('returns a valid IANA timezone or UTC fallback', () => {
+    const tz = getUserTimezone();
+    const isIANA = /^[A-Z][a-z]+\/[A-Z][a-z_]+$/.test(tz);
+    expect(isIANA || tz === 'UTC').toBe(true);
+  });
+});

--- a/apps/frontend/src/app/shared/utils/timezone.ts
+++ b/apps/frontend/src/app/shared/utils/timezone.ts
@@ -1,0 +1,7 @@
+/**
+ * Get the current user's local timezone.
+ * Falls back to UTC if the timezone cannot be resolved.
+ */
+export function getUserTimezone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -373,32 +373,32 @@ This sprint order supersedes the P0/P1/P2/P3 priority lanes in `ROADMAP.md`. Tra
 - [x] Replace `throw new Error('string')` in services with typed errors; add Fastify `setErrorHandler`
 - [x] Fix `as any` on `request.query.status` at the trust boundary
 - [x] Add `PreferencesStore` (or extend `ThemeService`'s pattern) and migrate the three `localStorage` magic-string keys
-- [ ] Replace the 4 problematic `setTimeout` UI hacks with signal-driven state
-- [ ] Fix the UTC vs local timezone bug; add `?tz=` to per-view queries
+- [x] Replace the 4 problematic `setTimeout` UI hacks with signal-driven state
+- [x] Fix the UTC vs local timezone bug; add `?tz=` to per-view queries
 - [x] Add a `no-restricted-syntax` ESLint rule against `as any` (warn-only, applied to all `.ts` files)
 - [x] Add "Superseded" notices to `ROADMAP.md`, `docs/project-plan.md`, `apps/frontend/TODO.md`, and `apps/api/TODO.md`
 - [ ] Delete `apps/frontend/TODO.md` and `apps/api/TODO.md`; create initial GitHub Issues from the surviving priorities
 - [ ] Write `docs/RELEASING.md` (checklist for what to verify before cutting a release, since the release script is automated but the verification is not)
 
-### Sprint 1: Push filtering to the API (highest impact)
+### Sprint 1: Push filtering to the API (completed)
 
 **Why:** Eliminates the expand loop, removes most computed signals, makes the app scale.
 
 **Frontend tasks:**
-- [ ] `getTodayTasks()` → `GET /tasks?view=today`
-- [ ] `getOverdueTasks()` → `GET /tasks?overdue=true`
-- [ ] `getInboxTasks()` → `GET /tasks?view=inbox`
-- [ ] `getUpcomingTasks()` → `GET /tasks?view=upcoming`
-- [ ] `getTodayCompletedTasks()` → `GET /tasks?completedSince=<date>`
-- [ ] Remove each `computed()` signal after migrating its view
+- [x] `getTodayTasks()` → `GET /tasks?view=today`
+- [x] `getOverdueTasks()` → `GET /tasks?overdue=true`
+- [x] `getInboxTasks()` → `GET /tasks?view=inbox`
+- [x] `getUpcomingTasks()` → `GET /tasks?view=upcoming`
+- [x] `getTodayCompletedTasks()` → `GET /tasks?completedSince=<date>`
+- [x] Remove each `computed()` signal after migrating its view
 
 **Backend tasks:**
-- [ ] Add `view=today|inbox|upcoming` query param with compound predicates:
+- [x] Add `view=today|inbox|upcoming` query param with compound predicates:
   - `view=today` → `status = 'today' OR dueDate = today`
   - `view=inbox` → `status = 'inbox' AND (dueDate IS NULL OR dueDate = '')`
   - `view=upcoming` → `status = 'upcoming' OR dueDate > today`
-- [ ] Add `completedSince` query param
-- [ ] Verify all status filters work correctly with integration tests (replace the "verify" checkboxes in the API TODO with real tests)
+- [x] Add `completedSince` query param
+- [x] Verify all status filters work correctly with integration tests (replace the "verify" checkboxes in the API TODO with real tests)
 - [ ] Tighten input validation on the new query params (closes A3)
 
 ### Sprint 1a: Remove setTimeout UI hacks (completed)
@@ -432,14 +432,14 @@ This sprint order supersedes the P0/P1/P2/P3 priority lanes in `ROADMAP.md`. Tra
 - [ ] Add success/error handling for both flows (toast on success, inline error on failure)
 - [ ] Add route guards to redirect authenticated users away from reset-password pages
 
-### Sprint 2: Clean up TaskService
+### Sprint 2: Clean up TaskService (in progress)
 
 **Why:** Makes the file maintainable and testable.
 
 - [ ] Extract date helpers to `shared/utils/timestamps.ts`
 - [ ] Extract auth-gate pattern into shared helper
-- [ ] Remove stale aliases (`archivedTasks`, `completedTasks`)
-- [ ] Remove active-task expand loop (no longer needed after Sprint 1)
+- [x] Remove stale aliases (`archivedTasks`, `completedTasks`) — done in Sprint 1 cleanup
+- [x] Remove active-task expand loop (no longer needed after Sprint 1) — done in Sprint 1 cleanup
 
 ### Sprint 3: Server-side search
 


### PR DESCRIPTION
## Summary

Removes the multi-page expand loop, stale computed signals, and client-side date-filtering helpers from `TaskService`. All task filtering is now handled server-side via per-view API queries (`view=today|inbox|upcoming`, `overdue=true`, `completedSince=<date>`).

## Changes

### Frontend (`apps/frontend`)
- **Removed** `fetchActiveTasks` expand loop and `tasks` signal
- **Removed** computed signals: `activeTasks`, `pendingTasks`, `completedTasks`, `archivedTasks`
- **Removed** client-side helpers: `isTaskOverdue()`, `isTaskToday()`, `isTaskUpcoming()`, `hasScheduledDate()`
- **Added** `allActiveTasks` signal with single-page fetch (`pageSize=1000`) for subtask maps, labels, and search
- **Migrated** all consumers: `task-list-page`, `labels-page`, `search-page`, `search.service`, `tasks-page`
- **Fixed** `fetchTodayCompletedTasks` to use `getUserTimezone()` instead of `DateTime.local()`

### Backend (`apps/api`)
- **Increased** max `pageSize` from 100 → 1000 to support the frontend's single-page fetch

### Tests
- Updated all mock TaskService providers to use `allActiveTasks`
- Updated URL assertions for new per-view query strings
- **419/419 frontend tests pass**, **38/38 API tests pass**

### Docs
- Updated `ARCHITECTURE.md` — Sprint 1 marked completed, Sprint 2 items checked off

## Verification
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (0 errors)
- [x] `ng test` — 419/419 pass
- [x] API tests — 38/38 pass
- [x] Frontend + API build clean