### PR TITLE
feat(rate-limiting): add global rate limiting and per-email password …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ packages/shared/src/*.js.map
 .reasonix/
 .commandcode/taste/taste.md
 .codegraph/
+reasonix.toml

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -4,3 +4,11 @@ DATABASE_URL=./data/yotara.db
 # API bind settings
 PORT=3000
 HOST=0.0.0.0
+
+# Rate limiting (global DDoS protection)
+RATE_LIMIT_MAX=100
+RATE_LIMIT_WINDOW_MINUTES=1
+
+# Password lockout (per-email after failed attempts)
+PASSWORD_LOCKOUT_ATTEMPTS=3
+PASSWORD_LOCKOUT_MINUTES=5

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@fastify/cors": "^11.2.0",
+    "@fastify/rate-limit": "^11.0.0",
     "@fastify/swagger": "^9.5.1",
     "@fastify/swagger-ui": "^5.2.3",
     "@types/luxon": "^3.7.1",

--- a/apps/api/src/db/client.ts
+++ b/apps/api/src/db/client.ts
@@ -118,6 +118,13 @@ const SQLITE_BOOTSTRAP_SQL = `
     FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
     FOREIGN KEY (label_id) REFERENCES labels(id) ON DELETE CASCADE
   );
+
+  CREATE TABLE IF NOT EXISTS login_attempts (
+    email TEXT PRIMARY KEY NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    locked_until INTEGER,
+    last_attempt_at INTEGER NOT NULL
+  );
 `;
 
 function normalizeTextTimestamp(value: unknown, fallback: string): string {

--- a/apps/api/src/lib/login-lockout.test.ts
+++ b/apps/api/src/lib/login-lockout.test.ts
@@ -74,3 +74,36 @@ test('login lockout utility tracks attempts and locks at threshold', async () =>
     rmSync(dbFile, { force: true });
   }
 });
+
+test('stale pre-lockout rows are cleaned up after the lockout window expires', async () => {
+  process.env['PASSWORD_LOCKOUT_ATTEMPTS'] = '5';
+  process.env['PASSWORD_LOCKOUT_MINUTES'] = '0.002'; // ~120ms window
+
+  try {
+    const { recordFailedAttempt, getRemainingAttempts } = await import('./login-lockout.js');
+    const { cleanExpiredLockouts } = await import('./login-lockout.js');
+    const email = `stale-${randomUUID()}@test.com`;
+
+    // Make one failed attempt (pre-lockout row, locked_until IS NULL)
+    const result = recordFailedAttempt(email);
+    assert.equal(result.locked, false);
+    assert.equal(result.remainingAttempts, 4);
+    assert.equal(getRemainingAttempts(email), 4);
+
+    // Wait for the lockout window to pass
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // Trigger cleanup
+    cleanExpiredLockouts();
+
+    // The stale pre-lockout row should be gone, so remaining attempts resets
+    assert.equal(
+      getRemainingAttempts(email),
+      5,
+      'stale row should be cleaned up, resetting attempts',
+    );
+  } finally {
+    delete process.env['PASSWORD_LOCKOUT_ATTEMPTS'];
+    delete process.env['PASSWORD_LOCKOUT_MINUTES'];
+  }
+});

--- a/apps/api/src/lib/login-lockout.test.ts
+++ b/apps/api/src/lib/login-lockout.test.ts
@@ -1,0 +1,76 @@
+import { randomUUID } from 'node:crypto';
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const TEST_EMAIL = `lockout-${randomUUID()}@test.com`;
+
+test('login lockout utility tracks attempts and locks at threshold', async () => {
+  const dbFile = join(tmpdir(), `yotara-lockout-test-${randomUUID()}.db`);
+  process.env['DATABASE_URL'] = dbFile;
+  process.env['PASSWORD_LOCKOUT_ATTEMPTS'] = '3';
+  process.env['PASSWORD_LOCKOUT_MINUTES'] = '5';
+
+  try {
+    // Import db/client to initialize the SQLite singleton with temp DB path.
+    // Must be imported before login-lockout since login-lockout imports sqlite from it.
+    await import('../db/client.js');
+    const {
+      isLockedOut,
+      getRemainingAttempts,
+      getRemainingLockoutSeconds,
+      recordFailedAttempt,
+      clearAttempts,
+    } = await import('./login-lockout.js');
+
+    assert.equal(isLockedOut(TEST_EMAIL), false, 'not locked before any attempts');
+    assert.equal(getRemainingAttempts(TEST_EMAIL), 3, '3 remaining before any attempts');
+    assert.equal(
+      getRemainingLockoutSeconds(TEST_EMAIL),
+      0,
+      'no lockout seconds before any attempts',
+    );
+
+    const first = recordFailedAttempt(TEST_EMAIL);
+    assert.equal(first.locked, false);
+    assert.equal(first.remainingAttempts, 2);
+    assert.equal(first.remainingLockoutSeconds, 0);
+    assert.equal(isLockedOut(TEST_EMAIL), false);
+    assert.equal(getRemainingAttempts(TEST_EMAIL), 2);
+
+    const second = recordFailedAttempt(TEST_EMAIL);
+    assert.equal(second.locked, false);
+    assert.equal(second.remainingAttempts, 1);
+    assert.equal(isLockedOut(TEST_EMAIL), false);
+    assert.equal(getRemainingAttempts(TEST_EMAIL), 1);
+
+    const third = recordFailedAttempt(TEST_EMAIL);
+    assert.equal(third.locked, true);
+    assert.equal(third.remainingAttempts, 0);
+    assert.ok(third.remainingLockoutSeconds > 0, 'lockout seconds are positive');
+    assert.equal(isLockedOut(TEST_EMAIL), true);
+    assert.equal(getRemainingAttempts(TEST_EMAIL), 0);
+
+    const lockoutSeconds = getRemainingLockoutSeconds(TEST_EMAIL);
+    assert.ok(lockoutSeconds > 0 && lockoutSeconds <= 300, 'lockout seconds within range');
+
+    // Attempting while locked should not extend the lockout
+    const whileLocked = recordFailedAttempt(TEST_EMAIL);
+    assert.equal(whileLocked.locked, true);
+    assert.equal(whileLocked.remainingAttempts, 0);
+    assert.ok(whileLocked.remainingLockoutSeconds > 0);
+    assert.ok(whileLocked.remainingLockoutSeconds <= 300, 'lockout not extended beyond window');
+
+    clearAttempts(TEST_EMAIL);
+    assert.equal(isLockedOut(TEST_EMAIL), false);
+    assert.equal(getRemainingAttempts(TEST_EMAIL), 3);
+    assert.equal(getRemainingLockoutSeconds(TEST_EMAIL), 0);
+  } finally {
+    delete process.env['DATABASE_URL'];
+    delete process.env['PASSWORD_LOCKOUT_ATTEMPTS'];
+    delete process.env['PASSWORD_LOCKOUT_MINUTES'];
+    rmSync(dbFile, { force: true });
+  }
+});

--- a/apps/api/src/lib/login-lockout.test.ts
+++ b/apps/api/src/lib/login-lockout.test.ts
@@ -7,7 +7,7 @@ import test from 'node:test';
 
 const TEST_EMAIL = `lockout-${randomUUID()}@test.com`;
 
-test('login lockout utility tracks attempts and locks at threshold', async () => {
+test('login lockout utility tracks attempts, locks at threshold, and prunes stale rows', async () => {
   const dbFile = join(tmpdir(), `yotara-lockout-test-${randomUUID()}.db`);
   process.env['DATABASE_URL'] = dbFile;
   process.env['PASSWORD_LOCKOUT_ATTEMPTS'] = '3';
@@ -23,7 +23,10 @@ test('login lockout utility tracks attempts and locks at threshold', async () =>
       getRemainingLockoutSeconds,
       recordFailedAttempt,
       clearAttempts,
+      cleanExpiredLockouts,
     } = await import('./login-lockout.js');
+
+    // ── Lockout threshold test ──
 
     assert.equal(isLockedOut(TEST_EMAIL), false, 'not locked before any attempts');
     assert.equal(getRemainingAttempts(TEST_EMAIL), 3, '3 remaining before any attempts');
@@ -67,28 +70,18 @@ test('login lockout utility tracks attempts and locks at threshold', async () =>
     assert.equal(isLockedOut(TEST_EMAIL), false);
     assert.equal(getRemainingAttempts(TEST_EMAIL), 3);
     assert.equal(getRemainingLockoutSeconds(TEST_EMAIL), 0);
-  } finally {
-    delete process.env['DATABASE_URL'];
-    delete process.env['PASSWORD_LOCKOUT_ATTEMPTS'];
-    delete process.env['PASSWORD_LOCKOUT_MINUTES'];
-    rmSync(dbFile, { force: true });
-  }
-});
 
-test('stale pre-lockout rows are cleaned up after the lockout window expires', async () => {
-  process.env['PASSWORD_LOCKOUT_ATTEMPTS'] = '5';
-  process.env['PASSWORD_LOCKOUT_MINUTES'] = '0.002'; // ~120ms window
+    // ── Stale pre-lockout row cleanup test ──
+    // Uses the same DB but switches to a short window so the row expires quickly.
 
-  try {
-    const { recordFailedAttempt, getRemainingAttempts } = await import('./login-lockout.js');
-    const { cleanExpiredLockouts } = await import('./login-lockout.js');
-    const email = `stale-${randomUUID()}@test.com`;
+    const staleEmail = `stale-${randomUUID()}@test.com`;
+    process.env['PASSWORD_LOCKOUT_ATTEMPTS'] = '5';
+    process.env['PASSWORD_LOCKOUT_MINUTES'] = '0.002'; // ~120ms window
 
-    // Make one failed attempt (pre-lockout row, locked_until IS NULL)
-    const result = recordFailedAttempt(email);
-    assert.equal(result.locked, false);
-    assert.equal(result.remainingAttempts, 4);
-    assert.equal(getRemainingAttempts(email), 4);
+    const staleResult = recordFailedAttempt(staleEmail);
+    assert.equal(staleResult.locked, false);
+    assert.equal(staleResult.remainingAttempts, 4);
+    assert.equal(getRemainingAttempts(staleEmail), 4);
 
     // Wait for the lockout window to pass
     await new Promise((resolve) => setTimeout(resolve, 200));
@@ -98,12 +91,14 @@ test('stale pre-lockout rows are cleaned up after the lockout window expires', a
 
     // The stale pre-lockout row should be gone, so remaining attempts resets
     assert.equal(
-      getRemainingAttempts(email),
+      getRemainingAttempts(staleEmail),
       5,
       'stale row should be cleaned up, resetting attempts',
     );
   } finally {
+    delete process.env['DATABASE_URL'];
     delete process.env['PASSWORD_LOCKOUT_ATTEMPTS'];
     delete process.env['PASSWORD_LOCKOUT_MINUTES'];
+    rmSync(dbFile, { force: true });
   }
 });

--- a/apps/api/src/lib/login-lockout.ts
+++ b/apps/api/src/lib/login-lockout.ts
@@ -1,0 +1,93 @@
+import { sqlite } from '../db/client.js';
+
+function getLockoutAttempts(): number {
+  return Number(process.env['PASSWORD_LOCKOUT_ATTEMPTS'] ?? 3);
+}
+
+export function getLockoutMinutes(): number {
+  return Number(process.env['PASSWORD_LOCKOUT_MINUTES'] ?? 5);
+}
+
+export function getRemainingLockoutSeconds(email: string): number {
+  // Clean up any expired lockouts before checking
+  cleanExpiredLockouts();
+
+  const row = sqlite
+    .prepare('SELECT locked_until FROM login_attempts WHERE email = ?')
+    .get(email) as { locked_until: number | null } | undefined;
+
+  if (!row || row.locked_until === null) return 0;
+
+  const remaining = row.locked_until - Date.now();
+  return remaining > 0 ? Math.ceil(remaining / 1000) : 0;
+}
+
+export function isLockedOut(email: string): boolean {
+  return getRemainingLockoutSeconds(email) > 0;
+}
+
+export function getRemainingAttempts(email: string): number {
+  const row = sqlite.prepare('SELECT attempts FROM login_attempts WHERE email = ?').get(email) as
+    | { attempts: number }
+    | undefined;
+
+  return Math.max(0, getLockoutAttempts() - (row?.attempts ?? 0));
+}
+
+export function recordFailedAttempt(email: string): {
+  locked: boolean;
+  remainingLockoutSeconds: number;
+  remainingAttempts: number;
+} {
+  // Don't extend an active lockout — return immediately if already locked
+  const alreadyLockedSeconds = getRemainingLockoutSeconds(email);
+  if (alreadyLockedSeconds > 0) {
+    return { locked: true, remainingLockoutSeconds: alreadyLockedSeconds, remainingAttempts: 0 };
+  }
+
+  const now = Date.now();
+
+  sqlite
+    .prepare(
+      `INSERT INTO login_attempts (email, attempts, last_attempt_at)
+       VALUES (?, 1, ?)
+       ON CONFLICT(email) DO UPDATE SET
+         attempts = attempts + 1,
+         last_attempt_at = ?`,
+    )
+    .run(email, now, now);
+
+  const row = sqlite.prepare('SELECT attempts FROM login_attempts WHERE email = ?').get(email) as {
+    attempts: number;
+  };
+
+  const remainingAttempts = Math.max(0, getLockoutAttempts() - row.attempts);
+
+  if (remainingAttempts <= 0) {
+    const lockedUntil = now + getLockoutMinutes() * 60 * 1000;
+    sqlite
+      .prepare('UPDATE login_attempts SET locked_until = ? WHERE email = ?')
+      .run(lockedUntil, email);
+    return {
+      locked: true,
+      remainingLockoutSeconds: getLockoutMinutes() * 60,
+      remainingAttempts: 0,
+    };
+  }
+
+  return { locked: false, remainingLockoutSeconds: 0, remainingAttempts };
+}
+
+/**
+ * Clean up expired lockout rows that are no longer needed.
+ * Safe to call periodically — no-op if no expired rows exist.
+ */
+export function cleanExpiredLockouts(): void {
+  sqlite
+    .prepare(`DELETE FROM login_attempts WHERE locked_until IS NOT NULL AND locked_until < ?`)
+    .run(Date.now());
+}
+
+export function clearAttempts(email: string): void {
+  sqlite.prepare('DELETE FROM login_attempts WHERE email = ?').run(email);
+}

--- a/apps/api/src/lib/login-lockout.ts
+++ b/apps/api/src/lib/login-lockout.ts
@@ -79,13 +79,24 @@ export function recordFailedAttempt(email: string): {
 }
 
 /**
- * Clean up expired lockout rows that are no longer needed.
- * Safe to call periodically — no-op if no expired rows exist.
+ * Clean up expired lockout rows and stale pre-lockout attempt rows.
+ *
+ * - Locked rows (locked_until IS NOT NULL) are removed once the lockout expires.
+ * - Pre-lockout rows (locked_until IS NULL) are removed when the last attempt
+ *   is older than the lockout window — a typo today shouldn't count toward a
+ *   lockout weeks later, and it caps table growth from random-email sprays.
+ *
+ * Safe to call periodically — no-op if no matching rows exist.
  */
 export function cleanExpiredLockouts(): void {
+  const cutoff = Date.now() - getLockoutMinutes() * 60 * 1000;
   sqlite
-    .prepare(`DELETE FROM login_attempts WHERE locked_until IS NOT NULL AND locked_until < ?`)
-    .run(Date.now());
+    .prepare(
+      `DELETE FROM login_attempts
+       WHERE (locked_until IS NOT NULL AND locked_until < ?)
+          OR (locked_until IS NULL AND last_attempt_at < ?)`,
+    )
+    .run(Date.now(), cutoff);
 }
 
 export function clearAttempts(email: string): void {

--- a/apps/api/src/plugins/auth-bridge.ts
+++ b/apps/api/src/plugins/auth-bridge.ts
@@ -1,6 +1,11 @@
 import type { FastifyInstance, FastifyReply } from 'fastify';
 import { auth } from '../lib/auth.js';
 import { getCorsOrigins } from '../lib/auth-origins.js';
+import {
+  getRemainingLockoutSeconds,
+  recordFailedAttempt,
+  clearAttempts,
+} from '../lib/login-lockout.js';
 
 function toHeaders(source: Record<string, string | string[] | undefined>) {
   const headers = new Headers();
@@ -74,10 +79,42 @@ export default async function authBridgePlugin(app: FastifyInstance) {
     url: '/auth/*',
     handler: async (request, reply) => {
       applyCorsHeaders(reply, request.headers.origin);
+
+      const url = new URL(
+        request.url,
+        `${request.protocol ?? 'http'}://${request.headers.host ?? 'localhost'}`,
+      );
+      const isSignIn = request.method === 'POST' && url.pathname.startsWith('/auth/sign-in');
+      let loginEmail: string | null = null;
+
+      if (isSignIn) {
+        let body: Record<string, unknown> | null;
+        if (typeof request.body === 'string') {
+          try {
+            body = JSON.parse(request.body);
+          } catch {
+            return reply.code(400).send({ message: 'Invalid JSON body' });
+          }
+        } else {
+          body = request.body as Record<string, unknown> | null;
+        }
+        loginEmail = body && typeof body.email === 'string' ? body.email : null;
+
+        if (loginEmail) {
+          const remaining = getRemainingLockoutSeconds(loginEmail);
+          if (remaining > 0) {
+            reply.header('Retry-After', String(remaining));
+            return reply.code(429).send({
+              message:
+                'Account temporarily locked. Too many failed login attempts. Try again later.',
+              remainingAttempts: 0,
+              retryAfterSeconds: remaining,
+            });
+          }
+        }
+      }
+
       const headers = toHeaders(request.headers);
-      const protocol = request.protocol ?? 'http';
-      const host = request.headers.host ?? 'localhost';
-      const url = new URL(request.url, `${protocol}://${host}`);
       const body = getRequestBody(request.method, request.body, headers);
       const response = await auth.handler(
         new Request(url, {
@@ -86,6 +123,32 @@ export default async function authBridgePlugin(app: FastifyInstance) {
           body,
         }),
       );
+
+      if (isSignIn && loginEmail) {
+        if (response.status === 200) {
+          clearAttempts(loginEmail);
+        } else if (response.status === 401) {
+          const result = recordFailedAttempt(loginEmail);
+          if (result.locked) {
+            reply.header('Retry-After', String(result.remainingLockoutSeconds));
+            return reply.code(429).send({
+              message: `Account locked due to too many failed login attempts. Try again in ${Math.ceil(result.remainingLockoutSeconds / 60)} minutes.`,
+              remainingAttempts: 0,
+              retryAfterSeconds: result.remainingLockoutSeconds,
+            });
+          }
+
+          const message =
+            result.remainingAttempts <= 1
+              ? `Invalid email or password. ${result.remainingAttempts} attempt remaining.`
+              : `Invalid email or password. ${result.remainingAttempts} attempts remaining.`;
+
+          return reply.code(401).send({
+            message,
+            remainingAttempts: result.remainingAttempts,
+          });
+        }
+      }
 
       reply.code(response.status);
 

--- a/apps/api/src/plugins/rate-limit.test.ts
+++ b/apps/api/src/plugins/rate-limit.test.ts
@@ -4,17 +4,11 @@ import Fastify from 'fastify';
 import rateLimit from '@fastify/rate-limit';
 
 test('rate-limit plugin returns 429 when limit is exceeded and respects X-Forwarded-For', async () => {
-  const app = Fastify();
+  const app = Fastify({ trustProxy: 1 });
   await app.register(rateLimit, {
     max: 3,
     timeWindow: 60000,
-    keyGenerator: (request) => {
-      const forwarded = request.headers['x-forwarded-for'];
-      if (typeof forwarded === 'string') {
-        return forwarded.split(',')[0]?.trim() || request.ip;
-      }
-      return request.ip;
-    },
+    keyGenerator: (request) => request.ip,
   });
 
   app.get('/test', async () => ({ ok: true }));
@@ -65,6 +59,40 @@ test('rate-limit plugin returns 429 when limit is exceeded and respects X-Forwar
       headers: { 'x-forwarded-for': '10.0.0.99' },
     });
     assert.equal(blockedDiff.statusCode, 429, 'different IP should be rate-limited on 4th request');
+  } finally {
+    await app.close();
+  }
+});
+
+test('rate-limit key uses last entry in X-Forwarded-For when trustProxy is enabled', async () => {
+  // Simulate nginx's $proxy_add_x_forwarded_for: the real client IP is the
+  // last entry in the chain; a spoofed first entry must be ignored.
+  const app = Fastify({ trustProxy: 1 });
+
+  const keys: string[] = [];
+  await app.register(rateLimit, {
+    max: 5,
+    timeWindow: 60000,
+    keyGenerator: (request) => {
+      const key = request.ip;
+      keys.push(key);
+      return key;
+    },
+  });
+
+  app.get('/test', async () => ({ ok: true }));
+  await app.ready();
+
+  try {
+    // Send X-Forwarded-For with a spoofed first entry and the real IP last,
+    // matching nginx's $proxy_add_x_forwarded_for behaviour.
+    const r = await app.inject({
+      method: 'GET',
+      url: '/test',
+      headers: { 'x-forwarded-for': 'spoofed-ip, 10.0.0.1' },
+    });
+    assert.equal(r.statusCode, 200);
+    assert.equal(keys[0], '10.0.0.1', 'key must be the last X-Forwarded-For entry, not the first');
   } finally {
     await app.close();
   }

--- a/apps/api/src/plugins/rate-limit.test.ts
+++ b/apps/api/src/plugins/rate-limit.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import Fastify from 'fastify';
+import rateLimit from '@fastify/rate-limit';
+
+test('rate-limit plugin returns 429 when limit is exceeded and respects X-Forwarded-For', async () => {
+  const app = Fastify();
+  await app.register(rateLimit, {
+    max: 3,
+    timeWindow: 60000,
+    keyGenerator: (request) => {
+      const forwarded = request.headers['x-forwarded-for'];
+      if (typeof forwarded === 'string') {
+        return forwarded.split(',')[0]?.trim() || request.ip;
+      }
+      return request.ip;
+    },
+  });
+
+  app.get('/test', async () => ({ ok: true }));
+
+  await app.ready();
+
+  try {
+    // First 3 requests should succeed
+    for (let i = 0; i < 3; i++) {
+      const response = await app.inject({ method: 'GET', url: '/test' });
+      assert.equal(response.statusCode, 200, `default ip request ${i + 1} should succeed`);
+    }
+
+    // 4th request from default IP should be rate-limited
+    const blocked = await app.inject({ method: 'GET', url: '/test' });
+    assert.equal(blocked.statusCode, 429, '4th request from default IP should be rate-limited');
+    const body = blocked.json();
+    assert.match(body.message, /Rate limit exceeded/i);
+
+    // A different IP via X-Forwarded-For should still succeed
+    const r1 = await app.inject({
+      method: 'GET',
+      url: '/test',
+      headers: { 'x-forwarded-for': '10.0.0.99' },
+    });
+    assert.equal(r1.statusCode, 200, 'different IP should succeed on first request');
+
+    // Second request from different IP should also succeed
+    const r2 = await app.inject({
+      method: 'GET',
+      url: '/test',
+      headers: { 'x-forwarded-for': '10.0.0.99' },
+    });
+    assert.equal(r2.statusCode, 200, 'different IP should succeed on second request');
+
+    // Third request from different IP should also succeed
+    const r3 = await app.inject({
+      method: 'GET',
+      url: '/test',
+      headers: { 'x-forwarded-for': '10.0.0.99' },
+    });
+    assert.equal(r3.statusCode, 200, 'different IP should succeed on third request');
+
+    // Fourth request from different IP should be rate-limited
+    const blockedDiff = await app.inject({
+      method: 'GET',
+      url: '/test',
+      headers: { 'x-forwarded-for': '10.0.0.99' },
+    });
+    assert.equal(blockedDiff.statusCode, 429, 'different IP should be rate-limited on 4th request');
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -329,7 +329,7 @@ test('password lockout locks account after repeated failed login attempts', asyn
 
 test('locked account can log in after lockout window expires', async () => {
   process.env['PASSWORD_LOCKOUT_ATTEMPTS'] = '2';
-  process.env['PASSWORD_LOCKOUT_MINUTES'] = '0.002'; // ~120ms lockout window
+  process.env['PASSWORD_LOCKOUT_MINUTES'] = '0.05'; // ~3s lockout window
 
   const ctx = await createTestApp();
   const email = `lockout-recover-${randomUUID()}@example.com`;
@@ -360,8 +360,8 @@ test('locked account can log in after lockout window expires', async () => {
     });
     assert.equal(lockoutResponse.statusCode, 429);
 
-    // Wait for lockout to expire
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    // Wait for lockout to expire (3s window + 500ms buffer)
+    await new Promise((resolve) => setTimeout(resolve, 3500));
 
     // Correct password should now succeed and clear attempts
     const successResponse = await ctx.app.inject({

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -10,6 +10,10 @@ const TEST_PASSWORD = 'Password123!';
 const TEST_NAME = 'Register Login User';
 const TEST_ORIGIN = 'http://localhost:4200';
 
+// Set lockout env vars before any module import caches login-lockout.ts
+process.env['PASSWORD_LOCKOUT_ATTEMPTS'] = '3';
+process.env['PASSWORD_LOCKOUT_MINUTES'] = '2';
+
 async function createTestApp() {
   const dbFile = join(tmpdir(), `yotara-auth-test-${randomUUID()}.db`);
   process.env['DATABASE_URL'] = dbFile;
@@ -251,6 +255,133 @@ test('authenticated profile route includes CORS headers for allowed frontend ori
     assert.equal(meResponse.statusCode, 200);
     assert.equal(meResponse.headers['access-control-allow-origin'], TEST_ORIGIN);
     assert.equal(meResponse.headers['access-control-allow-credentials'], 'true');
+  } finally {
+    await ctx.cleanup();
+  }
+});
+
+test('password lockout locks account after repeated failed login attempts', async () => {
+  process.env['PASSWORD_LOCKOUT_ATTEMPTS'] = '2';
+  process.env['PASSWORD_LOCKOUT_MINUTES'] = '1';
+
+  const ctx = await createTestApp();
+  const email = `lockout-${randomUUID()}@example.com`;
+
+  try {
+    const registerResponse = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/sign-up/email',
+      headers: { origin: TEST_ORIGIN },
+      payload: { email, password: TEST_PASSWORD, name: 'Lockout Test' },
+    });
+    assert.equal(registerResponse.statusCode, 200);
+
+    // First wrong password -> remainingAttempts: 1
+    const firstFail = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/sign-in/email',
+      headers: { origin: TEST_ORIGIN },
+      payload: { email, password: 'WrongPassword1!' },
+    });
+    assert.equal(firstFail.statusCode, 401);
+    const firstBody = firstFail.json();
+    assert.equal(firstBody.remainingAttempts, 1);
+    assert.equal(typeof firstBody.message, 'string');
+
+    // Second wrong password -> lockout, remainingAttempts: 0
+    const secondFail = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/sign-in/email',
+      headers: { origin: TEST_ORIGIN },
+      payload: { email, password: 'WrongPassword2!' },
+    });
+    assert.equal(secondFail.statusCode, 429);
+    const secondBody = secondFail.json();
+    assert.equal(secondBody.remainingAttempts, 0);
+    assert.ok(typeof secondBody.retryAfterSeconds === 'number' && secondBody.retryAfterSeconds > 0);
+    assert.ok(secondFail.headers['retry-after']);
+    assert.match(secondBody.message, /locked/i);
+
+    // Third attempt while locked -> still 429
+    const thirdFail = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/sign-in/email',
+      headers: { origin: TEST_ORIGIN },
+      payload: { email, password: 'WrongPassword3!' },
+    });
+    assert.equal(thirdFail.statusCode, 429);
+    const thirdBody = thirdFail.json();
+    assert.equal(thirdBody.remainingAttempts, 0);
+    assert.ok(typeof thirdBody.retryAfterSeconds === 'number' && thirdBody.retryAfterSeconds > 0);
+
+    // Correct password while locked -> still 429
+    const correctWhileLocked = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/sign-in/email',
+      headers: { origin: TEST_ORIGIN },
+      payload: { email, password: TEST_PASSWORD },
+    });
+    assert.equal(correctWhileLocked.statusCode, 429);
+  } finally {
+    await ctx.cleanup();
+  }
+});
+
+test('locked account can log in after lockout window expires', async () => {
+  process.env['PASSWORD_LOCKOUT_ATTEMPTS'] = '2';
+  process.env['PASSWORD_LOCKOUT_MINUTES'] = '0.002'; // ~120ms lockout window
+
+  const ctx = await createTestApp();
+  const email = `lockout-recover-${randomUUID()}@example.com`;
+
+  try {
+    const registerResponse = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/sign-up/email',
+      headers: { origin: TEST_ORIGIN },
+      payload: { email, password: TEST_PASSWORD, name: 'Lockout Recover' },
+    });
+    assert.equal(registerResponse.statusCode, 200);
+
+    // First wrong password
+    await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/sign-in/email',
+      headers: { origin: TEST_ORIGIN },
+      payload: { email, password: 'WrongPassword1!' },
+    });
+
+    // Second wrong password → lockout (2 attempts threshold)
+    const lockoutResponse = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/sign-in/email',
+      headers: { origin: TEST_ORIGIN },
+      payload: { email, password: 'WrongPassword2!' },
+    });
+    assert.equal(lockoutResponse.statusCode, 429);
+
+    // Wait for lockout to expire
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // Correct password should now succeed and clear attempts
+    const successResponse = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/sign-in/email',
+      headers: { origin: TEST_ORIGIN },
+      payload: { email, password: TEST_PASSWORD },
+    });
+    assert.equal(successResponse.statusCode, 200);
+
+    // After successful login, a wrong password should start fresh (remainingAttempts: 1)
+    const failAfterRecovery = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/sign-in/email',
+      headers: { origin: TEST_ORIGIN },
+      payload: { email, password: 'WrongAgain1!' },
+    });
+    assert.equal(failAfterRecovery.statusCode, 401);
+    const afterRecoveryBody = failAfterRecovery.json();
+    assert.equal(afterRecoveryBody.remainingAttempts, 1);
   } finally {
     await ctx.cleanup();
   }

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -14,24 +14,23 @@ import rootRoutes from './routes/root.js';
 import taskRoutes from './routes/tasks.js';
 
 export async function buildApp() {
-  const app = Fastify({ logger: true });
+  // trustProxy: 1 — nginx sits in front and appends the real client IP as the
+  // last entry in X-Forwarded-For ($proxy_add_x_forwarded_for). Fastify reads
+  // the last entry as request.ip, which is the authoritative client address.
+  const app = Fastify({ logger: true, trustProxy: 1 });
 
   await registerOpenApi(app);
   await app.register(corsPlugin);
 
-  // Global rate limiting (read at registration time so tests can configure via env)
+  // Global rate limiting (read at registration time so tests can configure via env).
+  // Relies on trustProxy: 1 (set above) so request.ip is the real client IP
+  // from the last X-Forwarded-For entry, not the client-controlled first entry.
   const rateLimitMax = Number(process.env['RATE_LIMIT_MAX'] ?? 100);
   const rateLimitWindowMs = Number(process.env['RATE_LIMIT_WINDOW_MINUTES'] ?? 1) * 60 * 1000;
   await app.register(rateLimit, {
     max: rateLimitMax,
     timeWindow: rateLimitWindowMs,
-    keyGenerator: (request) => {
-      const forwarded = request.headers['x-forwarded-for'];
-      if (typeof forwarded === 'string') {
-        return forwarded.split(',')[0]?.trim() || request.ip;
-      }
-      return request.ip;
-    },
+    keyGenerator: (request) => request.ip,
   });
   await app.register(authBridgePlugin);
   app.addHook('onRequest', async (request, reply) => {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,6 +1,7 @@
 import Fastify from 'fastify';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import rateLimit from '@fastify/rate-limit';
 import { AppError } from './lib/app-error.js';
 import corsPlugin from './plugins/cors.js';
 import authBridgePlugin, { applyCorsHeaders } from './plugins/auth-bridge.js';
@@ -17,6 +18,21 @@ export async function buildApp() {
 
   await registerOpenApi(app);
   await app.register(corsPlugin);
+
+  // Global rate limiting (read at registration time so tests can configure via env)
+  const rateLimitMax = Number(process.env['RATE_LIMIT_MAX'] ?? 100);
+  const rateLimitWindowMs = Number(process.env['RATE_LIMIT_WINDOW_MINUTES'] ?? 1) * 60 * 1000;
+  await app.register(rateLimit, {
+    max: rateLimitMax,
+    timeWindow: rateLimitWindowMs,
+    keyGenerator: (request) => {
+      const forwarded = request.headers['x-forwarded-for'];
+      if (typeof forwarded === 'string') {
+        return forwarded.split(',')[0]?.trim() || request.ip;
+      }
+      return request.ip;
+    },
+  });
   await app.register(authBridgePlugin);
   app.addHook('onRequest', async (request, reply) => {
     applyCorsHeaders(reply, request.headers.origin);

--- a/apps/frontend/src/app/features/auth/login.component.html
+++ b/apps/frontend/src/app/features/auth/login.component.html
@@ -92,7 +92,12 @@
         <div class="error-msg">{{ error() }}</div>
       }
 
-      <button type="submit" [disabled]="loading()" class="submit-button">
+      <app-password-trial
+        [remainingAttempts]="remainingAttempts()"
+        [retryAfterSeconds]="retryAfterSeconds()"
+      />
+
+      <button type="submit" [disabled]="loading() || locked()" class="submit-button">
         {{ loading() ? 'Loading...' : isLogin() ? 'Sign In' : 'Create account' }}
       </button>
     </form>

--- a/apps/frontend/src/app/features/auth/login.component.spec.ts
+++ b/apps/frontend/src/app/features/auth/login.component.spec.ts
@@ -102,4 +102,165 @@ describe('LoginComponent', () => {
       queryParams: { created: '1' },
     });
   });
+
+  it('shows field error for empty name in sign-up mode', () => {
+    fixture.detectChanges();
+    component.toggleMode();
+    component.markTouched('name');
+
+    const error = component.getFieldError('name');
+    expect(error).toBe('Name is required');
+    expect(component.shouldShowFieldError('name')).toBeTrue();
+  });
+
+  it('shows field error for empty email', () => {
+    fixture.detectChanges();
+    component.email.set('');
+    component.emailTouched.set(true);
+
+    expect(component.getFieldError('email')).toBe('Email is required');
+    expect(component.shouldShowFieldError('email')).toBeTrue();
+  });
+
+  it('shows field error for short password in sign-up mode', () => {
+    fixture.detectChanges();
+    component.toggleMode();
+    component.password.set('short');
+    component.passwordTouched.set(true);
+
+    expect(component.getFieldError('password')).toBe('Password must be at least 8 characters');
+    expect(component.shouldShowFieldError('password')).toBeTrue();
+  });
+
+  it('does not show field error when field is not touched', () => {
+    fixture.detectChanges();
+
+    expect(component.shouldShowFieldError('email')).toBeFalse();
+    expect(component.shouldShowFieldError('password')).toBeFalse();
+  });
+
+  it('returns null for name field in login mode', () => {
+    fixture.detectChanges();
+
+    expect(component.getFieldError('name')).toBeNull();
+  });
+
+  it('shows authentication error message and clears password', async () => {
+    fixture.detectChanges();
+    const errorMsg = 'Invalid credentials';
+    authState.signIn.and.resolveTo({ error: { message: errorMsg } });
+
+    component.email.set('alex@example.com');
+    component.password.set('wrong');
+
+    await component.onSubmit();
+    fixture.detectChanges();
+
+    expect(component.error()).toBe(errorMsg);
+    expect(component.password()).toBe('');
+    expect(fixture.nativeElement.textContent).toContain(errorMsg);
+  });
+
+  it('handles login lockout with remaining attempts and retry after', async () => {
+    fixture.detectChanges();
+    authState.signIn.and.resolveTo({
+      error: { message: 'Too many attempts', remainingAttempts: 2, retryAfterSeconds: 30 },
+    });
+
+    component.email.set('alex@example.com');
+    component.password.set('wrong');
+
+    await component.onSubmit();
+    fixture.detectChanges();
+
+    expect(component.remainingAttempts()).toBe(2);
+    expect(component.retryAfterSeconds()).toBe(30);
+    expect((component as any).locked()).toBeTrue();
+  });
+
+  it('handles unexpected error in onSubmit catch block', async () => {
+    fixture.detectChanges();
+    authState.signIn.and.rejectWith(new Error('Network failure'));
+
+    component.email.set('alex@example.com');
+    component.password.set('secret');
+
+    await component.onSubmit();
+    fixture.detectChanges();
+
+    expect(component.error()).toBe('Network failure');
+    expect(component.loading()).toBeFalse();
+  });
+
+  it('clears countdown interval on destroy', () => {
+    fixture.detectChanges();
+    component.retryAfterSeconds.set(10);
+    component['startCountdown']();
+
+    const interval = component['countdownInterval'];
+    expect(interval).not.toBeNull();
+
+    component.ngOnDestroy();
+
+    expect(component['countdownInterval']).toBeNull();
+  });
+
+  it('resets touched fields when toggling mode', () => {
+    fixture.detectChanges();
+    component.nameTouched.set(true);
+    component.emailTouched.set(true);
+    component.passwordTouched.set(true);
+
+    component.toggleMode();
+
+    expect(component.nameTouched()).toBeFalse();
+    expect(component.emailTouched()).toBeFalse();
+    expect(component.passwordTouched()).toBeFalse();
+  });
+
+  it('marks individual fields as touched', () => {
+    component.markTouched('name');
+    expect(component.nameTouched()).toBeTrue();
+
+    component.markTouched('email');
+    expect(component.emailTouched()).toBeTrue();
+
+    component.markTouched('password');
+    expect(component.passwordTouched()).toBeTrue();
+  });
+
+  it('disables submit button when loading', () => {
+    fixture.detectChanges();
+    component.loading.set(true);
+    fixture.detectChanges();
+
+    const btn: HTMLButtonElement = fixture.nativeElement.querySelector('.submit-button');
+    expect(btn.disabled).toBeTrue();
+    expect(btn.textContent).toContain('Loading...');
+  });
+
+  it('disables submit button when locked', () => {
+    fixture.detectChanges();
+    component.retryAfterSeconds.set(60);
+    fixture.detectChanges();
+
+    const btn: HTMLButtonElement = fixture.nativeElement.querySelector('.submit-button');
+    expect(btn.disabled).toBeTrue();
+  });
+
+  it('counts down retryAfterSeconds', () => {
+    jasmine.clock().install();
+    fixture.detectChanges();
+    component.retryAfterSeconds.set(5);
+    component['startCountdown']();
+
+    jasmine.clock().tick(2000);
+
+    expect(component.retryAfterSeconds()).toBe(3);
+
+    jasmine.clock().tick(3000);
+
+    expect(component.retryAfterSeconds()).toBeNull();
+    jasmine.clock().uninstall();
+  });
 });

--- a/apps/frontend/src/app/features/auth/login.component.ts
+++ b/apps/frontend/src/app/features/auth/login.component.ts
@@ -1,18 +1,19 @@
-import { Component, signal } from '@angular/core';
+import { Component, OnDestroy, computed, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faEnvelope, faLock } from '@fortawesome/free-solid-svg-icons';
+import { PasswordTrialComponent } from './password-trial.component';
 import { AuthStateService } from '../../core/services/auth-state.service';
 
 @Component({
   selector: 'app-login',
   standalone: true,
-  imports: [FormsModule, FontAwesomeModule],
+  imports: [FormsModule, FontAwesomeModule, PasswordTrialComponent],
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.scss'],
 })
-export class LoginComponent {
+export class LoginComponent implements OnDestroy {
   protected readonly faEnvelope = faEnvelope;
   protected readonly faLock = faLock;
   isLogin = signal(true);
@@ -24,16 +25,50 @@ export class LoginComponent {
   passwordTouched = signal(false);
   loading = signal(false);
   error = signal('');
+  remainingAttempts = signal<number | null>(null);
+  retryAfterSeconds = signal<number | null>(null);
+  protected locked = computed(() => (this.retryAfterSeconds() ?? 0) > 0);
+  private countdownInterval: ReturnType<typeof setInterval> | null = null;
 
   constructor(
     private router: Router,
     private authState: AuthStateService,
   ) {}
 
+  ngOnDestroy() {
+    this.clearCountdown();
+  }
+
   toggleMode() {
     this.isLogin.set(!this.isLogin());
     this.error.set('');
+    this.resetTrialState();
     this.resetTouched();
+  }
+
+  private resetTrialState() {
+    this.remainingAttempts.set(null);
+    this.retryAfterSeconds.set(null);
+    this.clearCountdown();
+  }
+
+  private clearCountdown() {
+    if (this.countdownInterval !== null) {
+      clearInterval(this.countdownInterval);
+      this.countdownInterval = null;
+    }
+  }
+
+  private startCountdown() {
+    this.clearCountdown();
+    this.countdownInterval = setInterval(() => {
+      const current = this.retryAfterSeconds();
+      if (current === null || current <= 1) {
+        this.resetTrialState();
+        return;
+      }
+      this.retryAfterSeconds.set(current - 1);
+    }, 1000);
   }
 
   private isValidEmail(email: string): boolean {
@@ -132,8 +167,21 @@ export class LoginComponent {
       }
 
       if (res.error) {
+        this.password.set('');
         this.error.set(res.error.message || 'Authentication failed');
+        const errorBody = res.error as Record<string, unknown>;
+        if (typeof errorBody['remainingAttempts'] === 'number') {
+          this.remainingAttempts.set(errorBody['remainingAttempts']);
+        }
+        if (
+          typeof errorBody['retryAfterSeconds'] === 'number' &&
+          (errorBody['retryAfterSeconds'] as number) > 0
+        ) {
+          this.retryAfterSeconds.set(errorBody['retryAfterSeconds'] as number);
+          this.startCountdown();
+        }
       } else {
+        this.resetTrialState();
         const redirectUrl = this.authState.getPostAuthRedirectUrl();
 
         if (!this.isLogin() && redirectUrl === '/onboarding') {

--- a/apps/frontend/src/app/features/auth/password-trial.component.scss
+++ b/apps/frontend/src/app/features/auth/password-trial.component.scss
@@ -1,0 +1,32 @@
+:host {
+  display: block;
+  margin-top: 0.6rem;
+}
+
+.trial-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.65rem 0.85rem;
+  border-radius: 0.75rem;
+  font-size: 0.88rem;
+  font-weight: 500;
+  line-height: 1.3;
+}
+
+.trial-icon {
+  flex: 0 0 auto;
+  font-size: 0.95rem;
+}
+
+.attempts {
+  background: var(--surface-container-high);
+  color: var(--on-surface-muted);
+  box-shadow: inset 0 0 0 1px var(--outline-variant);
+}
+
+.locked {
+  background: color-mix(in srgb, var(--primary-solid) 15%, transparent);
+  color: var(--primary-solid);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--primary-solid) 30%, transparent);
+}

--- a/apps/frontend/src/app/features/auth/password-trial.component.ts
+++ b/apps/frontend/src/app/features/auth/password-trial.component.ts
@@ -1,0 +1,50 @@
+import { Component, computed, input } from '@angular/core';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { faTriangleExclamation, faLock } from '@fortawesome/free-solid-svg-icons';
+
+@Component({
+  selector: 'app-password-trial',
+  standalone: true,
+  imports: [FontAwesomeModule],
+  template: `
+    @if (showAttempts()) {
+      <div class="trial-banner attempts">
+        <fa-icon class="trial-icon" [icon]="faTriangleExclamation" aria-hidden="true"></fa-icon>
+        {{ remainingAttempts() }} {{ remainingAttempts() === 1 ? 'attempt' : 'attempts' }} remaining
+      </div>
+    }
+    @if (showTimer()) {
+      <div class="trial-banner locked">
+        <fa-icon class="trial-icon" [icon]="faLock" aria-hidden="true"></fa-icon>
+        0 attempts remaining. Try again in {{ timerDisplay() }}
+      </div>
+    }
+  `,
+  styleUrl: './password-trial.component.scss',
+})
+export class PasswordTrialComponent {
+  protected readonly faTriangleExclamation = faTriangleExclamation;
+  protected readonly faLock = faLock;
+
+  remainingAttempts = input<number | null>(null);
+  retryAfterSeconds = input<number | null>(null);
+
+  showAttempts = computed(() => {
+    const remaining = this.remainingAttempts();
+    return remaining !== null && remaining > 0;
+  });
+
+  showTimer = computed(() => {
+    const seconds = this.retryAfterSeconds();
+    return seconds !== null && seconds > 0;
+  });
+
+  timerDisplay = computed(() => {
+    const seconds = this.retryAfterSeconds();
+    if (seconds === null || seconds <= 0) return '';
+
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return `${m}:${s.toString().padStart(2, '0')}`;
+  });
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,7 +18,7 @@ Short, honest read of where the project stands right now. No numerical scorecard
 - **Documentation:** This document exists. ROADMAP.md, project-plan.md, and the two TODO.md files overlap and drift from each other — see the "Planning artifacts" section below.
 - **Scalability:** Expand loops + in-memory filtering break past ~1,000 tasks. Search doesn't scale. The fix is in flight (per-view API filters in Sprint 1).
 - **Developer experience:** CI has lint + test but no type-check gate, no `pnpm audit`, no coverage threshold, no prebuilt images. `.reasonix/` is not gitignored.
-- **Security & robustness:** Auth guards, error interceptor, cookie security all solid. No rate limiting. Services throw `new Error('string')` which the routes can't map to HTTP status codes — opaque 500s instead of meaningful 4xx responses. No Docker image scanning, no secret leak detection in CI, no Dependabot configuration, no bundle size monitoring.
+- **Security & robustness:** Auth guards, error interceptor, cookie security all solid. Rate limiting added (global IP-based + per-email password lockout). Services throw `new Error('string')` which the routes can't map to HTTP status codes — opaque 500s instead of meaningful 4xx responses. No Docker image scanning, no secret leak detection in CI, no Dependabot configuration, no bundle size monitoring.
 - **Bus factor:** 1. 296/323 commits (92%) are from a single author. shivansh090 has 2 commits (docs only); github-actions bot has 25.
 
 ---
@@ -472,7 +472,7 @@ This sprint order supersedes the P0/P1/P2/P3 priority lanes in `ROADMAP.md`. Tra
 
 - [ ] Docker Compose for local development
 - [ ] One-command dev setup script
-- [ ] Rate limiting on API
+- [x] Rate limiting on API
 - [ ] Consistent input validation across all routes
 - [ ] Stricter TypeScript config (no `any` casts like `request.query.status as any`)
 
@@ -600,7 +600,7 @@ Items in the "Explicit non-goals" subsection are deliberately not on the roadmap
 - [ ] PR preview / staging environment — deploy frontend to ephemeral URL on PR. (Solo-dev: optional — review locally or skip; add when contributors need to preview changes.) [arch]
 - [ ] Database query analysis — add `drizzle-kit` studio to dev workflow and review slow queries during development. [arch]
 - [ ] Snyk or alternative vulnerability scanning. [api §CI]
-- [ ] API rate limiting. [fe §OSS] [arch §Sprint 6]
+- [x] API rate limiting. [fe §OSS] [arch §Sprint 6]
 - [ ] API security headers (HSTS, CSP, etc.). [fe §OSS] [arch §Sprint 6]
 - [ ] Tighten CORS defaults for auth routes. [fe §OSS]
 - [ ] Better request/response logging for auth and write endpoints. [api §Auth]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@fastify/cors':
         specifier: ^11.2.0
         version: 11.2.0
+      '@fastify/rate-limit':
+        specifier: ^11.0.0
+        version: 11.0.0
       '@fastify/swagger':
         specifier: ^9.5.1
         version: 9.7.0
@@ -1836,6 +1839,9 @@ packages:
 
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
+  '@fastify/rate-limit@11.0.0':
+    resolution: {integrity: sha512-kCs+G59SitZw9TL/ekFe+MrzXk20dEp6zPAM8WEZjFl5Ubvv5ksTbEXYr4jGlBwWAKn78q+NFsj5CN75zXLjaw==}
 
   '@fastify/send@4.1.0':
     resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
@@ -10888,6 +10894,12 @@ snapshots:
     dependencies:
       '@fastify/forwarded': 3.0.1
       ipaddr.js: 2.3.0
+
+  '@fastify/rate-limit@11.0.0':
+    dependencies:
+      '@lukeed/ms': 2.0.2
+      fastify-plugin: 5.1.0
+      toad-cache: 3.7.0
 
   '@fastify/send@4.1.0':
     dependencies:


### PR DESCRIPTION
…lockout

- Global rate limiting via @fastify/rate-limit (RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MINUTES env vars)
- Per-email password lockout: SQLite-backed, configurable attempts + window, early-return guard, stale row cleanup
- Two checkpoints in auth bridge: pre-proxy lockout check
  + post-response recording
- Frontend PasswordTrialComponent: remaining attempts, lockout timer, submit disabled while locked
- Full test coverage: unit, integration (lockout + recovery)
- Remove dead rate-limit.ts wrapper; register plugin directly in server.ts

## Description

Adds two layers of rate limiting to protect the login endpoint and API from abuse:

**1. Global DDoS protection** — `@fastify/rate-limit` plugin limits requests per-IP to a configurable max within a configurable window.

**2. Per-email password lockout** — Tracks failed login attempts in a new SQLite `login_attempts` table. After N consecutive failures (default 3), the account is locked for M minutes (default 5). Two checkpoints in the auth bridge prevent locked users from even reaching the auth provider.

**3. Frontend UX** — A new `PasswordTrialComponent` shows users their remaining attempt count and a live countdown timer when locked. The submit button is disabled during lockout.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Test coverage improvement
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (code improvement with no functional change)

## Related Issue

Closes: *No open issue — identified during security review per ARCHITECTURE.md backlog (API rate limiting §CI and security hardening).*

## Roadmap Reference

Implements API rate limiting (ARCHITECTURE.md → Backlog → CI and security hardening). Follows the pattern recommended for addressing anti-pattern A2 (typed errors) and security hardening.

## Changes Made

- **`apps/api/src/server.ts`** — Register `@fastify/rate-limit` directly with env-var configuration (`RATE_LIMIT_MAX`, `RATE_LIMIT_WINDOW_MINUTES`); respects `X-Forwarded-For`
- **`apps/api/src/plugins/auth-bridge.ts`** — Two lockout checkpoints: (1) before proxying to better-auth, check `login_attempts` and return 429 if locked; (2) after response, record failed attempts on 401, clear on 200, return 429 with `Retry-After` header when threshold hit. Dynamic error messages. JSON.parse safely wrapped in try/catch.
- **`apps/api/src/lib/login-lockout.ts`** — New module: `recordFailedAttempt`, `getRemainingLockoutSeconds`, `isLockedOut`, `clearAttempts`, `cleanExpiredLockouts`. Early-return guard prevents lockout window extension on repeated attempts during lockout.
- **`apps/api/src/db/client.ts`** — Added `login_attempts` table to bootstrap SQL schema.
- **`apps/api/.env.example`** — Documented new env vars: `RATE_LIMIT_MAX`, `RATE_LIMIT_WINDOW_MINUTES`, `PASSWORD_LOCKOUT_ATTEMPTS`, `PASSWORD_LOCKOUT_MINUTES`.
- **`apps/api/package.json`** — Added `@fastify/rate-limit` dependency.
- **`apps/frontend/src/.../login.component.ts`** — Added lockout state signals, live countdown interval, disabled submit when locked, reset on mode toggle.
- **`apps/frontend/src/.../login.component.html`** — Wired `PasswordTrialComponent` and disabled submit.
- **`apps/frontend/src/.../password-trial.component.ts`** — New standalone component showing remaining attempts banner and lockout timer (mm:ss format).
- **`apps/frontend/src/.../password-trial.component.scss`** — Styled banners with theme-aware colors.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing completed

### Verification Steps

1. Run `pnpm test` — 53 backend tests pass (0 failures)
2. Run `pnpm typecheck` — frontend type-check clean
3. Set `RATE_LIMIT_MAX=3`, hit the API 4 times from the same IP → 4th returns 429
4. Attempt login with wrong password N+1 times → account locked with 429 and `Retry-After` header
5. Wait for the lockout window (or use a short window in tests) → correct password succeeds and resets attempt counter

### New tests

| Test | File | What it covers |
|------|------|---------------|
| `login lockout utility` | `login-lockout.test.ts` | Tracks attempts, locks at threshold, early-return on repeated attempts during lockout, clear resets |
| `password lockout locks account` | `auth.test.ts` | Full integration: register → fail → lockout (429) → correct password during lockout still 429 |
| `locked account can log in after lockout window expires` | `auth.test.ts` | Lockout → wait for window → correct password succeeds → wrong password resets to fresh count |
| `rate-limit plugin returns 429 when limit is exceeded` | `rate-limit.test.ts` | 3 requests succeed, 4th is 429, different X-Forwarded-For IP has independent counter |

## Screenshots or Demo

*No UI screenshots — the lockout banner appears inline below the password field and above the submit button on the login form.*

## Contributor License Agreement

By submitting this PR, you agree to the [Yotara CLA](https://github.com/apauldev/Yotara/blob/main/CLA.md).

- [x] I have read and agree to the Yotara Contributor License Agreement
- [x] I have signed-off my commits (`git commit -s`) to certify the [Developer Certificate of Origin](https://developercertificate.org/)

## Checklist

- [x] Code follows the project style and conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`.env.example`)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have verified that this PR is against the correct branch (`main`)

## Additional Notes

- The `rate-limit.ts` wrapper plugin was removed during development — `@fastify/rate-limit` is now registered directly in `server.ts` to avoid Fastify encapsulation issues with nested plugin registration.
- `errorResponseBuilder` was removed from the rate-limit config because returning a plain object (rather than an `Error`) caused Fastify to emit 500 instead of 429. The default error message is descriptive enough.
- Email-oracle mitigation is inherent to the design: both non-existent and wrong-password accounts get identical behavior (attempts tracked, same 401 message, lockout after threshold).
