### PR TITLE
fix: replace N+1 label queries with batch fetch in task listing

### DIFF
--- a/apps/api/drizzle/0005_add_task_labels_index.sql
+++ b/apps/api/drizzle/0005_add_task_labels_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS `idx_task_labels_task_id` ON `task_labels`(`task_id`);

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1778673964935,
       "tag": "0004_noisy_black_knight",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1782993449825,
+      "tag": "0005_add_task_labels_index",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/services/label-service.test.ts
+++ b/apps/api/src/services/label-service.test.ts
@@ -173,6 +173,29 @@ test('Label Service', async (t) => {
       assert.equal(taskLabelsAfter.length, 1);
       assert.equal(taskLabelsAfter[0].name, 'Sync 1');
     });
+    await t.test('getLabelsForTasks', async () => {
+      const label1 = await ctx.labelService.createLabelForOwner(ownerId, { name: 'Batch 1' });
+      const label2 = await ctx.labelService.createLabelForOwner(ownerId, { name: 'Batch 2' });
+      const label3 = await ctx.labelService.createLabelForOwner(ownerId, { name: 'Batch 3' });
+      assert.ok(label1 && label2 && label3);
+
+      const { createTaskForOwner } = await import('./task-service.js');
+      const task1 = await createTaskForOwner(ownerId, { title: 'Task 1' });
+      const task2 = await createTaskForOwner(ownerId, { title: 'Task 2' });
+      const task3 = await createTaskForOwner(ownerId, { title: 'Task 3' });
+      assert.ok(task1 && task2 && task3);
+
+      await ctx.labelService.syncTaskLabels(ownerId, task1.id, [label1.id, label2.id]);
+      await ctx.labelService.syncTaskLabels(ownerId, task2.id, [label3.id]);
+
+      const map = await ctx.labelService.getLabelsForTasks([task1.id, task2.id, task3.id]);
+      assert.deepEqual([...map.get(task1.id)!.sort()], [label1.id, label2.id].sort());
+      assert.deepEqual(map.get(task2.id), [label3.id]);
+      assert.equal(map.has(task3.id), false);
+
+      const emptyMap = await ctx.labelService.getLabelsForTasks([]);
+      assert.equal(emptyMap.size, 0);
+    });
   } finally {
     ctx.cleanup();
   }

--- a/apps/api/src/services/label-service.ts
+++ b/apps/api/src/services/label-service.ts
@@ -185,6 +185,37 @@ export async function getTaskLabels(taskId: string) {
   return rows.map((row) => toLabel({ ...row, taskCount: 0 }));
 }
 
+/**
+ * Batch-fetch label IDs for multiple tasks in a single query.
+ * Chunks taskIds to stay within SQLite's 999-parameter limit ($SQLITE_LIMIT_VARIABLE_NUMBER).
+ * Returns a Map<taskId, labelId[]>. Tasks without labels are absent from the map.
+ */
+const IN_ARRAY_BATCH = 999;
+export async function getLabelsForTasks(taskIds: string[]): Promise<Map<string, string[]>> {
+  if (taskIds.length === 0) return new Map();
+
+  const map = new Map<string, string[]>();
+  for (let i = 0; i < taskIds.length; i += IN_ARRAY_BATCH) {
+    const batch = taskIds.slice(i, i + IN_ARRAY_BATCH);
+    const rows = await db
+      .select({ taskId: taskLabels.taskId, labelId: labels.id })
+      .from(taskLabels)
+      .innerJoin(labels, eq(taskLabels.labelId, labels.id))
+      .where(inArray(taskLabels.taskId, batch))
+      .orderBy(asc(labels.name));
+
+    for (const row of rows) {
+      const existing = map.get(row.taskId);
+      if (existing) {
+        existing.push(row.labelId);
+      } else {
+        map.set(row.taskId, [row.labelId]);
+      }
+    }
+  }
+  return map;
+}
+
 function pickLabelColor(name: string) {
   const palette = ['#82d7a9', '#81d7e8', '#f1c582', '#c7e9b3', '#a5d3e1', '#bcd0fb'];
   const index =

--- a/apps/api/src/services/task-service.ts
+++ b/apps/api/src/services/task-service.ts
@@ -15,7 +15,7 @@ import { DateTime } from 'luxon';
 import { nowIsoTimestamp } from '../lib/timestamps.js';
 import { todayInTimezone, startOfDayInUtc } from '../lib/timezone.js';
 import { AppError, BadRequestError, NotFoundError } from '../lib/app-error.js';
-import { getTaskLabels, syncTaskLabels } from './label-service.js';
+import { getLabelsForTasks, getTaskLabels, syncTaskLabels } from './label-service.js';
 import { getDefaultProjectForOwner } from './project-service.js';
 
 type TaskRow = typeof tasks.$inferSelect;
@@ -228,14 +228,9 @@ export async function listTasksForOwner(
     .offset(offset);
 
   const totalPages = total === 0 ? 0 : Math.ceil(total / pageSize);
-  const data = await Promise.all(
-    rows.map(async (row) =>
-      toTask(
-        row,
-        (await getTaskLabels(row.id)).map((label) => label.id),
-      ),
-    ),
-  );
+  const taskIds = rows.map((r) => r.id);
+  const labelsMap = await getLabelsForTasks(taskIds);
+  const data = rows.map((row) => toTask(row, labelsMap.get(row.id) ?? []));
 
   return {
     data,
@@ -274,14 +269,9 @@ export async function listSubtasks(parentId: string, ownerId: string): Promise<T
     .where(and(eq(tasks.parentId, parentId), eq(tasks.userId, ownerId), isNull(tasks.deletedAt)))
     .orderBy(asc(tasks.order), asc(tasks.createdAt));
 
-  return Promise.all(
-    rows.map(async (row) =>
-      toTask(
-        row,
-        (await getTaskLabels(row.id)).map((l) => l.id),
-      ),
-    ),
-  );
+  const taskIds = rows.map((r) => r.id);
+  const labelsMap = await getLabelsForTasks(taskIds);
+  return rows.map((row) => toTask(row, labelsMap.get(row.id) ?? []));
 }
 
 function advanceDueDate(from: string, rule: RecurrenceRule): string {


### PR DESCRIPTION
## Description

`listTasksForOwner` and `listSubtasks` each called `getTaskLabels(row.id)` inside a `Promise.all` loop — one SQL query per task. On a page of 50 tasks this made 51 queries. Replaced with `getLabelsForTasks` that fetches all label IDs for a set of tasks in a single batched query, reducing it to 2 queries total.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Performance improvement

## Changes Made

- Added `getLabelsForTasks(taskIds)` to `label-service.ts` — batch-fetches `(taskId, labelId)` pairs in a single query with `INNER JOIN labels`, chunked in batches of 999 to stay within SQLite's `SQLITE_LIMIT_VARIABLE_NUMBER`
- Replaced `Promise.all(rows.map(r => getTaskLabels(r.id)))` in `listTasksForOwner` and `listSubtasks` with a single `getLabelsForTasks` call + map lookup
- Added Drizzle migration `0005_add_task_labels_index.sql` — index on `task_labels.task_id`
- Registered migration in `drizzle/meta/_journal.json`
- Added test covering: tasks with multiple labels, one label, no labels, and empty input

## Testing

- `pnpm --filter @yotara/api test` — 92/92 tests pass
- `pnpm --filter @yotara/api typecheck` — clean
- `pnpm --filter @yotara/frontend build` — compiles successfully
- `pnpm lint` — 0 errors, 0 new warnings

## Checklist

- [x] Code follows the project style and conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have verified that this PR is against the correct branch (`main`)