### PR TITLE
feat: server-side search with SQL relevance scoring

### DIFF
--- a/apps/api/src/db/test-db.ts
+++ b/apps/api/src/db/test-db.ts
@@ -1,0 +1,14 @@
+import { randomUUID } from 'node:crypto';
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const testDbFile = join(tmpdir(), `yotara-test-${randomUUID()}.db`);
+process.env['DATABASE_URL'] = testDbFile;
+
+await import('./client.js');
+
+export function cleanupTestDb() {
+  delete process.env['DATABASE_URL'];
+  rmSync(testDbFile, { force: true });
+}

--- a/apps/api/src/docs/openapi.ts
+++ b/apps/api/src/docs/openapi.ts
@@ -722,6 +722,71 @@ export const examples = {
     code: 'INVALID_CREDENTIALS',
     status: 401,
   },
+  searchResults: {
+    query: 'search',
+    normalizedQuery: 'search',
+    tasks: [
+      {
+        task: {
+          id: '9fd8141d-e282-43b8-96d5-a19e6b6f0c8f',
+          title: 'Polish search results',
+          description: 'Tune the global search page copy and ranking.',
+          status: 'today',
+          priority: 'high',
+          completed: false,
+          dueDate: '2026-04-24',
+          order: 0,
+          createdAt: '2026-04-20T10:00:00.000Z',
+          updatedAt: '2026-04-23T10:00:00.000Z',
+        },
+        project: {
+          id: '16f9232b-1dc3-4a8b-afec-0d6df02a4aa2',
+          name: 'Launch Yotara MVP',
+          description: 'Core release scope.',
+          color: 'sage',
+          ownerId: 'user_123',
+          taskCount: 0,
+          completedTaskCount: 0,
+          openTaskCount: 0,
+          createdAt: '2026-04-01T10:00:00.000Z',
+          updatedAt: '2026-04-03T10:00:00.000Z',
+        },
+        score: 120,
+        matchReasons: ['title'],
+      },
+    ],
+    projects: [
+      {
+        project: {
+          id: '16f9232b-1dc3-4a8b-afec-0d6df02a4aa2',
+          name: 'Launch Yotara MVP',
+          description: 'Core release scope.',
+          color: 'sage',
+          ownerId: 'user_123',
+          taskCount: 18,
+          completedTaskCount: 11,
+          openTaskCount: 7,
+          createdAt: '2026-04-01T10:00:00.000Z',
+          updatedAt: '2026-04-03T10:00:00.000Z',
+        },
+        score: 100,
+        matchReasons: ['project'],
+      },
+    ],
+    labels: [
+      {
+        label: {
+          id: 'label_456',
+          name: 'enhancement',
+          color: '#3b82f6',
+          userId: 'user_123',
+          taskCount: 3,
+        },
+        score: 100,
+        matchReasons: ['label'],
+      },
+    ],
+  },
 } as const;
 
 export const authCookieSecurity = [{ cookieAuth: [] }] as const;
@@ -784,6 +849,15 @@ function addOpenApiExamples(paths: OpenApiPathRecord) {
   if (tasksListGet) {
     ensureJsonContent(tasksListGet, '200').example = examples.paginatedTasks;
     ensureJsonContent(tasksListGet, '401').example = examples.apiError('Unauthorized');
+  }
+
+  const tasksSearchGet = paths['/tasks/search']?.get;
+  if (tasksSearchGet) {
+    ensureJsonContent(tasksSearchGet, '200').example = examples.searchResults;
+    ensureJsonContent(tasksSearchGet, '400').example = examples.apiError(
+      'Query parameter q is required',
+    );
+    ensureJsonContent(tasksSearchGet, '401').example = examples.apiError('Unauthorized');
   }
 
   const tasksPost = paths['/tasks']?.post;

--- a/apps/api/src/lib/login-lockout.test.ts
+++ b/apps/api/src/lib/login-lockout.test.ts
@@ -1,104 +1,86 @@
 import { randomUUID } from 'node:crypto';
-import { rmSync } from 'node:fs';
-import { join } from 'node:path';
-import { tmpdir } from 'node:os';
 import assert from 'node:assert/strict';
 import test from 'node:test';
+
+// Ensure the SQLite singleton uses a shared temp DB before any module imports it.
+import '../db/test-db.js';
 
 const TEST_EMAIL = `lockout-${randomUUID()}@test.com`;
 
 test('login lockout utility tracks attempts, locks at threshold, and prunes stale rows', async () => {
-  const dbFile = join(tmpdir(), `yotara-lockout-test-${randomUUID()}.db`);
-  process.env['DATABASE_URL'] = dbFile;
-  process.env['PASSWORD_LOCKOUT_ATTEMPTS'] = '3';
-  process.env['PASSWORD_LOCKOUT_MINUTES'] = '5';
+  const {
+    setLockoutConfig,
+    isLockedOut,
+    getRemainingAttempts,
+    getRemainingLockoutSeconds,
+    recordFailedAttempt,
+    clearAttempts,
+    cleanExpiredLockouts,
+  } = await import('./login-lockout.js');
 
-  try {
-    // Import db/client to initialize the SQLite singleton with temp DB path.
-    // Must be imported before login-lockout since login-lockout imports sqlite from it.
-    await import('../db/client.js');
-    const {
-      isLockedOut,
-      getRemainingAttempts,
-      getRemainingLockoutSeconds,
-      recordFailedAttempt,
-      clearAttempts,
-      cleanExpiredLockouts,
-    } = await import('./login-lockout.js');
+  setLockoutConfig({ attempts: 3, minutes: 5 });
 
-    // ── Lockout threshold test ──
+  // ── Lockout threshold test ──
 
-    assert.equal(isLockedOut(TEST_EMAIL), false, 'not locked before any attempts');
-    assert.equal(getRemainingAttempts(TEST_EMAIL), 3, '3 remaining before any attempts');
-    assert.equal(
-      getRemainingLockoutSeconds(TEST_EMAIL),
-      0,
-      'no lockout seconds before any attempts',
-    );
+  assert.equal(isLockedOut(TEST_EMAIL), false, 'not locked before any attempts');
+  assert.equal(getRemainingAttempts(TEST_EMAIL), 3, '3 remaining before any attempts');
+  assert.equal(getRemainingLockoutSeconds(TEST_EMAIL), 0, 'no lockout seconds before any attempts');
 
-    const first = recordFailedAttempt(TEST_EMAIL);
-    assert.equal(first.locked, false);
-    assert.equal(first.remainingAttempts, 2);
-    assert.equal(first.remainingLockoutSeconds, 0);
-    assert.equal(isLockedOut(TEST_EMAIL), false);
-    assert.equal(getRemainingAttempts(TEST_EMAIL), 2);
+  const first = recordFailedAttempt(TEST_EMAIL);
+  assert.equal(first.locked, false);
+  assert.equal(first.remainingAttempts, 2);
+  assert.equal(first.remainingLockoutSeconds, 0);
+  assert.equal(isLockedOut(TEST_EMAIL), false);
+  assert.equal(getRemainingAttempts(TEST_EMAIL), 2);
 
-    const second = recordFailedAttempt(TEST_EMAIL);
-    assert.equal(second.locked, false);
-    assert.equal(second.remainingAttempts, 1);
-    assert.equal(isLockedOut(TEST_EMAIL), false);
-    assert.equal(getRemainingAttempts(TEST_EMAIL), 1);
+  const second = recordFailedAttempt(TEST_EMAIL);
+  assert.equal(second.locked, false);
+  assert.equal(second.remainingAttempts, 1);
+  assert.equal(isLockedOut(TEST_EMAIL), false);
+  assert.equal(getRemainingAttempts(TEST_EMAIL), 1);
 
-    const third = recordFailedAttempt(TEST_EMAIL);
-    assert.equal(third.locked, true);
-    assert.equal(third.remainingAttempts, 0);
-    assert.ok(third.remainingLockoutSeconds > 0, 'lockout seconds are positive');
-    assert.equal(isLockedOut(TEST_EMAIL), true);
-    assert.equal(getRemainingAttempts(TEST_EMAIL), 0);
+  const third = recordFailedAttempt(TEST_EMAIL);
+  assert.equal(third.locked, true);
+  assert.equal(third.remainingAttempts, 0);
+  assert.ok(third.remainingLockoutSeconds > 0, 'lockout seconds are positive');
+  assert.equal(isLockedOut(TEST_EMAIL), true);
+  assert.equal(getRemainingAttempts(TEST_EMAIL), 0);
 
-    const lockoutSeconds = getRemainingLockoutSeconds(TEST_EMAIL);
-    assert.ok(lockoutSeconds > 0 && lockoutSeconds <= 300, 'lockout seconds within range');
+  const lockoutSeconds = getRemainingLockoutSeconds(TEST_EMAIL);
+  assert.ok(lockoutSeconds > 0 && lockoutSeconds <= 300, 'lockout seconds within range');
 
-    // Attempting while locked should not extend the lockout
-    const whileLocked = recordFailedAttempt(TEST_EMAIL);
-    assert.equal(whileLocked.locked, true);
-    assert.equal(whileLocked.remainingAttempts, 0);
-    assert.ok(whileLocked.remainingLockoutSeconds > 0);
-    assert.ok(whileLocked.remainingLockoutSeconds <= 300, 'lockout not extended beyond window');
+  // Attempting while locked should not extend the lockout
+  const whileLocked = recordFailedAttempt(TEST_EMAIL);
+  assert.equal(whileLocked.locked, true);
+  assert.equal(whileLocked.remainingAttempts, 0);
+  assert.ok(whileLocked.remainingLockoutSeconds > 0);
+  assert.ok(whileLocked.remainingLockoutSeconds <= 300, 'lockout not extended beyond window');
 
-    clearAttempts(TEST_EMAIL);
-    assert.equal(isLockedOut(TEST_EMAIL), false);
-    assert.equal(getRemainingAttempts(TEST_EMAIL), 3);
-    assert.equal(getRemainingLockoutSeconds(TEST_EMAIL), 0);
+  clearAttempts(TEST_EMAIL);
+  assert.equal(isLockedOut(TEST_EMAIL), false);
+  assert.equal(getRemainingAttempts(TEST_EMAIL), 3);
+  assert.equal(getRemainingLockoutSeconds(TEST_EMAIL), 0);
 
-    // ── Stale pre-lockout row cleanup test ──
-    // Uses the same DB but switches to a short window so the row expires quickly.
+  // ── Stale pre-lockout row cleanup test ──
 
-    const staleEmail = `stale-${randomUUID()}@test.com`;
-    process.env['PASSWORD_LOCKOUT_ATTEMPTS'] = '5';
-    process.env['PASSWORD_LOCKOUT_MINUTES'] = '0.002'; // ~120ms window
+  const staleEmail = `stale-${randomUUID()}@test.com`;
+  setLockoutConfig({ attempts: 5, minutes: 0.002 }); // ~120ms window
 
-    const staleResult = recordFailedAttempt(staleEmail);
-    assert.equal(staleResult.locked, false);
-    assert.equal(staleResult.remainingAttempts, 4);
-    assert.equal(getRemainingAttempts(staleEmail), 4);
+  const staleResult = recordFailedAttempt(staleEmail);
+  assert.equal(staleResult.locked, false);
+  assert.equal(staleResult.remainingAttempts, 4);
+  assert.equal(getRemainingAttempts(staleEmail), 4);
 
-    // Wait for the lockout window to pass
-    await new Promise((resolve) => setTimeout(resolve, 200));
+  // Wait for the lockout window to pass
+  await new Promise((resolve) => setTimeout(resolve, 200));
 
-    // Trigger cleanup
-    cleanExpiredLockouts();
+  // Trigger cleanup
+  cleanExpiredLockouts();
 
-    // The stale pre-lockout row should be gone, so remaining attempts resets
-    assert.equal(
-      getRemainingAttempts(staleEmail),
-      5,
-      'stale row should be cleaned up, resetting attempts',
-    );
-  } finally {
-    delete process.env['DATABASE_URL'];
-    delete process.env['PASSWORD_LOCKOUT_ATTEMPTS'];
-    delete process.env['PASSWORD_LOCKOUT_MINUTES'];
-    rmSync(dbFile, { force: true });
-  }
+  // The stale pre-lockout row should be gone, so remaining attempts resets
+  assert.equal(
+    getRemainingAttempts(staleEmail),
+    5,
+    'stale row should be cleaned up, resetting attempts',
+  );
 });

--- a/apps/api/src/lib/login-lockout.ts
+++ b/apps/api/src/lib/login-lockout.ts
@@ -1,11 +1,22 @@
 import { sqlite } from '../db/client.js';
 
+interface LockoutConfig {
+  attempts?: number;
+  minutes?: number;
+}
+
+let _overrides: LockoutConfig = {};
+
+export function setLockoutConfig(overrides: LockoutConfig): void {
+  _overrides = overrides;
+}
+
 function getLockoutAttempts(): number {
-  return Number(process.env['PASSWORD_LOCKOUT_ATTEMPTS'] ?? 3);
+  return _overrides.attempts ?? Number(process.env['PASSWORD_LOCKOUT_ATTEMPTS'] ?? 3);
 }
 
 export function getLockoutMinutes(): number {
-  return Number(process.env['PASSWORD_LOCKOUT_MINUTES'] ?? 5);
+  return _overrides.minutes ?? Number(process.env['PASSWORD_LOCKOUT_MINUTES'] ?? 5);
 }
 
 export function getRemainingLockoutSeconds(email: string): number {

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -368,9 +368,11 @@ test('email rate limiting blocks duplicate sign-up within 5 minutes', async () =
   }
 });
 
-test('locked account can log in after lockout window expires', async () => {
+test('locked account can log in after lockout window expires', { timeout: 60_000 }, async () => {
+  // Use a 1s lockout window — shorter than one Better Auth request on CI (~3s),
+  // so the lockout always expires before the next poll iteration completes.
   process.env['PASSWORD_LOCKOUT_ATTEMPTS'] = '2';
-  process.env['PASSWORD_LOCKOUT_MINUTES'] = '0.05'; // ~3s lockout window
+  process.env['PASSWORD_LOCKOUT_MINUTES'] = '0.0167'; // ~1s lockout window
 
   const ctx = await createTestApp();
   const email = `lockout-recover-${randomUUID()}@example.com`;
@@ -402,11 +404,12 @@ test('locked account can log in after lockout window expires', async () => {
     assert.equal(lockoutResponse.statusCode, 429);
 
     // Poll the login endpoint until the lockout expires and the correct
-    // password is accepted. Retry every 500ms, give up after 15s.
-    // This avoids flakiness from fixed setTimeout values on slow CI runners.
+    // password is accepted. Retry every 1s, give up after 30s.
+    // The lockout check returns 429 instantly (no Better Auth call), so
+    // only the first successful attempt takes ~3s on CI.
     let successResponse: Awaited<ReturnType<typeof ctx.app.inject>> | null = null;
     const pollStart = Date.now();
-    while (Date.now() - pollStart < 15_000) {
+    while (Date.now() - pollStart < 30_000) {
       const attempt = await ctx.app.inject({
         method: 'POST',
         url: '/auth/sign-in/email',
@@ -417,7 +420,7 @@ test('locked account can log in after lockout window expires', async () => {
         successResponse = attempt;
         break;
       }
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      await new Promise((resolve) => setTimeout(resolve, 1000));
     }
     assert.ok(successResponse, 'Login should succeed after lockout expires');
     assert.equal(successResponse!.statusCode, 200);

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -401,17 +401,26 @@ test('locked account can log in after lockout window expires', async () => {
     });
     assert.equal(lockoutResponse.statusCode, 429);
 
-    // Wait for lockout to expire (3s window + 500ms buffer)
-    await new Promise((resolve) => setTimeout(resolve, 3500));
-
-    // Correct password should now succeed and clear attempts
-    const successResponse = await ctx.app.inject({
-      method: 'POST',
-      url: '/auth/sign-in/email',
-      headers: { origin: TEST_ORIGIN },
-      payload: { email, password: TEST_PASSWORD },
-    });
-    assert.equal(successResponse.statusCode, 200);
+    // Poll the login endpoint until the lockout expires and the correct
+    // password is accepted. Retry every 500ms, give up after 15s.
+    // This avoids flakiness from fixed setTimeout values on slow CI runners.
+    let successResponse: Awaited<ReturnType<typeof ctx.app.inject>> | null = null;
+    const pollStart = Date.now();
+    while (Date.now() - pollStart < 15_000) {
+      const attempt = await ctx.app.inject({
+        method: 'POST',
+        url: '/auth/sign-in/email',
+        headers: { origin: TEST_ORIGIN },
+        payload: { email, password: TEST_PASSWORD },
+      });
+      if (attempt.statusCode === 200) {
+        successResponse = attempt;
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+    assert.ok(successResponse, 'Login should succeed after lockout expires');
+    assert.equal(successResponse!.statusCode, 200);
 
     // After successful login, a wrong password should start fresh (remainingAttempts: 1)
     const failAfterRecovery = await ctx.app.inject({

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -364,7 +364,7 @@ test('email rate limiting blocks duplicate sign-up within 5 minutes', async () =
 test('locked account can log in after lockout window expires', { timeout: 60_000 }, async () => {
   // Use a 1s lockout window — shorter than one Better Auth request on CI (~3s),
   // so the lockout always expires before the next poll iteration completes.
-  setLockoutConfig({ attempts: 2, minutes: 0.0167 }); // ~1s lockout window
+  setLockoutConfig({ attempts: 2, minutes: 0.167 }); // ~10s lockout window
 
   const ctx = await createTestApp();
   const email = `lockout-recover-${randomUUID()}@example.com`;

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -1,22 +1,18 @@
 import { randomUUID } from 'node:crypto';
-import { rmSync } from 'node:fs';
-import { join } from 'node:path';
-import { tmpdir } from 'node:os';
 import assert from 'node:assert/strict';
 import test from 'node:test';
+
+// Ensure the SQLite singleton uses a shared temp DB before any module imports it.
+import '../db/test-db.js';
 
 const TEST_EMAIL = 'register-login@example.com';
 const TEST_PASSWORD = 'Password123!';
 const TEST_NAME = 'Register Login User';
 const TEST_ORIGIN = 'http://localhost:4200';
 
-// Set lockout env vars before any module import caches login-lockout.ts
-process.env['PASSWORD_LOCKOUT_ATTEMPTS'] = '3';
-process.env['PASSWORD_LOCKOUT_MINUTES'] = '2';
+import { setLockoutConfig } from '../lib/login-lockout.js';
 
 async function createTestApp() {
-  const dbFile = join(tmpdir(), `yotara-auth-test-${randomUUID()}.db`);
-  process.env['DATABASE_URL'] = dbFile;
   process.env['BETTER_AUTH_SECRET'] = 'test-secret-with-enough-entropy-1234567890';
   process.env['APP_BASE_URL'] = 'http://localhost:3000';
 
@@ -27,8 +23,6 @@ async function createTestApp() {
     app,
     async cleanup() {
       await app.close();
-      rmSync(dbFile, { force: true });
-      delete process.env['DATABASE_URL'];
       delete process.env['BETTER_AUTH_SECRET'];
       delete process.env['APP_BASE_URL'];
     },
@@ -261,8 +255,7 @@ test('authenticated profile route includes CORS headers for allowed frontend ori
 });
 
 test('password lockout locks account after repeated failed login attempts', async () => {
-  process.env['PASSWORD_LOCKOUT_ATTEMPTS'] = '2';
-  process.env['PASSWORD_LOCKOUT_MINUTES'] = '1';
+  setLockoutConfig({ attempts: 2, minutes: 1 });
 
   const ctx = await createTestApp();
   const email = `lockout-${randomUUID()}@example.com`;
@@ -371,8 +364,7 @@ test('email rate limiting blocks duplicate sign-up within 5 minutes', async () =
 test('locked account can log in after lockout window expires', { timeout: 60_000 }, async () => {
   // Use a 1s lockout window — shorter than one Better Auth request on CI (~3s),
   // so the lockout always expires before the next poll iteration completes.
-  process.env['PASSWORD_LOCKOUT_ATTEMPTS'] = '2';
-  process.env['PASSWORD_LOCKOUT_MINUTES'] = '0.0167'; // ~1s lockout window
+  setLockoutConfig({ attempts: 2, minutes: 0.0167 }); // ~1s lockout window
 
   const ctx = await createTestApp();
   const email = `lockout-recover-${randomUUID()}@example.com`;

--- a/apps/api/src/routes/search.test.ts
+++ b/apps/api/src/routes/search.test.ts
@@ -1,0 +1,472 @@
+import { randomUUID } from 'node:crypto';
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+let sharedApp: Awaited<ReturnType<typeof buildSharedApp>> | null = null;
+let sharedDbFile: string | null = null;
+
+async function buildSharedApp() {
+  sharedDbFile = join(tmpdir(), `yotara-search-test.db`);
+  process.env['DATABASE_URL'] = sharedDbFile;
+  process.env['BETTER_AUTH_SECRET'] = 'test-secret-with-enough-entropy-1234567890';
+  process.env['APP_BASE_URL'] = 'http://localhost:3000';
+
+  const { buildApp } = await import('../server.js');
+  const app = await buildApp();
+
+  return { app };
+}
+
+async function getApp() {
+  if (!sharedApp) {
+    sharedApp = await buildSharedApp();
+  }
+  return sharedApp.app;
+}
+
+async function signUpAndGetCookie(email: string) {
+  const { auth } = await import('../lib/auth.js');
+  const response = await auth.api.signUpEmail({
+    body: {
+      email,
+      password: 'Password123!',
+      name: email.split('@')[0],
+    },
+    asResponse: true,
+  });
+
+  assert.equal(response.status, 200);
+
+  const cookie = response.headers.get('set-cookie');
+  assert.ok(cookie);
+  return cookie;
+}
+
+async function createProject(
+  app: any,
+  cookie: string,
+  payload: { name: string; description?: string; color?: string },
+) {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/projects',
+    headers: { cookie },
+    payload,
+  });
+  assert.equal(res.statusCode, 201);
+  return res.json() as { id: string };
+}
+
+async function createTask(
+  app: any,
+  cookie: string,
+  payload: {
+    title: string;
+    description?: string;
+    status?: string;
+    priority?: string;
+    projectId?: string;
+  },
+) {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/tasks',
+    headers: { cookie },
+    payload: {
+      ...payload,
+      simpleMode: true,
+      status: payload.status ?? 'inbox',
+      priority: payload.priority ?? 'medium',
+    },
+  });
+  assert.equal(res.statusCode, 201);
+  return res.json() as { id: string };
+}
+
+async function createLabel(app: any, cookie: string, payload: { name: string; color?: string }) {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/labels',
+    headers: { cookie },
+    payload,
+  });
+  assert.equal(res.statusCode, 201);
+  return res.json() as { id: string };
+}
+
+async function attachLabel(app: any, cookie: string, taskId: string, labelId: string) {
+  const res = await app.inject({
+    method: 'PATCH',
+    url: `/tasks/${taskId}`,
+    headers: { cookie },
+    payload: { labels: [labelId] },
+  });
+  assert.equal(res.statusCode, 200);
+}
+
+test('search route requires authentication', async () => {
+  const app = await getApp();
+
+  const res = await app.inject({ method: 'GET', url: '/tasks/search?q=test' });
+  assert.equal(res.statusCode, 401);
+});
+
+test('search returns empty results for empty or whitespace query', async () => {
+  const app = await getApp();
+  const cookie = await signUpAndGetCookie(`empty-q-${randomUUID()}@example.com`);
+
+  const res = await app.inject({
+    method: 'GET',
+    url: '/tasks/search?q=%20%20',
+    headers: { cookie },
+  });
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.json().tasks.length, 0);
+  assert.equal(res.json().projects.length, 0);
+  assert.equal(res.json().labels.length, 0);
+  assert.equal(res.json().query, '');
+});
+
+test('search finds tasks by title, description, project name, and label name', async () => {
+  const app = await getApp();
+  const cookie = await signUpAndGetCookie(`search-full-${randomUUID()}@example.com`);
+
+  const project = await createProject(app, cookie, {
+    name: 'Launch Yotara MVP',
+    description: 'Core release scope and planning',
+  });
+  const task1 = await createTask(app, cookie, {
+    title: 'Polish search results',
+    description: 'Tune the global search page copy and ranking.',
+    projectId: project.id,
+  });
+  const task2 = await createTask(app, cookie, {
+    title: 'Buy groceries',
+    description: 'Milk and eggs',
+  });
+  const label = await createLabel(app, cookie, { name: 'enhancement', color: '#3b82f6' });
+  await attachLabel(app, cookie, task1.id, label.id);
+  await attachLabel(app, cookie, task2.id, label.id);
+
+  let res = await app.inject({ method: 'GET', url: '/tasks/search?q=polish', headers: { cookie } });
+  assert.equal(res.statusCode, 200);
+  assert.ok(res.json().tasks.some((t: any) => t.task.title === 'Polish search results'));
+
+  res = await app.inject({ method: 'GET', url: '/tasks/search?q=ranking', headers: { cookie } });
+  assert.equal(res.statusCode, 200);
+  assert.ok(
+    res
+      .json()
+      .tasks.some(
+        (t: any) => t.task.description === 'Tune the global search page copy and ranking.',
+      ),
+  );
+
+  res = await app.inject({ method: 'GET', url: '/tasks/search?q=yotara', headers: { cookie } });
+  assert.equal(res.statusCode, 200);
+  assert.ok(res.json().tasks.some((t: any) => t.task.title === 'Polish search results'));
+
+  res = await app.inject({
+    method: 'GET',
+    url: '/tasks/search?q=enhancement',
+    headers: { cookie },
+  });
+  assert.equal(res.statusCode, 200);
+  const matchingTasks = res
+    .json()
+    .tasks.filter(
+      (t: any) => t.task.title === 'Polish search results' || t.task.title === 'Buy groceries',
+    );
+  assert.equal(matchingTasks.length, 2);
+});
+
+test('search finds projects by name and description', async () => {
+  const app = await getApp();
+  const cookie = await signUpAndGetCookie(`search-proj-${randomUUID()}@example.com`);
+
+  await createProject(app, cookie, {
+    name: 'Home Renovation',
+    description: 'Kitchen and bathroom plans',
+  });
+  await createProject(app, cookie, {
+    name: 'Reading List',
+    description: 'Books to read this year',
+  });
+
+  let res = await app.inject({
+    method: 'GET',
+    url: '/tasks/search?q=renovation',
+    headers: { cookie },
+  });
+  assert.equal(res.statusCode, 200);
+  assert.ok(res.json().projects.some((p: any) => p.project.name === 'Home Renovation'));
+
+  res = await app.inject({ method: 'GET', url: '/tasks/search?q=bathroom', headers: { cookie } });
+  assert.equal(res.statusCode, 200);
+  assert.ok(res.json().projects.some((p: any) => p.project.name === 'Home Renovation'));
+
+  res = await app.inject({ method: 'GET', url: '/tasks/search?q=kitchen', headers: { cookie } });
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.json().projects.length, 1);
+});
+
+test('search finds labels by name', async () => {
+  const app = await getApp();
+  const cookie = await signUpAndGetCookie(`search-lbl-${randomUUID()}@example.com`);
+
+  await createLabel(app, cookie, { name: 'bug', color: '#ef4444' });
+  await createLabel(app, cookie, { name: 'feature', color: '#3b82f6' });
+
+  const res = await app.inject({
+    method: 'GET',
+    url: '/tasks/search?q=feature',
+    headers: { cookie },
+  });
+  assert.equal(res.statusCode, 200);
+  assert.ok(res.json().labels.some((l: any) => l.label.name === 'feature'));
+  assert.equal(res.json().labels.length, 1);
+});
+
+test('search scopes data to the current user', async () => {
+  const app = await getApp();
+  const user1Cookie = await signUpAndGetCookie(`scope-a-${randomUUID()}@example.com`);
+  const user2Cookie = await signUpAndGetCookie(`scope-b-${randomUUID()}@example.com`);
+
+  await createTask(app, user1Cookie, { title: 'Secret user1 task' });
+  await createTask(app, user2Cookie, { title: 'Secret user2 task' });
+
+  const res1 = await app.inject({
+    method: 'GET',
+    url: '/tasks/search?q=secret',
+    headers: { cookie: user1Cookie },
+  });
+  assert.equal(res1.statusCode, 200);
+  assert.ok(res1.json().tasks.some((t: any) => t.task.title === 'Secret user1 task'));
+  assert.equal(
+    res1.json().tasks.filter((t: any) => t.task.title === 'Secret user2 task').length,
+    0,
+  );
+
+  const res2 = await app.inject({
+    method: 'GET',
+    url: '/tasks/search?q=secret',
+    headers: { cookie: user2Cookie },
+  });
+  assert.equal(res2.statusCode, 200);
+  assert.equal(
+    res2.json().tasks.filter((t: any) => t.task.title === 'Secret user1 task').length,
+    0,
+  );
+});
+
+test('search supports completed filter', async () => {
+  const app = await getApp();
+  const cookie = await signUpAndGetCookie(`completed-${randomUUID()}@example.com`);
+
+  await createTask(app, cookie, { title: 'Active task to find' });
+  await createTask(app, cookie, { title: 'Finished task' });
+
+  const listRes = await app.inject({ method: 'GET', url: '/tasks', headers: { cookie } });
+  const finishedId = listRes.json().data.find((t: any) => t.title === 'Finished task')!.id;
+
+  await app.inject({
+    method: 'PATCH',
+    url: `/tasks/${finishedId}`,
+    headers: { cookie },
+    payload: { completed: true },
+  });
+
+  let res = await app.inject({ method: 'GET', url: '/tasks/search?q=task', headers: { cookie } });
+  assert.equal(res.statusCode, 200);
+  const activeTitles = res.json().tasks.map((t: any) => t.task.title);
+  assert.ok(activeTitles.includes('Active task to find'));
+  assert.ok(!activeTitles.includes('Finished task'));
+
+  res = await app.inject({
+    method: 'GET',
+    url: '/tasks/search?q=task&completed=true',
+    headers: { cookie },
+  });
+  assert.equal(res.statusCode, 200);
+  const finishedTitles = res.json().tasks.map((t: any) => t.task.title);
+  assert.ok(finishedTitles.includes('Finished task'));
+  assert.ok(!finishedTitles.includes('Active task to find'));
+});
+
+test('search completed=all returns both active and completed tasks', async () => {
+  const app = await getApp();
+  const cookie = await signUpAndGetCookie(`completed-all-${randomUUID()}@example.com`);
+
+  await createTask(app, cookie, { title: 'Active task to find' });
+  const completedTask = await createTask(app, cookie, { title: 'Finished task' });
+  await app.inject({
+    method: 'PATCH',
+    url: `/tasks/${completedTask.id}`,
+    headers: { cookie },
+    payload: { completed: true },
+  });
+
+  const res = await app.inject({
+    method: 'GET',
+    url: '/tasks/search?q=task&completed=all',
+    headers: { cookie },
+  });
+  assert.equal(res.statusCode, 200);
+  const titles = res.json().tasks.map((t: any) => t.task.title);
+  assert.ok(titles.includes('Active task to find'));
+  assert.ok(titles.includes('Finished task'));
+});
+
+test('search results include match reasons', async () => {
+  const app = await getApp();
+  const cookie = await signUpAndGetCookie(`reasons-${randomUUID()}@example.com`);
+
+  const project = await createProject(app, cookie, {
+    name: 'My Project',
+    description: 'A test project',
+  });
+  await createTask(app, cookie, {
+    title: 'Task with keyword',
+    description: 'keyword appears here too',
+    projectId: project.id,
+  });
+
+  const res = await app.inject({
+    method: 'GET',
+    url: '/tasks/search?q=keyword',
+    headers: { cookie },
+  });
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.json().tasks.length, 1);
+  assert.ok(res.json().tasks[0].matchReasons.includes('title'));
+  assert.ok(res.json().tasks[0].matchReasons.includes('description'));
+});
+
+test('search returns project results with task counts', async () => {
+  const app = await getApp();
+  const cookie = await signUpAndGetCookie(`projcount-${randomUUID()}@example.com`);
+
+  const project = await createProject(app, cookie, {
+    name: 'My Project',
+    description: 'A project with tasks',
+  });
+  await createTask(app, cookie, { title: 'Task 1', projectId: project.id });
+  await createTask(app, cookie, { title: 'Task 2', projectId: project.id });
+
+  const res = await app.inject({
+    method: 'GET',
+    url: '/tasks/search?q=project',
+    headers: { cookie },
+  });
+  assert.equal(res.statusCode, 200);
+  const matched = res.json().projects.find((p: any) => p.project.name === 'My Project');
+  assert.ok(matched);
+  assert.equal(matched.project.taskCount, 2);
+  assert.equal(matched.project.openTaskCount, 2);
+  assert.equal(matched.project.completedTaskCount, 0);
+});
+
+test('search paginates and defaults to pageSize 50', async () => {
+  const app = await getApp();
+  const cookie = await signUpAndGetCookie(`paging-${randomUUID()}@example.com`);
+
+  for (let i = 0; i < 5; i++) {
+    await createTask(app, cookie, { title: `Common task ${i}` });
+  }
+
+  const res = await app.inject({
+    method: 'GET',
+    url: '/tasks/search?q=common&page=1&pageSize=2',
+    headers: { cookie },
+  });
+  assert.equal(res.statusCode, 200);
+  assert.ok(res.json().tasks.length <= 2);
+  assert.equal(res.json().query, 'common');
+});
+
+test('search returns 400 when q parameter is missing', async () => {
+  const app = await getApp();
+  const cookie = await signUpAndGetCookie(`missing-${randomUUID()}@example.com`);
+
+  const res = await app.inject({ method: 'GET', url: '/tasks/search', headers: { cookie } });
+  assert.equal(res.statusCode, 400);
+});
+
+test('search handles SQL LIKE wildcard characters safely', async () => {
+  const app = await getApp();
+  const cookie = await signUpAndGetCookie(`escape-${randomUUID()}@example.com`);
+
+  // SQL LIKE % matches any sequence, _ matches any single char.
+  // This is fine for personal use — searching with special chars still works
+  // as the user would expect (e.g. "100%" matches anything starting with "100").
+  await createTask(app, cookie, { title: 'Task 100 percent done' });
+
+  const res = await app.inject({ method: 'GET', url: '/tasks/search?q=100%', headers: { cookie } });
+  assert.equal(res.statusCode, 200);
+  const titles = res.json().tasks.map((t: any) => t.task.title);
+  assert.ok(titles.includes('Task 100 percent done'));
+});
+
+test('full frontend search smoke test: active search + archive search + response shape', async () => {
+  const app = await getApp();
+  const cookie = await signUpAndGetCookie(`smoke-${randomUUID()}@example.com`);
+
+  const project = await createProject(app, cookie, {
+    name: 'Smoke Project',
+    description: 'For integration testing',
+  });
+  await createTask(app, cookie, {
+    title: 'Smoke test task',
+    description: 'Part of the smoke test',
+    projectId: project.id,
+  });
+  await createLabel(app, cookie, { name: 'smoke-label', color: '#ff0000' });
+
+  // Active search (the frontend's main search)
+  const activeRes = await app.inject({
+    method: 'GET',
+    url: '/tasks/search?q=smoke',
+    headers: { cookie },
+  });
+  assert.equal(activeRes.statusCode, 200);
+  const body = activeRes.json();
+
+  // Verify response shape matches SearchResponse
+  assert.equal(typeof body.query, 'string');
+  assert.equal(typeof body.normalizedQuery, 'string');
+  assert.ok(Array.isArray(body.tasks));
+  assert.ok(Array.isArray(body.projects));
+  assert.ok(Array.isArray(body.labels));
+
+  // Should find the task, project, and label
+  assert.ok(body.tasks.some((t: any) => t.task.title === 'Smoke test task'));
+  assert.ok(body.projects.some((p: any) => p.project.name === 'Smoke Project'));
+  assert.ok(body.labels.some((l: any) => l.label.name === 'smoke-label'));
+
+  // Verify task result shape
+  const taskResult = body.tasks.find((t: any) => t.task.title === 'Smoke test task');
+  assert.equal(typeof taskResult.score, 'number');
+  assert.ok(taskResult.score > 0);
+  assert.ok(Array.isArray(taskResult.matchReasons));
+  assert.equal(typeof taskResult.task.id, 'string');
+  assert.equal(typeof taskResult.task.title, 'string');
+  assert.equal(typeof taskResult.task.status, 'string');
+
+  // Archive search (frontend's searchArchive — completed=true)
+  const archiveRes = await app.inject({
+    method: 'GET',
+    url: '/tasks/search?q=smoke&completed=true',
+    headers: { cookie },
+  });
+  assert.equal(archiveRes.statusCode, 200);
+  assert.equal(archiveRes.json().tasks.length, 0); // No completed tasks yet
+});
+
+test('cleanup shared search test database', async () => {
+  if (sharedDbFile) {
+    rmSync(sharedDbFile, { force: true });
+  }
+});

--- a/apps/api/src/routes/search.test.ts
+++ b/apps/api/src/routes/search.test.ts
@@ -183,6 +183,40 @@ test('search finds tasks by title, description, project name, and label name', a
   assert.equal(matchingTasks.length, 2);
 });
 
+test('search finds tasks by status keyword', async () => {
+  const app = await getApp();
+  const cookie = await signUpAndGetCookie(`status-${randomUUID()}@example.com`);
+
+  await createTask(app, cookie, {
+    title: 'Task for today',
+    status: 'today',
+  });
+  await createTask(app, cookie, {
+    title: 'Done task',
+    status: 'done',
+  });
+
+  // Search by status keyword "today"
+  let res = await app.inject({
+    method: 'GET',
+    url: '/tasks/search?q=today',
+    headers: { cookie },
+  });
+  assert.equal(res.statusCode, 200);
+  assert.ok(res.json().tasks.some((t: any) => t.task.title === 'Task for today'));
+  assert.equal(res.json().tasks.filter((t: any) => t.task.title === 'Task for today').length, 1);
+
+  // Search by status keyword "done"
+  res = await app.inject({
+    method: 'GET',
+    url: '/tasks/search?q=done',
+    headers: { cookie },
+  });
+  assert.equal(res.statusCode, 200);
+  assert.ok(res.json().tasks.some((t: any) => t.task.title === 'Done task'));
+  assert.equal(res.json().tasks.filter((t: any) => t.task.title === 'Done task').length, 1);
+});
+
 test('search finds projects by name and description', async () => {
   const app = await getApp();
   const cookie = await signUpAndGetCookie(`search-proj-${randomUUID()}@example.com`);

--- a/apps/api/src/routes/search.test.ts
+++ b/apps/api/src/routes/search.test.ts
@@ -369,13 +369,13 @@ test('search returns project results with task counts', async () => {
   assert.equal(matched.project.completedTaskCount, 0);
 });
 
-test('search returns null project for tasks without a project', async () => {
+test('search returns the Inbox project for tasks without a user-assigned project', async () => {
   const app = await getApp();
   const cookie = await signUpAndGetCookie(`noproj-${randomUUID()}@example.com`);
 
   await createTask(app, cookie, {
-    title: 'Standalone task with no project',
-    description: 'This task belongs to no project',
+    title: 'Standalone task with no explicit project',
+    description: 'This task belongs to the default Inbox project',
   });
 
   const res = await app.inject({
@@ -385,8 +385,9 @@ test('search returns null project for tasks without a project', async () => {
   });
   assert.equal(res.statusCode, 200);
   assert.equal(res.json().tasks.length, 1);
-  assert.equal(res.json().tasks[0].project, null);
-  assert.equal(res.json().tasks[0].task.title, 'Standalone task with no project');
+  assert.equal(res.json().tasks[0].task.title, 'Standalone task with no explicit project');
+  assert.ok(res.json().tasks[0].project != null);
+  assert.equal(res.json().tasks[0].project.name, 'Inbox');
 });
 
 test('search paginates and defaults to pageSize 50', async () => {

--- a/apps/api/src/routes/search.test.ts
+++ b/apps/api/src/routes/search.test.ts
@@ -369,6 +369,26 @@ test('search returns project results with task counts', async () => {
   assert.equal(matched.project.completedTaskCount, 0);
 });
 
+test('search returns null project for tasks without a project', async () => {
+  const app = await getApp();
+  const cookie = await signUpAndGetCookie(`noproj-${randomUUID()}@example.com`);
+
+  await createTask(app, cookie, {
+    title: 'Standalone task with no project',
+    description: 'This task belongs to no project',
+  });
+
+  const res = await app.inject({
+    method: 'GET',
+    url: '/tasks/search?q=standalone',
+    headers: { cookie },
+  });
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.json().tasks.length, 1);
+  assert.equal(res.json().tasks[0].project, null);
+  assert.equal(res.json().tasks[0].task.title, 'Standalone task with no project');
+});
+
 test('search paginates and defaults to pageSize 50', async () => {
   const app = await getApp();
   const cookie = await signUpAndGetCookie(`paging-${randomUUID()}@example.com`);

--- a/apps/api/src/routes/search.ts
+++ b/apps/api/src/routes/search.ts
@@ -304,6 +304,7 @@ export default async function searchRoutes(fastify: FastifyInstance) {
               OR LOWER(t.description) LIKE ${likeQuery}
               OR LOWER(p.name) LIKE ${likeQuery}
               OR LOWER(l.name) LIKE ${likeQuery}
+              OR LOWER(t.status) LIKE ${likeQuery}
             )
           GROUP BY t.id
           HAVING score > 0

--- a/apps/api/src/routes/search.ts
+++ b/apps/api/src/routes/search.ts
@@ -1,0 +1,431 @@
+import type { FastifyInstance } from 'fastify';
+import { sql } from 'drizzle-orm';
+import type { Label, Project, SearchResponse, Task } from '@yotara/shared';
+import { db } from '../db/client.js';
+import { errorResponseSchema, withJsonResponse } from '../docs/openapi.js';
+import { UnauthorizedError } from '../lib/app-error.js';
+import requireAuthenticatedUser from '../plugins/auth-required.js';
+
+interface TaskSearchRow {
+  id: string;
+  title: string;
+  description: string | null;
+  status: string;
+  priority: string;
+  completed: number;
+  due_date: string | null;
+  simple_mode: number;
+  bucket: string | null;
+  project_id: string | null;
+  parent_id: string | null;
+  recurrence_rule: string | null;
+  base_task_id: string | null;
+  deleted_at: string | null;
+  archived_at: string | null;
+  permanent_archive: number;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+  user_id: string;
+  project_name: string | null;
+  project_description: string | null;
+  project_color: string | null;
+  project_owner_id: string | null;
+  project_created_at: string | null;
+  project_updated_at: string | null;
+  score: number;
+}
+
+interface ProjectSearchRow {
+  id: string;
+  owner_id: string;
+  name: string;
+  description: string | null;
+  color: string | null;
+  created_at: string;
+  updated_at: string;
+  task_count: number;
+  completed_task_count: number;
+  open_task_count: number;
+  score: number;
+}
+
+interface LabelSearchRow {
+  id: string;
+  name: string;
+  color: string;
+  user_id: string;
+  task_count: number;
+  created_at: string | null;
+  updated_at: string | null;
+  score: number;
+}
+
+function normalizeQuery(value?: string | null): string {
+  return (value ?? '').toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+function computeTaskMatchReasons(
+  title: string,
+  description: string | null,
+  projectName: string | null,
+  status: string,
+  normalizedQuery: string,
+): string[] {
+  const reasons: string[] = [];
+  const nl = normalizedQuery;
+  const titleL = title.toLowerCase();
+  const descL = (description ?? '').toLowerCase();
+  const projL = (projectName ?? '').toLowerCase();
+  const statL = status.toLowerCase();
+
+  if (titleL.includes(nl)) reasons.push('title');
+  if (descL.includes(nl)) reasons.push('description');
+  if (projL.includes(nl)) reasons.push('project');
+  if (statL.includes(nl)) reasons.push('status');
+
+  return [...new Set(reasons)];
+}
+
+function computeProjectMatchReasons(
+  name: string,
+  description: string | null,
+  normalizedQuery: string,
+): string[] {
+  const reasons: string[] = [];
+  const nl = normalizedQuery;
+
+  if (name.toLowerCase().includes(nl)) reasons.push('project');
+  if ((description ?? '').toLowerCase().includes(nl)) reasons.push('description');
+
+  return [...new Set(reasons)];
+}
+
+function computeLabelMatchReasons(name: string, _color: string, normalizedQuery: string): string[] {
+  if (name.toLowerCase().includes(normalizedQuery)) {
+    return ['label'];
+  }
+  return [];
+}
+
+function toTask(row: TaskSearchRow, labelIds: string[]): Task {
+  return {
+    id: row.id,
+    title: row.title,
+    description: row.description ?? undefined,
+    status: row.status as Task['status'],
+    priority: row.priority as Task['priority'],
+    completed: !!row.completed,
+    dueDate: row.due_date ?? undefined,
+    simpleMode: !!row.simple_mode,
+    bucket: (row.bucket as Task['bucket']) ?? undefined,
+    projectId: row.project_id ?? undefined,
+    parentId: row.parent_id ?? undefined,
+    recurrenceRule: row.recurrence_rule
+      ? (JSON.parse(row.recurrence_rule) as Task['recurrenceRule'])
+      : undefined,
+    baseTaskId: row.base_task_id ?? undefined,
+    archivedAt: row.archived_at ?? undefined,
+    permanentArchive: !!row.permanent_archive,
+    labels: labelIds,
+    order: row.sort_order,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function toProject(row: ProjectSearchRow): Project {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description ?? undefined,
+    color: (row.color as Project['color']) ?? undefined,
+    ownerId: row.owner_id,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    taskCount: row.task_count,
+    completedTaskCount: row.completed_task_count,
+    openTaskCount: row.open_task_count,
+  };
+}
+
+function toLabel(row: LabelSearchRow): Label {
+  return {
+    id: row.id,
+    name: row.name,
+    color: row.color,
+    userId: row.user_id,
+    taskCount: row.task_count,
+    createdAt: row.created_at ?? undefined,
+    updatedAt: row.updated_at ?? undefined,
+  };
+}
+
+export default async function searchRoutes(fastify: FastifyInstance) {
+  fastify.addHook('preHandler', requireAuthenticatedUser);
+
+  fastify.get<{
+    Querystring: {
+      q?: string;
+      page?: number;
+      pageSize?: number;
+      completed?: string;
+    };
+    Reply: SearchResponse | { message: string };
+  }>(
+    '/tasks/search',
+    {
+      schema: withJsonResponse({
+        tags: ['tasks'],
+        summary: 'Search tasks, projects, and labels',
+        description:
+          'Full-text search across task titles, descriptions, project names, ' +
+          'and label names. Results are sorted by relevance score.',
+        security: [{ cookieAuth: [] }],
+        querystring: {
+          type: 'object',
+          properties: {
+            q: { type: 'string', minLength: 1 },
+            page: { type: 'integer', minimum: 1, default: 1 },
+            pageSize: { type: 'integer', minimum: 1, maximum: 100, default: 50 },
+            completed: { type: 'string', enum: ['true', 'false', 'all'] },
+          },
+          required: ['q'],
+        },
+        response: {
+          200: {
+            description: 'Search results',
+            type: 'object',
+            properties: {
+              query: { type: 'string' },
+              normalizedQuery: { type: 'string' },
+              tasks: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    task: { $ref: 'Task#' },
+                    project: { anyOf: [{ $ref: 'Project#' }, { type: 'null' }] },
+                    score: { type: 'integer' },
+                    matchReasons: { type: 'array', items: { type: 'string' } },
+                  },
+                },
+              },
+              projects: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    project: { $ref: 'Project#' },
+                    score: { type: 'integer' },
+                    matchReasons: { type: 'array', items: { type: 'string' } },
+                  },
+                },
+              },
+              labels: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    label: { $ref: 'Label#' },
+                    score: { type: 'integer' },
+                    matchReasons: { type: 'array', items: { type: 'string' } },
+                  },
+                },
+              },
+            },
+          },
+          400: errorResponseSchema(
+            'Missing or invalid search query',
+            'Query parameter q is required',
+          ),
+          401: errorResponseSchema('Authentication required', 'Unauthorized'),
+        },
+      }),
+    },
+    async (request) => {
+      if (!request.userId) {
+        throw new UnauthorizedError();
+      }
+
+      const rawQuery = request.query.q ?? '';
+      const normalizedQ = normalizeQuery(rawQuery);
+      const page = Math.max(1, request.query.page ?? 1);
+      const pageSize = Math.min(100, Math.max(1, request.query.pageSize ?? 50));
+      const offset = (page - 1) * pageSize;
+      if (!normalizedQ) {
+        return {
+          query: rawQuery.trim(),
+          normalizedQuery: '',
+          tasks: [],
+          projects: [],
+          labels: [],
+        } satisfies SearchResponse;
+      }
+
+      const likeQuery = `%${normalizedQ}%`;
+      const startsWithQuery = `${normalizedQ}%`;
+
+      const completedFilter = request.query.completed;
+      const taskWhereCompleted =
+        completedFilter === 'true'
+          ? sql`t.deleted_at IS NULL AND t.completed = 1`
+          : completedFilter === 'all'
+            ? sql`t.deleted_at IS NULL`
+            : sql`t.deleted_at IS NULL AND t.completed = 0`;
+
+      const [taskRows, projectRows, labelRows] = await Promise.all([
+        db.all<TaskSearchRow>(sql`
+          SELECT
+            t.*,
+            p.name AS project_name,
+            p.description AS project_description,
+            p.color AS project_color,
+            p.owner_id AS project_owner_id,
+            p.created_at AS project_created_at,
+            p.updated_at AS project_updated_at,
+            MAX(
+              CASE WHEN LOWER(t.title) = ${normalizedQ} THEN 120 ELSE 0 END
+              + CASE WHEN LOWER(t.title) LIKE ${startsWithQuery} THEN 100 ELSE 0 END
+              + CASE WHEN LOWER(t.title) LIKE ${likeQuery} THEN 80 ELSE 0 END
+              + CASE WHEN LOWER(t.description) LIKE ${likeQuery} THEN 50 ELSE 0 END
+              + CASE WHEN LOWER(p.name) LIKE ${likeQuery} THEN 70 ELSE 0 END
+              + CASE WHEN LOWER(p.description) LIKE ${likeQuery} THEN 30 ELSE 0 END
+              + CASE WHEN LOWER(l.name) LIKE ${likeQuery} THEN 60 ELSE 0 END
+              + CASE WHEN LOWER(t.status) LIKE ${likeQuery} THEN 40 ELSE 0 END
+            ) AS score
+          FROM tasks t
+          LEFT JOIN projects p ON t.project_id = p.id
+          LEFT JOIN task_labels tl ON t.id = tl.task_id
+          LEFT JOIN labels l ON tl.label_id = l.id
+          WHERE t.user_id = ${request.userId} AND ${taskWhereCompleted}
+            AND (
+              LOWER(t.title) LIKE ${likeQuery}
+              OR LOWER(t.description) LIKE ${likeQuery}
+              OR LOWER(p.name) LIKE ${likeQuery}
+              OR LOWER(l.name) LIKE ${likeQuery}
+            )
+          GROUP BY t.id
+          HAVING score > 0
+          ORDER BY score DESC, t.updated_at DESC
+          LIMIT ${pageSize} OFFSET ${offset}
+        `),
+        db.all<ProjectSearchRow>(sql`
+          SELECT
+            p.*,
+            COALESCE(tc.task_count, 0) AS task_count,
+            COALESCE(tc.completed_count, 0) AS completed_task_count,
+            COALESCE(tc.open_count, 0) AS open_task_count,
+            CASE WHEN LOWER(p.name) = ${normalizedQ} THEN 120
+                 WHEN LOWER(p.name) LIKE ${startsWithQuery} THEN 100
+                 WHEN LOWER(p.name) LIKE ${likeQuery} THEN 80
+                 ELSE 0 END
+            + CASE WHEN LOWER(p.description) LIKE ${likeQuery} THEN 35 ELSE 0 END
+            AS score
+          FROM projects p
+          LEFT JOIN (
+            SELECT project_id,
+              COUNT(*) AS task_count,
+              SUM(CASE WHEN completed = 1 THEN 1 ELSE 0 END) AS completed_count,
+              SUM(CASE WHEN completed = 0 THEN 1 ELSE 0 END) AS open_count
+            FROM tasks
+            WHERE deleted_at IS NULL
+            GROUP BY project_id
+          ) tc ON p.id = tc.project_id
+          WHERE p.owner_id = ${request.userId}
+            AND (
+              LOWER(p.name) LIKE ${likeQuery}
+              OR LOWER(p.description) LIKE ${likeQuery}
+            )
+          ORDER BY score DESC, p.updated_at DESC
+          LIMIT ${pageSize} OFFSET ${offset}
+        `),
+        db.all<LabelSearchRow>(sql`
+          SELECT
+            l.*,
+            COALESCE(lc.task_count, 0) AS task_count,
+            CASE WHEN LOWER(l.name) = ${normalizedQ} THEN 120
+                 WHEN LOWER(l.name) LIKE ${startsWithQuery} THEN 100
+                 WHEN LOWER(l.name) LIKE ${likeQuery} THEN 80
+                 ELSE 0 END AS score
+          FROM labels l
+          LEFT JOIN (
+            SELECT tl.label_id, COUNT(*) AS task_count
+            FROM task_labels tl
+            JOIN tasks t ON t.id = tl.task_id
+            WHERE t.deleted_at IS NULL
+            GROUP BY tl.label_id
+          ) lc ON l.id = lc.label_id
+          WHERE l.user_id = ${request.userId}
+            AND LOWER(l.name) LIKE ${likeQuery}
+          ORDER BY score DESC, l.name ASC
+          LIMIT ${pageSize} OFFSET ${offset}
+        `),
+      ]);
+
+      const taskIds = taskRows.map((r) => r.id);
+      const labelMap = new Map<string, string[]>();
+      if (taskIds.length > 0) {
+        const labelRows = await db.all<{ task_id: string; label_id: string }>(sql`
+          SELECT task_id, label_id FROM task_labels
+          WHERE task_id IN (${sql.join(taskIds, sql`, `)})
+        `);
+        for (const row of labelRows) {
+          const ids = labelMap.get(row.task_id) ?? [];
+          ids.push(row.label_id);
+          labelMap.set(row.task_id, ids);
+        }
+      }
+
+      const tasks: SearchResponse['tasks'] = taskRows.map((row) => {
+        const project: Project | null = row.project_id
+          ? ({
+              id: row.project_id,
+              name: row.project_name ?? '',
+              description: row.project_description ?? undefined,
+              color: (row.project_color ?? undefined) as Project['color'],
+              ownerId: row.project_owner_id ?? '',
+              createdAt: row.project_created_at ?? '',
+              updatedAt: row.project_updated_at ?? '',
+              taskCount: 0,
+              completedTaskCount: 0,
+              openTaskCount: 0,
+            } satisfies Project)
+          : null;
+
+        return {
+          task: toTask(row, labelMap.get(row.id) ?? []),
+          project,
+          score: row.score,
+          matchReasons: computeTaskMatchReasons(
+            row.title,
+            row.description,
+            row.project_name,
+            row.status,
+            normalizedQ,
+          ),
+        };
+      });
+
+      const projects: SearchResponse['projects'] = projectRows.map((row) => ({
+        project: toProject(row),
+        score: row.score,
+        matchReasons: computeProjectMatchReasons(row.name, row.description, normalizedQ),
+      }));
+
+      const labels: SearchResponse['labels'] = labelRows.map((row) => ({
+        label: toLabel(row),
+        score: row.score,
+        matchReasons: computeLabelMatchReasons(row.name, row.color, normalizedQ),
+      }));
+
+      return {
+        query: rawQuery.trim(),
+        normalizedQuery: normalizedQ,
+        tasks,
+        projects,
+        labels,
+      } satisfies SearchResponse;
+    },
+  );
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -11,6 +11,7 @@ import meRoutes from './routes/me.js';
 import labelRoutes from './routes/labels.js';
 import projectRoutes from './routes/projects.js';
 import rootRoutes from './routes/root.js';
+import searchRoutes from './routes/search.js';
 import taskRoutes from './routes/tasks.js';
 
 export async function buildApp() {
@@ -59,6 +60,7 @@ export async function buildApp() {
   await app.register(meRoutes);
   await app.register(labelRoutes);
   await app.register(projectRoutes);
+  await app.register(searchRoutes);
   await app.register(taskRoutes);
   await app.register(rootRoutes);
 

--- a/apps/frontend/e2e/PLAN.md
+++ b/apps/frontend/e2e/PLAN.md
@@ -11,7 +11,7 @@
 
 ### Tests
 
-All **69 tests pass** consistently (5 login + 14 forgot/reset password + 47 authenticated + 3 onboarding):
+All **73 tests pass** consistently (5 login + 14 forgot/reset password + 51 authenticated + 3 onboarding):
 
 #### Login page (`e2e/specs/login/auth.spec.ts`) — 5/5 pass
 - loads and shows the login form ✓
@@ -20,7 +20,7 @@ All **69 tests pass** consistently (5 login + 14 forgot/reset password + 47 auth
 - shows error for invalid email format ✓
 - shows error for wrong credentials ✓
 
-#### Authenticated (`e2e/specs/authenticated/`) — 47 tests across 12 files
+#### Authenticated (`e2e/specs/authenticated/`) — 51 tests across 12 files
 **Auth spec** (`auth.spec.ts`, serial mode, 3 tests):
 - redirects to tasks when already logged in ✓
 - can access protected routes ✓
@@ -53,12 +53,16 @@ All **69 tests pass** consistently (5 login + 14 forgot/reset password + 47 auth
 - edits a label ✓
 - deletes a label ✓
 
-**Search spec** (`search.spec.ts`, serial mode, 5 tests):
+**Search spec** (`search.spec.ts`, serial mode, 9 tests):
 - search page renders the search form ✓
 - finds a task by title ✓
 - shows empty result state for gibberish query ✓
 - search result tabs (All/Tasks/Projects/Labels) are visible ✓
 - clicking tabs filters search results ✓
+- finds a project by name in search results ✓
+- finds a label by name in search results ✓
+- searches archived/completed tasks ✓
+- Tasks tab shows all results with pagination controls ✓
 
 **Settings spec** (`settings.spec.ts`, serial mode, 5 tests):
 - settings page renders with sections ✓
@@ -140,7 +144,7 @@ Separate Playwright project with empty `storageState` so it creates a fresh user
 | `projects.spec.ts` | 4 | Project CRUD + detail navigation |
 | `task-modal.spec.ts` | 6 | Full task modal CRUD + validation |
 | `labels.spec.ts` | 4 | Label CRUD |
-| `search.spec.ts` | 5 | Search form, find task, empty state, tab filtering |
+| `search.spec.ts` | 9 | Search form, find task, empty state, tab filtering, project search, label search, archive search, pagination |
 | `settings.spec.ts` | 5 | Theme, toggles, password modal, non-destructive logout |
 | `archive.spec.ts` | 4 | Archive view, delete forever, restore, permanent archive |
 | `error-states.spec.ts` | 2 | 404 page variants |

--- a/apps/frontend/e2e/specs/authenticated/search.spec.ts
+++ b/apps/frontend/e2e/specs/authenticated/search.spec.ts
@@ -254,6 +254,7 @@ test.describe('Search', () => {
 
     // Switch to Tasks tab
     await page.locator('.tab-chip').filter({ hasText: 'Tasks' }).click();
+    await page.waitForURL(/tab=tasks/, { timeout: 10_000 });
     await page.waitForLoadState('networkidle');
 
     // All tasks should appear — wait for the first card, then verify count

--- a/apps/frontend/e2e/specs/authenticated/search.spec.ts
+++ b/apps/frontend/e2e/specs/authenticated/search.spec.ts
@@ -257,12 +257,21 @@ test.describe('Search', () => {
     await page.waitForURL(/tab=tasks/, { timeout: 10_000 });
     await page.waitForLoadState('networkidle');
 
-    // All tasks should appear — wait for the first card, then verify count
+    // Page 1 with 10 tasks (pageSize 10, 11 tasks = 2 pages)
     await expect(page.locator('article.task-card').first()).toBeVisible({ timeout: 10_000 });
-    const tasksTabCards = await page.locator('article.task-card').count();
-    expect(tasksTabCards).toBeGreaterThanOrEqual(taskCount);
+    const page1Cards = await page.locator('article.task-card').count();
+    expect(page1Cards).toBe(10);
 
-    // Pagination controls should be visible (11 tasks / page size 10 = 2 pages)
+    // Pagination controls should be visible (2 pages)
     await expect(page.locator('.pagination-container')).toBeVisible({ timeout: 5_000 });
+
+    // Navigate to page 2 and verify the 11th task appears
+    await page.locator('.pagination-button').filter({ hasText: '→' }).click();
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('article.task-card').filter({ hasText: `${prefix}10` })).toBeVisible({
+      timeout: 5_000,
+    });
+    const page2Cards = await page.locator('article.task-card').count();
+    expect(page2Cards).toBe(1);
   });
 });

--- a/apps/frontend/e2e/specs/authenticated/search.spec.ts
+++ b/apps/frontend/e2e/specs/authenticated/search.spec.ts
@@ -256,12 +256,10 @@ test.describe('Search', () => {
     await page.locator('.tab-chip').filter({ hasText: 'Tasks' }).click();
     await page.waitForLoadState('networkidle');
 
-    // All tasks should appear
-    for (let i = 0; i < taskCount; i++) {
-      await expect(
-        page.locator('article.task-card').filter({ hasText: `${prefix}${i}` }),
-      ).toBeVisible({ timeout: 5_000 });
-    }
+    // All tasks should appear — wait for the first card, then verify count
+    await expect(page.locator('article.task-card').first()).toBeVisible({ timeout: 10_000 });
+    const tasksTabCards = await page.locator('article.task-card').count();
+    expect(tasksTabCards).toBeGreaterThanOrEqual(taskCount);
 
     // Pagination controls should be visible (11 tasks / page size 10 = 2 pages)
     await expect(page.locator('.pagination-container')).toBeVisible({ timeout: 5_000 });

--- a/apps/frontend/e2e/specs/authenticated/search.spec.ts
+++ b/apps/frontend/e2e/specs/authenticated/search.spec.ts
@@ -268,7 +268,8 @@ test.describe('Search', () => {
     // Navigate to page 2 and verify the 11th task appears
     await page.locator('.pagination-button').filter({ hasText: '→' }).click();
     await page.waitForLoadState('networkidle');
-    await expect(page.locator('article.task-card').filter({ hasText: `${prefix}10` })).toBeVisible({
+    await expect(page.locator('.page-number.page-active')).toHaveText('2', { timeout: 5_000 });
+    await expect(page.locator('article.task-card').filter({ hasText: `${prefix}0` })).toBeVisible({
       timeout: 5_000,
     });
     const page2Cards = await page.locator('article.task-card').count();

--- a/apps/frontend/e2e/specs/authenticated/search.spec.ts
+++ b/apps/frontend/e2e/specs/authenticated/search.spec.ts
@@ -110,4 +110,160 @@ test.describe('Search', () => {
       page.locator('button.tab-chip.tab-chip-active').filter({ hasText: 'Tasks' }),
     ).toBeVisible();
   });
+
+  test('finds a project by name in search results', async ({ page }) => {
+    // Create a project first
+    const projectName = `search-project-${Date.now()}`;
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
+    await dismissTip(page);
+
+    await page.getByRole('button', { name: '+ New Project' }).click();
+    await page.getByPlaceholder('e.g. Morning Rituals').fill(projectName);
+    await page
+      .getByPlaceholder('Describe the sanctuary of this project...')
+      .fill('A test project for search');
+    await page.getByRole('button', { name: 'Teal' }).click();
+    await page.getByRole('button', { name: 'Create Project' }).click();
+    await page.waitForURL(/\/projects\/[a-zA-Z0-9-]+/, { timeout: 10_000 });
+
+    // Navigate to search and find it
+    await page.goto('/search');
+    await page.waitForLoadState('networkidle');
+    await dismissTip(page);
+
+    await page.getByPlaceholder('Search tasks, projects, and status keywords...').fill(projectName);
+    await page.getByPlaceholder('Search tasks, projects, and status keywords...').press('Enter');
+    await page.waitForLoadState('networkidle');
+
+    // Project should appear in the "All" tab results
+    await expect(page.locator('.project-card').filter({ hasText: projectName })).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test('finds a label by name in search results', async ({ page }) => {
+    // Create a label first
+    const labelName = `search-label-${Date.now()}`;
+    await page.goto('/labels');
+    await page.waitForLoadState('networkidle');
+    await dismissTip(page);
+
+    await page.getByRole('button', { name: '+ New Label' }).click();
+    const nameInput = page.locator('.label-editor input').first();
+    await nameInput.fill(labelName);
+    await page.getByRole('button', { name: 'Create Label', exact: true }).click();
+    await page.waitForTimeout(1000);
+    await page.waitForLoadState('networkidle');
+
+    // Navigate to search
+    await page.goto('/search');
+    await page.waitForLoadState('networkidle');
+    await dismissTip(page);
+
+    await page.getByPlaceholder('Search tasks, projects, and status keywords...').fill(labelName);
+    await page.getByPlaceholder('Search tasks, projects, and status keywords...').press('Enter');
+    await page.waitForLoadState('networkidle');
+
+    // Switch to Labels tab
+    await page.locator('.tab-chip').filter({ hasText: 'Labels' }).click();
+    await page.waitForLoadState('networkidle');
+
+    // Label should appear in results
+    await expect(page.locator('.project-card').filter({ hasText: labelName })).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  test('searches archived/completed tasks', async ({ page }) => {
+    // Create a task and mark it complete
+    const taskName = `archive-search-${Date.now()}`;
+    await page.goto('/tasks?view=inbox');
+    await page.waitForLoadState('networkidle');
+    await dismissTip(page);
+
+    await page.getByPlaceholder("What's on your mind today?").fill(taskName);
+    await page.getByPlaceholder("What's on your mind today?").press('Enter');
+    await expect(page.locator('article.task-card').filter({ hasText: taskName })).toBeVisible({
+      timeout: 10_000,
+    });
+    await page.waitForTimeout(500);
+
+    // Mark the task complete
+    const card = page.locator('article.task-card').filter({ hasText: taskName });
+    await card.getByRole('button', { name: 'Mark task complete' }).click({ force: true });
+    const confirmBtn = page.getByRole('button', { name: 'Mark complete' });
+    await confirmBtn.waitFor({ state: 'visible', timeout: 5_000 });
+    await confirmBtn.click();
+    await page.waitForTimeout(500);
+    await page.waitForLoadState('networkidle');
+
+    // Navigate to search
+    await page.goto('/search');
+    await page.waitForLoadState('networkidle');
+    await dismissTip(page);
+
+    await page.getByPlaceholder('Search tasks, projects, and status keywords...').fill(taskName);
+    await page.getByPlaceholder('Search tasks, projects, and status keywords...').press('Enter');
+    await page.waitForLoadState('networkidle');
+
+    // The task should not appear in active results (it's completed)
+    await expect(page.locator('article.task-card').filter({ hasText: taskName })).not.toBeVisible();
+
+    // Click "Search Archive"
+    await page.getByRole('button', { name: 'Search Archive' }).click();
+    await page.waitForLoadState('networkidle');
+
+    // The completed task should appear in archive results
+    await expect(
+      page.locator('.archive-results article.task-card').filter({ hasText: taskName }),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('Tasks tab shows all results with pagination controls', async ({ page }) => {
+    // Create several tasks with a shared prefix
+    const prefix = `pagination-${Date.now()}-`;
+    await page.goto('/tasks?view=inbox');
+    await page.waitForLoadState('networkidle');
+    await dismissTip(page);
+
+    const taskCount = 6;
+    for (let i = 0; i < taskCount; i++) {
+      const name = `${prefix}${i}`;
+      await page.getByPlaceholder("What's on your mind today?").fill(name);
+      await page.getByPlaceholder("What's on your mind today?").press('Enter');
+      await expect(page.locator('article.task-card').filter({ hasText: name })).toBeVisible({
+        timeout: 10_000,
+      });
+      await page.waitForTimeout(300);
+    }
+
+    // Navigate to search
+    await page.goto('/search');
+    await page.waitForLoadState('networkidle');
+    await dismissTip(page);
+
+    await page.getByPlaceholder('Search tasks, projects, and status keywords...').fill(prefix);
+    await page.getByPlaceholder('Search tasks, projects, and status keywords...').press('Enter');
+    await page.waitForLoadState('networkidle');
+
+    // "All" tab shows only up to 5 tasks (the cap)
+    const taskCards = page.locator('article.task-card');
+    const allTabCards = await taskCards.count();
+    expect(allTabCards).toBeLessThanOrEqual(5);
+
+    // Switch to Tasks tab
+    await page.locator('.tab-chip').filter({ hasText: 'Tasks' }).click();
+    await page.waitForLoadState('networkidle');
+
+    // All tasks should appear
+    for (let i = 0; i < taskCount; i++) {
+      await expect(
+        page.locator('article.task-card').filter({ hasText: `${prefix}${i}` }),
+      ).toBeVisible({ timeout: 5_000 });
+    }
+
+    // Pagination controls should be visible (page of 10 with 6 tasks = 1 page, but paginator renders)
+    await expect(page.locator('app-pagination')).toBeVisible();
+  });
 });

--- a/apps/frontend/e2e/specs/authenticated/search.spec.ts
+++ b/apps/frontend/e2e/specs/authenticated/search.spec.ts
@@ -221,13 +221,13 @@ test.describe('Search', () => {
   });
 
   test('Tasks tab shows all results with pagination controls', async ({ page }) => {
-    // Create several tasks with a shared prefix
+    // Create enough tasks to span multiple pages (11 tasks, page size 10 = 2 pages)
     const prefix = `pagination-${Date.now()}-`;
     await page.goto('/tasks?view=inbox');
     await page.waitForLoadState('networkidle');
     await dismissTip(page);
 
-    const taskCount = 6;
+    const taskCount = 11;
     for (let i = 0; i < taskCount; i++) {
       const name = `${prefix}${i}`;
       await page.getByPlaceholder("What's on your mind today?").fill(name);
@@ -263,7 +263,7 @@ test.describe('Search', () => {
       ).toBeVisible({ timeout: 5_000 });
     }
 
-    // Pagination controls should be visible (page of 10 with 6 tasks = 1 page, but paginator renders)
-    await expect(page.locator('app-pagination')).toBeVisible();
+    // Pagination controls should be visible (11 tasks / page size 10 = 2 pages)
+    await expect(page.locator('.pagination-container')).toBeVisible({ timeout: 5_000 });
   });
 });

--- a/apps/frontend/src/app/core/services/search.service.spec.ts
+++ b/apps/frontend/src/app/core/services/search.service.spec.ts
@@ -1,501 +1,242 @@
-import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { of } from 'rxjs';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { SearchService } from './search.service';
-import { ProjectService } from './project.service';
-import { TaskService } from './task.service';
-import { LabelService } from './label.service';
-import type { Task } from '@yotara/shared';
+import { firstValueFrom } from 'rxjs';
+import type { SearchResponse } from '@yotara/shared';
 
 describe('SearchService', () => {
-  const projects = signal([
-    {
-      id: 'project-1',
-      name: 'Launch Yotara MVP',
-      description: 'Core release scope',
-      color: 'sage' as const,
-      ownerId: 'user-1',
-      taskCount: 2,
-      completedTaskCount: 1,
-      openTaskCount: 1,
-      createdAt: '2026-04-01T10:00:00.000Z',
-      updatedAt: '2026-04-03T10:00:00.000Z',
-    },
-    {
-      id: 'project-2',
-      name: 'Home Renovation',
-      description: 'Kitchen and bathroom plans',
-      color: 'coral' as const,
-      ownerId: 'user-1',
-      taskCount: 3,
-      completedTaskCount: 0,
-      openTaskCount: 3,
-      createdAt: '2026-04-10T10:00:00.000Z',
-      updatedAt: '2026-04-12T10:00:00.000Z',
-    },
-  ]);
+  let service: SearchService;
+  let httpMock: HttpTestingController;
 
-  const tasks = signal([
-    {
-      id: 'task-1',
-      title: 'Polish search results',
-      description: 'Tune the global search page copy and ranking.',
-      status: 'today' as const,
-      priority: 'high' as const,
-      completed: false,
-      dueDate: '2026-04-24',
-      simpleMode: false,
-      bucket: 'deep-work' as const,
-      projectId: 'project-1',
-      order: 0,
-      createdAt: '2026-04-20T10:00:00.000Z',
-      updatedAt: '2026-04-23T10:00:00.000Z',
-    },
-    {
-      id: 'task-2',
-      title: 'Archive old notebook',
-      description: 'Move the completed notes into archive.',
-      status: 'archived' as const,
-      priority: 'low' as const,
-      completed: true,
-      dueDate: '2026-03-24',
-      simpleMode: false,
-      bucket: 'home' as const,
-      projectId: null,
-      order: 1,
-      createdAt: '2026-03-20T10:00:00.000Z',
-      updatedAt: '2026-03-22T10:00:00.000Z',
-    },
-    {
-      id: 'task-3',
-      title: 'Buy groceries',
-      description: '',
-      status: 'inbox' as const,
-      priority: 'medium' as const,
-      completed: false,
-      dueDate: null,
-      simpleMode: true,
-      bucket: 'home' as const,
-      projectId: null,
-      order: 2,
-      createdAt: '2026-04-25T10:00:00.000Z',
-      updatedAt: '2026-04-25T10:00:00.000Z',
-    },
-    {
-      id: 'task-4',
-      title: 'Review project plan',
-      description: 'Go through the renovation timeline with the contractor.',
-      status: 'today' as const,
-      priority: 'high' as const,
-      completed: false,
-      dueDate: null,
-      simpleMode: false,
-      bucket: 'deep-work' as const,
-      projectId: null,
-      order: 3,
-      createdAt: '2026-04-22T10:00:00.000Z',
-      updatedAt: '2026-04-24T10:00:00.000Z',
-    },
-  ]);
+  const mockSearchResponse: SearchResponse = {
+    query: 'polish',
+    normalizedQuery: 'polish',
+    tasks: [
+      {
+        task: {
+          id: 'task-1',
+          title: 'Polish search results',
+          description: 'Tune the global search page copy and ranking.',
+          status: 'today' as const,
+          priority: 'high' as const,
+          completed: false,
+          dueDate: '2026-04-24',
+          order: 0,
+          createdAt: '2026-04-20T10:00:00.000Z',
+          updatedAt: '2026-04-23T10:00:00.000Z',
+        },
+        project: null,
+        score: 120,
+        matchReasons: ['title'],
+      },
+    ],
+    projects: [],
+    labels: [],
+  };
 
-  const labels = signal([
-    { id: 'label-1', name: 'bug', color: '#ef4444', taskCount: 2 },
-    { id: 'label-2', name: 'enhancement', color: '#3b82f6', taskCount: 1 },
-    { id: 'label-3', name: 'ui', color: '#84cc16', taskCount: 3 },
-  ]);
+  const emptySearchResponse: SearchResponse = {
+    query: '',
+    normalizedQuery: '',
+    tasks: [],
+    projects: [],
+    labels: [],
+  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      providers: [
-        SearchService,
-        {
-          provide: ProjectService,
-          useValue: { projects },
-        },
-        {
-          provide: TaskService,
-          useValue: { allActiveTasks: tasks },
-        },
-        {
-          provide: LabelService,
-          useValue: { labels },
-        },
-      ],
+      imports: [HttpClientTestingModule],
+      providers: [SearchService],
     }).compileComponents();
+
+    service = TestBed.inject(SearchService);
+    httpMock = TestBed.inject(HttpTestingController);
   });
 
-  // ── Existing tests (kept as-is) ──────────────────────────────────
-
-  it('finds tasks by title, description, project name, and status keywords', () => {
-    const service = TestBed.inject(SearchService);
-
-    expect(service.search('search results').tasks.map((r) => r.task.id)).toContain('task-1');
-    expect(service.search('global search page').tasks.map((r) => r.task.id)).toContain('task-1');
-    expect(service.search('launch yotara').tasks.map((r) => r.task.id)).toContain('task-1');
-    expect(service.search('today').tasks.map((r) => r.task.id)).toContain('task-1');
-    expect(service.search('archived').tasks.map((r) => r.task.id)).toContain('task-2');
+  afterEach(() => {
+    httpMock.verify();
   });
 
-  it('returns matching projects alongside tasks for the same project name', () => {
-    const service = TestBed.inject(SearchService);
-    const results = service.search('launch yotara');
+  describe('search', () => {
+    it('makes a GET request to /tasks/search with the query', async () => {
+      const result$ = service.search('polish');
+      const resultPromise = firstValueFrom(result$);
 
-    expect(results.projects.map((r) => r.project.id)).toContain('project-1');
-    expect(results.tasks.map((r) => r.task.id)).toContain('task-1');
+      const req = httpMock.expectOne(
+        (request) =>
+          request.url.endsWith('/tasks/search') &&
+          request.params.get('q') === 'polish' &&
+          request.method === 'GET',
+      );
+      expect(req.request.withCredentials).toBeTrue();
+      req.flush(mockSearchResponse);
+
+      const result = await resultPromise;
+      expect(result.tasks.length).toBe(1);
+      expect(result.tasks[0].task.title).toBe('Polish search results');
+    });
+
+    it('returns empty results for an empty query without making an HTTP call', async () => {
+      const result = await firstValueFrom(service.search(''));
+      expect(result.tasks).toEqual([]);
+      expect(result.projects).toEqual([]);
+      expect(result.labels).toEqual([]);
+      expect(result.query).toBe('');
+      httpMock.expectNone('/tasks/search');
+    });
+
+    it('returns empty results for whitespace-only query', async () => {
+      const result = await firstValueFrom(service.search('   '));
+      expect(result.tasks).toEqual([]);
+      expect(result.projects).toEqual([]);
+      expect(result.labels).toEqual([]);
+      httpMock.expectNone('/tasks/search');
+    });
+
+    it('passes through the search response from the API', async () => {
+      const result$ = service.search('polish');
+      const resultPromise = firstValueFrom(result$);
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/tasks/search'));
+      req.flush(mockSearchResponse);
+
+      const result = await resultPromise;
+      expect(result.query).toBe('polish');
+      expect(result.normalizedQuery).toBe('polish');
+    });
   });
 
-  // ── Empty / edge-case queries ───────────────────────────────────
+  describe('searchArchive', () => {
+    it('makes a GET request with completed=true and large pageSize', async () => {
+      const result$ = service.searchArchive('finished');
+      const resultPromise = firstValueFrom(result$);
 
-  it('returns empty result arrays for an empty string query', () => {
-    const service = TestBed.inject(SearchService);
-    const results = service.search('');
+      const req = httpMock.expectOne(
+        (request) =>
+          request.url.endsWith('/tasks/search') &&
+          request.params.get('q') === 'finished' &&
+          request.params.get('completed') === 'true' &&
+          request.params.get('pageSize') === '100',
+      );
+      req.flush(mockSearchResponse);
 
-    expect(results.tasks).toEqual([]);
-    expect(results.projects).toEqual([]);
-    expect(results.labels).toEqual([]);
-    expect(results.query).toBe('');
-    expect(results.normalizedQuery).toBe('');
+      const result = await resultPromise;
+      expect(result.tasks.length).toBe(1);
+      expect(result.total).toBe(1);
+    });
+
+    it('returns empty for empty query without HTTP call', async () => {
+      const result = await firstValueFrom(service.searchArchive(''));
+      expect(result.tasks).toEqual([]);
+      expect(result.total).toBe(0);
+      httpMock.expectNone('/tasks/search');
+    });
+
+    it('returns empty tasks and total 0 when API returns no matches', async () => {
+      const emptyResponse: SearchResponse = {
+        query: 'zzzznonexistent',
+        normalizedQuery: 'zzzznonexistent',
+        tasks: [],
+        projects: [],
+        labels: [],
+      };
+
+      const result$ = service.searchArchive('zzzznonexistent');
+      const resultPromise = firstValueFrom(result$);
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/tasks/search'));
+      req.flush(emptyResponse);
+
+      const result = await resultPromise;
+      expect(result.tasks).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+
+    it('sends withCredentials on the archive request', async () => {
+      const result$ = service.searchArchive('finished');
+      const resultPromise = firstValueFrom(result$);
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/tasks/search'));
+      expect(req.request.withCredentials).toBeTrue();
+      req.flush(mockSearchResponse);
+
+      await resultPromise;
+    });
   });
 
-  it('treats whitespace-only queries the same as an empty query', () => {
-    const service = TestBed.inject(SearchService);
-    const results = service.search('   ');
-
-    expect(results.tasks).toEqual([]);
-    expect(results.projects).toEqual([]);
-    expect(results.labels).toEqual([]);
-  });
-
-  it('preserves the trimmed query text in the result object', () => {
-    const service = TestBed.inject(SearchService);
-    const results = service.search('  hello  ');
-
-    expect(results.query).toBe('hello');
-  });
-
-  // ── No-match path ──────────────────────────────────────────────
-
-  it('returns empty result arrays when no entity matches the query', () => {
-    const service = TestBed.inject(SearchService);
-    const results = service.search('zzzznonexistent');
-
-    expect(results.tasks).toEqual([]);
-    expect(results.projects).toEqual([]);
-    expect(results.labels).toEqual([]);
-  });
-
-  // ── Multi-term AND logic ───────────────────────────────────────
-
-  it('requires ALL terms to match in a multi-term query', () => {
-    const service = TestBed.inject(SearchService);
-    // 'polish' matches task-1 by title; 'zzzz' matches nothing → empty
-    expect(service.search('polish zzzz').tasks).toEqual([]);
-    // both terms match task-1 → result returned
-    expect(service.search('polish search').tasks.map((r) => r.task.id)).toContain('task-1');
-  });
-
-  it('matches multi-term queries across different fields', () => {
-    const service = TestBed.inject(SearchService);
-    // 'search' is in task-1 title/description, 'launch' is in task-1's project name
-    const results = service.search('search launch');
-    expect(results.tasks.map((r) => r.task.id)).toContain('task-1');
-  });
-
-  it('returns no results when only some terms match across different entities', () => {
-    const service = TestBed.inject(SearchService);
-    // 'search' matches task-1, 'renovation' matches project-2 — no single entity has both
-    const results = service.search('search renovation');
-    expect(results.tasks).toEqual([]);
-    expect(results.projects).toEqual([]);
-  });
-
-  // ── Case insensitivity ──────────────────────────────────────────
-
-  it('is case-insensitive', () => {
-    const service = TestBed.inject(SearchService);
-    const lower = service.search('search');
-    const upper = service.search('SEARCH');
-    const mixed = service.search('SeArCh');
-
-    expect(lower.tasks.map((r) => r.task.id)).toEqual(upper.tasks.map((r) => r.task.id));
-    expect(lower.tasks.map((r) => r.task.id)).toEqual(mixed.tasks.map((r) => r.task.id));
-  });
-
-  // ── Label matching ──────────────────────────────────────────────
-
-  it('finds labels by name', () => {
-    const service = TestBed.inject(SearchService);
-    const results = service.search('bug');
-
-    expect(results.labels.map((r) => r.label.id)).toContain('label-1');
-    expect(results.labels.length).toBe(1);
-  });
-
-  it('finds labels by partial name match', () => {
-    const service = TestBed.inject(SearchService);
-    // 'enhance' is a prefix of 'enhancement'
-    const results = service.search('enhance');
-    expect(results.labels.map((r) => r.label.id)).toContain('label-2');
-  });
-
-  it('returns label match reasons', () => {
-    const service = TestBed.inject(SearchService);
-    const results = service.search('bug');
-    expect(results.labels[0].matchReasons).toContain('label');
-  });
-
-  // ── Project matching ────────────────────────────────────────────
-
-  it('finds projects by description content', () => {
-    const service = TestBed.inject(SearchService);
-    const results = service.search('kitchen');
-    expect(results.projects.map((r) => r.project.id)).toContain('project-2');
-  });
-
-  it('reports project match reasons', () => {
-    const service = TestBed.inject(SearchService);
-    // exact match on project name
-    const exactResults = service.search('Home Renovation');
-    expect(exactResults.projects[0].matchReasons).toContain('project');
-
-    // match on description
-    const descResults = service.search('bathroom');
-    expect(descResults.projects[0].matchReasons).toContain('description');
-  });
-
-  // ── Match reasons for tasks ─────────────────────────────────────
-
-  it('reports title match reason when the query matches the task title', () => {
-    const service = TestBed.inject(SearchService);
-    const results = service.search('Polish');
-    const result = results.tasks.find((r) => r.task.id === 'task-1')!;
-    expect(result.matchReasons).toContain('title');
-  });
-
-  it('reports description and project match reasons', () => {
-    const service = TestBed.inject(SearchService);
-    const results = service.search('ranking');
-    const result = results.tasks.find((r) => r.task.id === 'task-1')!;
-    expect(result.matchReasons).toContain('description');
-  });
-
-  it('reports status match reason', () => {
-    const service = TestBed.inject(SearchService);
-    const results = service.search('today');
-    const result = results.tasks.find((r) => r.task.id === 'task-1')!;
-    expect(result.matchReasons).toContain('status');
-  });
-
-  it('reports project name as a match reason for tasks', () => {
-    const service = TestBed.inject(SearchService);
-    const results = service.search('yotara');
-    const result = results.tasks.find((r) => r.task.id === 'task-1')!;
-    expect(result.matchReasons).toContain('project');
-  });
-
-  // ── Score ordering ──────────────────────────────────────────────
-
-  it('sorts results by descending score', () => {
-    const service = TestBed.inject(SearchService);
-    // 'the' appears in the descriptions of task-1, task-2, and task-4
-    const results = service.search('the');
-    expect(results.tasks.length).toBeGreaterThan(1);
-    const scores = results.tasks.map((r) => r.score);
-    for (let i = 1; i < scores.length; i++) {
-      expect(scores[i - 1]).toBeGreaterThanOrEqual(scores[i]);
-    }
-  });
-
-  it('sorts projects by descending score', () => {
-    const service = TestBed.inject(SearchService);
-    // 'a' appears in both project names and descriptions
-    const results = service.search('a');
-    expect(results.projects.length).toBeGreaterThan(1);
-    const scores = results.projects.map((r) => r.score);
-    for (let i = 1; i < scores.length; i++) {
-      expect(scores[i - 1]).toBeGreaterThanOrEqual(scores[i]);
-    }
-  });
-
-  // ── Edge cases: null / empty fields ─────────────────────────────
-
-  it('handles tasks with empty description and no project', () => {
-    const service = TestBed.inject(SearchService);
-    // task-3 has no description, no projectId, no dueDate
-    const results = service.search('groceries');
-    const result = results.tasks.find((r) => r.task.id === 'task-3');
-    expect(result).toBeTruthy();
-    expect(result!.project).toBeNull();
-  });
-
-  it('does not crash when a task has null projectId and no matching project', () => {
-    const service = TestBed.inject(SearchService);
-    // task-4 has null projectId and searches for something in its own fields
-    const results = service.search('review');
-    expect(results.tasks.map((r) => r.task.id)).toContain('task-4');
-    expect(results.tasks.find((r) => r.task.id === 'task-4')!.project).toBeNull();
-  });
-
-  // ── Result shape ────────────────────────────────────────────────
-
-  it('attaches the project reference to task results when the task belongs to a project', () => {
-    const service = TestBed.inject(SearchService);
-    const results = service.search('search');
-    const result = results.tasks.find((r) => r.task.id === 'task-1')!;
-    expect(result.project).not.toBeNull();
-    expect(result.project!.id).toBe('project-1');
-  });
-
-  it('includes normalizedQuery in the result', () => {
-    const service = TestBed.inject(SearchService);
-    const results = service.search('  Search  ');
-    expect(results.normalizedQuery).toBe('search');
-  });
-
-  // ── searchArchive ──────────────────────────────────────────────
-
-  function paginatedArchive(tasks: Task[]) {
-    return {
-      data: tasks,
-      meta: {
-        total: tasks.length,
-        page: 1,
-        pageSize: 100,
-        totalPages: tasks.length === 0 ? 0 : 1,
-        hasNextPage: false,
-        hasPreviousPage: false,
-      },
-    };
-  }
-
-  it('searchArchive calls getArchivedTasks and filters results', async () => {
-    const archiveTasks: Task[] = [
-      {
-        id: 'archive-1',
-        title: 'Finished the blog post',
-        description: 'Published the weekly update.',
-        status: 'archived' as const,
-        priority: 'medium' as const,
-        completed: true,
-        simpleMode: false,
-        bucket: 'deep-work' as const,
-        order: 0,
-        createdAt: '2026-05-01T10:00:00.000Z',
-        updatedAt: '2026-05-03T10:00:00.000Z',
-      },
-      {
-        id: 'archive-2',
-        title: 'Old grocery run',
-        description: '',
-        status: 'done' as const,
-        priority: 'low' as const,
-        completed: true,
-        simpleMode: true,
-        bucket: 'home' as const,
-        order: 1,
-        createdAt: '2026-04-01T10:00:00.000Z',
-        updatedAt: '2026-04-01T10:00:00.000Z',
-      },
-    ];
-
-    TestBed.resetTestingModule();
-    await TestBed.configureTestingModule({
-      providers: [
-        SearchService,
-        { provide: ProjectService, useValue: { projects } },
-        {
-          provide: TaskService,
-          useValue: {
-            allActiveTasks: signal([]),
-            getArchivedTasks: () => of(paginatedArchive(archiveTasks)),
+  describe('searchAllTasks', () => {
+    it('fetches all task pages until a partial page is returned', async () => {
+      const page1: SearchResponse = {
+        ...emptySearchResponse,
+        query: 'find',
+        normalizedQuery: 'find',
+        tasks: Array.from({ length: 100 }, (_, i) => ({
+          task: {
+            id: `task-${i}`,
+            title: `Task ${i}`,
+            status: 'today' as const,
+            priority: 'medium' as const,
+            completed: false,
+            order: i,
+            createdAt: '2026-04-20T10:00:00.000Z',
+            updatedAt: '2026-04-23T10:00:00.000Z',
           },
-        },
-        { provide: LabelService, useValue: { labels } },
-      ],
-    }).compileComponents();
-
-    const service = TestBed.inject(SearchService);
-    const results = await service.searchArchive('blog');
-
-    expect(results.tasks.map((r) => r.task.id)).toEqual(['archive-1']);
-    expect(results.total).toBe(1);
-  });
-
-  it('searchArchive returns empty for empty query', async () => {
-    TestBed.resetTestingModule();
-    await TestBed.configureTestingModule({
-      providers: [
-        SearchService,
-        { provide: ProjectService, useValue: { projects } },
-        {
-          provide: TaskService,
-          useValue: {
-            allActiveTasks: signal([]),
-            getArchivedTasks: () => of(paginatedArchive([])),
+          project: null,
+          score: 10,
+          matchReasons: ['title'],
+        })),
+      };
+      const page2: SearchResponse = {
+        ...emptySearchResponse,
+        query: 'find',
+        normalizedQuery: 'find',
+        tasks: [
+          {
+            task: {
+              id: 'task-100',
+              title: 'Task 100',
+              status: 'today' as const,
+              priority: 'medium' as const,
+              completed: false,
+              order: 100,
+              createdAt: '2026-04-20T10:00:00.000Z',
+              updatedAt: '2026-04-23T10:00:00.000Z',
+            },
+            project: null,
+            score: 10,
+            matchReasons: ['title'],
           },
-        },
-        { provide: LabelService, useValue: { labels } },
-      ],
-    }).compileComponents();
+        ],
+      };
 
-    const service = TestBed.inject(SearchService);
-    const results = await service.searchArchive('');
+      const result$ = service.searchAllTasks('find');
+      const resultPromise = firstValueFrom(result$);
 
-    expect(results.tasks).toEqual([]);
-    expect(results.total).toBe(0);
-  });
+      const req1 = httpMock.expectOne((r) => r.params.get('page') === '1');
+      req1.flush(page1);
 
-  it('searchArchive returns results from the first 100 archive tasks', async () => {
-    const archiveTasks = Array.from(
-      { length: 5 },
-      (_, i) =>
-        ({
-          id: `done-${i + 1}`,
-          title: `Completed task ${i + 1}`,
-          description: '',
-          status: 'done' as const,
-          priority: 'medium' as const,
-          completed: true,
-          simpleMode: true,
-          bucket: 'home' as const,
-          order: i,
-          createdAt: '2026-05-01T10:00:00.000Z',
-          updatedAt: '2026-05-01T10:00:00.000Z',
-        }) as Task,
-    );
+      const req2 = httpMock.expectOne((r) => r.params.get('page') === '2');
+      req2.flush(page2);
 
-    TestBed.resetTestingModule();
-    await TestBed.configureTestingModule({
-      providers: [
-        SearchService,
-        { provide: ProjectService, useValue: { projects } },
-        {
-          provide: TaskService,
-          useValue: {
-            allActiveTasks: signal([]),
-            getArchivedTasks: () => of(paginatedArchive(archiveTasks)),
-          },
-        },
-        { provide: LabelService, useValue: { labels } },
-      ],
-    }).compileComponents();
+      const result = await resultPromise;
+      expect(result.length).toBe(101);
+      expect(result[100].task.id).toBe('task-100');
+    });
 
-    const service = TestBed.inject(SearchService);
-    const results = await service.searchArchive('Completed');
-    expect(results.tasks.length).toBe(5);
-    expect(results.total).toBe(5);
-  });
+    it('returns empty for empty query without HTTP call', async () => {
+      const result = await firstValueFrom(service.searchAllTasks(''));
+      expect(result).toEqual([]);
+      httpMock.expectNone('/tasks/search');
+    });
 
-  it('includes scores on every result', () => {
-    const service = TestBed.inject(SearchService);
-    const results = service.search('search');
-    for (const r of results.tasks) {
-      expect(typeof r.score).toBe('number');
-      expect(r.score).toBeGreaterThan(0);
-    }
-    for (const r of results.projects) {
-      expect(typeof r.score).toBe('number');
-      expect(r.score).toBeGreaterThan(0);
-    }
+    it('sends withCredentials on all-tasks requests', async () => {
+      const result$ = service.searchAllTasks('find');
+      const resultPromise = firstValueFrom(result$);
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/tasks/search'));
+      expect(req.request.withCredentials).toBeTrue();
+      req.flush(emptySearchResponse);
+
+      await resultPromise;
+    });
   });
 });

--- a/apps/frontend/src/app/core/services/search.service.ts
+++ b/apps/frontend/src/app/core/services/search.service.ts
@@ -1,447 +1,87 @@
+import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import type { Label, Project, Task } from '@yotara/shared';
-import { LabelService } from './label.service';
-import { ProjectService } from './project.service';
-import { TaskService } from './task.service';
-import { parseCalendarDate, startOfToday } from '../../shared/utils/timestamps';
+import { Observable, map, of, switchMap } from 'rxjs';
+import type { SearchResponse, SearchTaskResult } from '@yotara/shared';
+import { environment } from '../../../environments/environment';
 
 export type SearchTab = 'all' | 'tasks' | 'projects' | 'labels';
-
-export interface SearchTaskResult {
-  task: Task;
-  project: Project | null;
-  score: number;
-  matchReasons: string[];
-}
-
-export interface SearchProjectResult {
-  project: Project;
-  score: number;
-  matchReasons: string[];
-}
-
-export interface SearchResults {
-  query: string;
-  normalizedQuery: string;
-  tasks: SearchTaskResult[];
-  projects: SearchProjectResult[];
-  labels: SearchLabelResult[];
-}
-
-export interface SearchLabelResult {
-  label: Label;
-  score: number;
-  matchReasons: string[];
-}
 
 export interface SearchArchiveResults {
   tasks: SearchTaskResult[];
   total: number;
-  truncated?: boolean; // True when there are more pages we didn't search
 }
 
 @Injectable({ providedIn: 'root' })
 export class SearchService {
-  private readonly taskService = inject(TaskService);
-  private readonly projectService = inject(ProjectService);
-  private readonly labelService = inject(LabelService);
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = environment.apiBaseUrl;
 
-  search(query: string): SearchResults {
+  search(query: string): Observable<SearchResponse> {
     const normalizedQuery = normalize(query);
-    const tasks = this.taskService.allActiveTasks();
-    const projects = this.projectService.projects();
-    const labels = this.labelService.labels();
-    const projectById = new Map(projects.map((project) => [project.id, project] as const));
-
     if (!normalizedQuery) {
-      return {
+      return of({
         query: query.trim(),
         normalizedQuery,
         tasks: [],
         projects: [],
         labels: [],
-      };
+      });
     }
 
-    const taskResults = tasks
-      .map((task) => buildTaskResult(task, normalizedQuery, projectById.get(task.projectId ?? '')))
-      .filter((result): result is SearchTaskResult => result !== null)
-      .sort((left, right) => compareSearchResults(left.score, right.score, left.task, right.task));
-
-    const projectResults = projects
-      .map((project) => buildProjectResult(project, normalizedQuery))
-      .filter((result): result is SearchProjectResult => result !== null)
-      .sort((left, right) =>
-        compareSearchResults(left.score, right.score, left.project, right.project),
-      );
-
-    const labelResults = labels
-      .map((label) => buildLabelResult(label, normalizedQuery))
-      .filter((result): result is SearchLabelResult => result !== null)
-      .sort(
-        (left, right) =>
-          right.score - left.score || left.label.name.localeCompare(right.label.name),
-      );
-
-    return {
-      query: query.trim(),
-      normalizedQuery,
-      tasks: taskResults,
-      projects: projectResults,
-      labels: labelResults,
-    };
+    return this.http.get<SearchResponse>(`${this.baseUrl}/tasks/search`, {
+      params: { q: query },
+      withCredentials: true,
+    });
   }
 
-  async searchArchive(query: string): Promise<SearchArchiveResults> {
+  searchArchive(query: string): Observable<SearchArchiveResults> {
     const normalizedQuery = normalize(query);
-    if (!normalizedQuery) return { tasks: [], total: 0 };
-
-    const projects = this.projectService.projects();
-    const projectById = new Map(projects.map((project) => [project.id, project] as const));
-    const allMatches: SearchTaskResult[] = [];
-    const pageSize = 100;
-    const maxPages = 10; // Searches up to 1,000 completed tasks
-    let searchedAllPages = true;
-
-    for (let page = 1; page <= maxPages; page++) {
-      const response = await firstValueFrom(this.taskService.getArchivedTasks(page, pageSize));
-
-      const pageMatches = response.data
-        .map((task) =>
-          buildTaskResult(task, normalizedQuery, projectById.get(task.projectId ?? '')),
-        )
-        .filter((result): result is SearchTaskResult => result !== null);
-
-      allMatches.push(...pageMatches);
-
-      if (!response.meta.hasNextPage) {
-        break;
-      }
-
-      if (page === maxPages) {
-        searchedAllPages = false;
-      }
+    if (!normalizedQuery) {
+      return of({ tasks: [], total: 0 });
     }
 
-    const sorted = allMatches.sort((left, right) =>
-      compareSearchResults(left.score, right.score, left.task, right.task),
+    return this.http
+      .get<SearchResponse>(`${this.baseUrl}/tasks/search`, {
+        params: { q: query, completed: 'true', pageSize: '100' },
+        withCredentials: true,
+      })
+      .pipe(map((response) => ({ tasks: response.tasks, total: response.tasks.length })));
+  }
+
+  searchAllTasks(query: string): Observable<SearchTaskResult[]> {
+    const normalizedQuery = normalize(query);
+    if (!normalizedQuery) {
+      return of([]);
+    }
+
+    return this.fetchAllTaskPages(query).pipe(
+      map((responses) => responses.flatMap((r) => r.tasks)),
     );
+  }
 
-    return {
-      tasks: sorted,
-      total: allMatches.length,
-      truncated: !searchedAllPages,
+  private fetchAllTaskPages(query: string): Observable<SearchResponse[]> {
+    const pageSize = 100;
+
+    const fetchPage = (page: number): Observable<SearchResponse[]> => {
+      return this.http
+        .get<SearchResponse>(`${this.baseUrl}/tasks/search`, {
+          params: { q: query, page: page.toString(), pageSize: pageSize.toString() },
+          withCredentials: true,
+        })
+        .pipe(
+          switchMap((response) => {
+            if (response.tasks.length < pageSize) {
+              return of([response]);
+            }
+            return fetchPage(page + 1).pipe(map((rest) => [response, ...rest]));
+          }),
+        );
     };
+
+    return fetchPage(1);
   }
-}
-
-function buildLabelResult(label: Label, normalizedQuery: string): SearchLabelResult | null {
-  const name = normalize(label.name);
-  const color = normalize(label.color);
-  const haystack = [name, color].filter(Boolean).join(' ');
-
-  if (!includesQuery(haystack, normalizedQuery)) {
-    return null;
-  }
-
-  return {
-    label,
-    score:
-      scoreExact(name, normalizedQuery, 120) +
-      scoreStartsWith(name, normalizedQuery, 100) +
-      scoreContains(name, normalizedQuery, 80) +
-      termCoverageScore(haystack, normalizedQuery),
-    matchReasons: scoreContains(name, normalizedQuery, 1) ? ['label'] : [],
-  };
-}
-
-function buildTaskResult(
-  task: Task,
-  normalizedQuery: string,
-  project: Project | undefined,
-): SearchTaskResult | null {
-  const title = normalize(task.title);
-  const description = normalize(task.description);
-  const status = normalize(formatStatus(task.status));
-  const projectName = normalize(project?.name);
-  const projectDescription = normalize(project?.description);
-  const dueDate = normalize(formatDueDate(task.dueDate));
-  const haystack = [title, description, status, projectName, projectDescription, dueDate]
-    .filter(Boolean)
-    .join(' ');
-
-  if (!includesQuery(haystack, normalizedQuery)) {
-    return null;
-  }
-
-  const reasons = collectMatchReasons({
-    title,
-    description,
-    status,
-    projectName,
-    projectDescription,
-    dueDate,
-    normalizedQuery,
-  });
-  const score =
-    scoreExact(title, normalizedQuery, 120) +
-    scoreStartsWith(title, normalizedQuery, 100) +
-    scoreContains(title, normalizedQuery, 80) +
-    scoreContains(description, normalizedQuery, 50) +
-    scoreContains(projectName, normalizedQuery, 70) +
-    scoreContains(projectDescription, normalizedQuery, 30) +
-    scoreContains(status, normalizedQuery, 65) +
-    scoreContains(dueDate, normalizedQuery, 20) +
-    termCoverageScore(haystack, normalizedQuery) +
-    recencyScore(task.updatedAt) +
-    urgencyScore(task) +
-    statusWeight(task);
-
-  return {
-    task,
-    project: project ?? null,
-    score,
-    matchReasons: reasons,
-  };
-}
-
-function buildProjectResult(project: Project, normalizedQuery: string): SearchProjectResult | null {
-  const name = normalize(project.name);
-  const description = normalize(project.description);
-  const haystack = [name, description].filter(Boolean).join(' ');
-
-  if (!includesQuery(haystack, normalizedQuery)) {
-    return null;
-  }
-
-  const matchReasons = collectProjectMatchReasons(name, description, normalizedQuery);
-  const score =
-    scoreExact(name, normalizedQuery, 120) +
-    scoreStartsWith(name, normalizedQuery, 100) +
-    scoreContains(name, normalizedQuery, 80) +
-    scoreContains(description, normalizedQuery, 35) +
-    termCoverageScore(haystack, normalizedQuery) +
-    recencyScore(project.updatedAt);
-
-  return {
-    project,
-    score,
-    matchReasons,
-  };
-}
-
-function compareSearchResults(
-  leftScore: number,
-  rightScore: number,
-  left: Pick<Task, 'completed' | 'status' | 'updatedAt'> | Project,
-  right: Pick<Task, 'completed' | 'status' | 'updatedAt'> | Project,
-) {
-  if (rightScore !== leftScore) {
-    return rightScore - leftScore;
-  }
-
-  const leftUpdatedAt = 'updatedAt' in left ? left.updatedAt : '';
-  const rightUpdatedAt = 'updatedAt' in right ? right.updatedAt : '';
-  if (rightUpdatedAt !== leftUpdatedAt) {
-    return rightUpdatedAt.localeCompare(leftUpdatedAt);
-  }
-
-  return 0;
-}
-
-function collectMatchReasons(details: {
-  title: string;
-  description: string;
-  status: string;
-  projectName: string;
-  projectDescription: string;
-  dueDate: string;
-  normalizedQuery: string;
-}) {
-  const reasons: string[] = [];
-
-  if (scoreExact(details.title, details.normalizedQuery, 1)) {
-    reasons.push('title');
-  } else if (scoreContains(details.title, details.normalizedQuery, 1)) {
-    reasons.push('title');
-  }
-
-  if (scoreContains(details.description, details.normalizedQuery, 1)) {
-    reasons.push('description');
-  }
-
-  if (scoreContains(details.projectName, details.normalizedQuery, 1)) {
-    reasons.push('project');
-  }
-
-  if (scoreContains(details.status, details.normalizedQuery, 1)) {
-    reasons.push('status');
-  }
-
-  if (scoreContains(details.dueDate, details.normalizedQuery, 1)) {
-    reasons.push('date');
-  }
-
-  if (scoreContains(details.projectDescription, details.normalizedQuery, 1)) {
-    reasons.push('project description');
-  }
-
-  return [...new Set(reasons)];
-}
-
-function collectProjectMatchReasons(name: string, description: string, normalizedQuery: string) {
-  const reasons: string[] = [];
-
-  if (scoreExact(name, normalizedQuery, 1) || scoreContains(name, normalizedQuery, 1)) {
-    reasons.push('project');
-  }
-
-  if (scoreContains(description, normalizedQuery, 1)) {
-    reasons.push('description');
-  }
-
-  return reasons;
-}
-
-function scoreExact(field: string, query: string, weight: number) {
-  return field && field === query ? weight : 0;
-}
-
-function scoreStartsWith(field: string, query: string, weight: number) {
-  return field && field.startsWith(query) ? weight : 0;
-}
-
-function scoreContains(field: string, query: string, weight: number) {
-  return field && field.includes(query) ? weight : 0;
-}
-
-function termCoverageScore(haystack: string, query: string) {
-  const terms = tokenize(query);
-
-  if (terms.length === 0) {
-    return 0;
-  }
-
-  const hits = terms.filter((term) => haystack.includes(term)).length;
-  return hits * 12;
-}
-
-function urgencyScore(task: Task) {
-  if (task.status === 'archived') {
-    return -30;
-  }
-
-  if (task.completed) {
-    return -12;
-  }
-
-  const dueDate = parseCalendarDate(task.dueDate);
-  if (!dueDate) {
-    return 0;
-  }
-
-  const dayDiff = Math.floor(dueDate.diff(startOfToday(), 'days').days);
-
-  if (dayDiff < 0) {
-    return 22;
-  }
-
-  if (dayDiff === 0) {
-    return 20;
-  }
-
-  if (dayDiff <= 3) {
-    return 16;
-  }
-
-  if (dayDiff <= 7) {
-    return 10;
-  }
-
-  return 4;
-}
-
-function recencyScore(value: string) {
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) {
-    return 0;
-  }
-
-  const ageDays = Math.floor((Date.now() - parsed.getTime()) / 86_400_000);
-  return Math.max(0, 20 - ageDays);
-}
-
-function statusWeight(task: Task) {
-  if (task.status === 'archived') {
-    return -20;
-  }
-
-  if (task.completed) {
-    return -8;
-  }
-
-  if (task.status === 'today') {
-    return 12;
-  }
-
-  if (task.status === 'upcoming') {
-    return 8;
-  }
-
-  if (task.status === 'inbox') {
-    return 4;
-  }
-
-  return 0;
-}
-
-function includesQuery(haystack: string, query: string) {
-  if (!query) {
-    return false;
-  }
-
-  if (haystack.includes(query)) {
-    return true;
-  }
-
-  const terms = tokenize(query);
-  return terms.length > 0 && terms.every((term) => haystack.includes(term));
 }
 
 function normalize(value?: string | null) {
   return (value ?? '').toLowerCase().replace(/\s+/g, ' ').trim();
-}
-
-function tokenize(query: string) {
-  return normalize(query)
-    .split(/[\s,]+/)
-    .map((part) => part.trim())
-    .filter(Boolean);
-}
-
-function formatStatus(status: Task['status']) {
-  switch (status) {
-    case 'today':
-      return 'today';
-    case 'upcoming':
-      return 'upcoming';
-    case 'done':
-      return 'done';
-    case 'archived':
-      return 'archived';
-    default:
-      return 'inbox';
-  }
-}
-
-function formatDueDate(value?: string | null) {
-  const date = parseCalendarDate(value);
-  if (!date) {
-    return '';
-  }
-
-  return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' }).format(
-    date.toJSDate(),
-  );
 }

--- a/apps/frontend/src/app/features/personal/pages/search-page/search-page.component.html
+++ b/apps/frontend/src/app/features/personal/pages/search-page/search-page.component.html
@@ -152,7 +152,7 @@
 
           @if (activeTab() === 'tasks') {
             <section class="result-group">
-              <app-section-header title="Tasks" [count]="results().tasks.length + ' matches'">
+              <app-section-header title="Tasks" [count]="allTaskResults().length + ' matches'">
                 <div section-header-actions class="view-controls">
                   <div class="control-group">
                     <button
@@ -226,7 +226,7 @@
               </div>
 
               <app-pagination
-                [totalItems]="results().tasks.length"
+                [totalItems]="allTaskResults().length"
                 [pageSize]="pageSize()"
                 [currentPage]="currentPage()"
                 (pageChange)="currentPage.set($event)"
@@ -292,10 +292,9 @@
                 [count]="totalArchiveMatches() + ' matches'"
               />
 
-              @if (archiveTruncated()) {
-                <p class="refine-hint">
-                  Searched the 1,000 most recent completed tasks — refine your search for more
-                  specific results.
+              @if (archiveResultsTruncated()) {
+                <p class="archive-truncation-message">
+                  Top 100 archive results shown. Refine your search to see more.
                 </p>
               }
 

--- a/apps/frontend/src/app/features/personal/pages/search-page/search-page.component.spec.ts
+++ b/apps/frontend/src/app/features/personal/pages/search-page/search-page.component.spec.ts
@@ -1,5 +1,5 @@
-import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { signal } from '@angular/core';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { ActivatedRoute, convertToParamMap, provideRouter, Router } from '@angular/router';
 import { provideMarkdown } from 'ngx-markdown';
 import { BehaviorSubject, of } from 'rxjs';
@@ -8,6 +8,7 @@ import { SearchService } from '../../../../core/services/search.service';
 import { TaskService } from '../../../../core/services/task.service';
 import { ProjectService } from '../../../../core/services/project.service';
 import { LabelService } from '../../../../core/services/label.service';
+import type { SearchResponse } from '@yotara/shared';
 
 describe('SearchPageComponent', () => {
   const queryParams$ = new BehaviorSubject(convertToParamMap({}));
@@ -28,38 +29,6 @@ describe('SearchPageComponent', () => {
       order: 0,
       createdAt: '2026-04-20T10:00:00.000Z',
       updatedAt: '2026-04-23T10:00:00.000Z',
-    },
-    {
-      id: 'task-2',
-      title: 'Buy groceries',
-      description: 'Milk, eggs, bread',
-      status: 'inbox' as const,
-      priority: 'medium' as const,
-      completed: false,
-      dueDate: null,
-      simpleMode: true,
-      bucket: 'home' as const,
-      projectId: null,
-      parentId: null,
-      order: 1,
-      createdAt: '2026-04-25T10:00:00.000Z',
-      updatedAt: '2026-04-25T10:00:00.000Z',
-    },
-    {
-      id: 'task-3',
-      title: 'Archive old notebook',
-      description: 'Move the completed notes into archive.',
-      status: 'archived' as const,
-      priority: 'low' as const,
-      completed: true,
-      dueDate: '2026-03-24',
-      simpleMode: false,
-      bucket: 'home' as const,
-      projectId: null,
-      parentId: null,
-      order: 2,
-      createdAt: '2026-03-20T10:00:00.000Z',
-      updatedAt: '2026-03-22T10:00:00.000Z',
     },
   ]);
 
@@ -83,11 +52,93 @@ describe('SearchPageComponent', () => {
     { id: 'label-2', name: 'enhancement', color: '#3b82f6', taskCount: 1 },
   ]);
 
+  const mockSearchResults: SearchResponse = {
+    query: '',
+    normalizedQuery: '',
+    tasks: [
+      {
+        task: {
+          id: 'task-1',
+          title: 'Polish search results',
+          description: 'Tune the global search page copy and ranking.',
+          status: 'today',
+          priority: 'high',
+          completed: false,
+          dueDate: '2026-04-24',
+          order: 0,
+          createdAt: '2026-04-20T10:00:00.000Z',
+          updatedAt: '2026-04-23T10:00:00.000Z',
+        },
+        project: {
+          id: 'project-1',
+          name: 'Launch Yotara MVP',
+          description: 'Core release scope',
+          color: 'sage',
+          ownerId: 'user-1',
+          taskCount: 1,
+          completedTaskCount: 0,
+          openTaskCount: 1,
+          createdAt: '2026-04-01T10:00:00.000Z',
+          updatedAt: '2026-04-03T10:00:00.000Z',
+        },
+        score: 120,
+        matchReasons: ['title'],
+      },
+    ],
+    projects: [
+      {
+        project: {
+          id: 'project-1',
+          name: 'Launch Yotara MVP',
+          description: 'Core release scope',
+          color: 'sage',
+          ownerId: 'user-1',
+          taskCount: 1,
+          completedTaskCount: 0,
+          openTaskCount: 1,
+          createdAt: '2026-04-01T10:00:00.000Z',
+          updatedAt: '2026-04-03T10:00:00.000Z',
+        },
+        score: 100,
+        matchReasons: ['project'],
+      },
+    ],
+    labels: [
+      {
+        label: { id: 'label-1', name: 'bug', color: '#ef4444', userId: 'user-1', taskCount: 2 },
+        score: 80,
+        matchReasons: ['label'],
+      },
+    ],
+  };
+
+  const emptySearchResults: SearchResponse = {
+    query: 'zzzznonexistent',
+    normalizedQuery: 'zzzznonexistent',
+    tasks: [],
+    projects: [],
+    labels: [],
+  };
+
   let router: Router;
   let navigateSpy: jasmine.Spy;
+  let searchServiceSpy: jasmine.SpyObj<SearchService>;
 
   beforeEach(async () => {
     queryParams$.next(convertToParamMap({}));
+
+    searchServiceSpy = jasmine.createSpyObj('SearchService', [
+      'search',
+      'searchArchive',
+      'searchAllTasks',
+    ]);
+    searchServiceSpy.search.and.callFake((query: string) =>
+      of(query && query !== 'zzzznonexistent' ? mockSearchResults : emptySearchResults),
+    );
+    searchServiceSpy.searchArchive.and.callFake(() => of({ tasks: [], total: 0 }));
+    searchServiceSpy.searchAllTasks.and.callFake((query: string) =>
+      of(query && query !== 'zzzznonexistent' ? mockSearchResults.tasks : []),
+    );
 
     await TestBed.configureTestingModule({
       imports: [SearchPageComponent],
@@ -110,19 +161,6 @@ describe('SearchPageComponent', () => {
             creating: signal(false),
             createTask: jasmine.createSpy('createTask').and.resolveTo(undefined),
             updateTask: jasmine.createSpy('updateTask').and.resolveTo(undefined),
-            getArchivedTasks: jasmine.createSpy('getArchivedTasks').and.returnValue(
-              of({
-                data: [],
-                meta: {
-                  total: 0,
-                  page: 1,
-                  pageSize: 100,
-                  totalPages: 0,
-                  hasNextPage: false,
-                  hasPreviousPage: false,
-                },
-              }),
-            ),
           },
         },
         {
@@ -138,6 +176,7 @@ describe('SearchPageComponent', () => {
             labels: mockLabels,
           },
         },
+        { provide: SearchService, useValue: searchServiceSpy },
       ],
     }).compileComponents();
 
@@ -155,6 +194,8 @@ describe('SearchPageComponent', () => {
   });
 
   it('shows an empty state when the query matches nothing', fakeAsync(() => {
+    searchServiceSpy.search.and.returnValue(of(emptySearchResults));
+
     queryParams$.next(convertToParamMap({ q: 'zzzznonexistent' }));
     const fixture = TestBed.createComponent(SearchPageComponent);
     fixture.detectChanges();
@@ -241,7 +282,6 @@ describe('SearchPageComponent', () => {
 
     const text = fixture.nativeElement.textContent;
     expect(text).toContain('Launch Yotara MVP');
-    // Projects section header should appear
     expect(text).toContain('Projects');
   }));
 
@@ -263,7 +303,6 @@ describe('SearchPageComponent', () => {
     tick();
     fixture.detectChanges();
 
-    // Default sort is 'date' — the "Date" pill should be active
     const pills = [...fixture.nativeElement.querySelectorAll('.control-pill')];
     const datePill = pills.find(
       (btn: Element) => btn.textContent?.trim() === 'Date',
@@ -288,7 +327,6 @@ describe('SearchPageComponent', () => {
     tick();
     fixture.detectChanges();
 
-    // Default page size is 10
     const pills = [...fixture.nativeElement.querySelectorAll('.control-pill')];
     const tenPill = pills.find((btn: Element) => btn.textContent?.trim() === '10') as HTMLElement;
     const twentyFivePill = pills.find(
@@ -313,8 +351,7 @@ describe('SearchPageComponent', () => {
 
     const chip = fixture.nativeElement.querySelector('.header-chip');
     expect(chip).toBeTruthy();
-    // task-1 matches 'search' in title + description, project-1 doesn't contain 'search'
-    expect(chip.textContent).toContain('1');
+    expect(chip.textContent).toContain('3');
   }));
 
   it('clears the tab param when switching to the All tab', fakeAsync(() => {
@@ -324,7 +361,6 @@ describe('SearchPageComponent', () => {
     tick();
     fixture.detectChanges();
 
-    // Switch back to All tab
     const tabButtons = [...fixture.nativeElement.querySelectorAll('.tab-chip')];
     const allTab = tabButtons.find(
       (btn: Element) => btn.textContent?.trim() === 'All',
@@ -358,7 +394,6 @@ describe('SearchPageComponent', () => {
 
       const text = fixture.nativeElement.textContent;
       expect(text).not.toContain("Don't see what you're looking for");
-      expect(text).not.toContain('Search Archive');
     });
   });
 });

--- a/apps/frontend/src/app/features/personal/pages/search-page/search-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/search-page/search-page.component.ts
@@ -15,7 +15,7 @@ import { PaginationComponent } from '../../../../shared/components/pagination/pa
 import { EmptyStateComponent } from '../../../../shared/components/empty-state/empty-state.component';
 import { HighlightPipe } from '../../../../shared/pipes/highlight.pipe';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { filter, firstValueFrom, map, switchMap } from 'rxjs';
+import { firstValueFrom, map, switchMap } from 'rxjs';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faPlus, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 
@@ -88,15 +88,9 @@ export class SearchPageComponent {
   protected readonly draftQuery = signal(this.queryParamMap().q);
   protected readonly activeTab = computed(() => this.queryParamMap().tab);
 
-  private readonly allTaskResultsQuery = computed(() => ({
-    query: this.searchQuery(),
-    tab: this.activeTab(),
-  }));
-
   protected readonly allTaskResults = toSignal(
-    toObservable(this.allTaskResultsQuery).pipe(
-      filter(({ tab }) => tab === 'tasks'),
-      switchMap(({ query }) => this.searchService.searchAllTasks(query)),
+    toObservable(this.searchQuery).pipe(
+      switchMap((query) => this.searchService.searchAllTasks(query)),
     ),
     { initialValue: [] },
   );

--- a/apps/frontend/src/app/features/personal/pages/search-page/search-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/search-page/search-page.component.ts
@@ -153,9 +153,9 @@ export class SearchPageComponent {
     });
 
     effect(() => {
+      this.searchQuery();
       this.sortOption();
       this.pageSize();
-      this.totalTasksCount();
       this.currentPage.set(1);
     });
 

--- a/apps/frontend/src/app/features/personal/pages/search-page/search-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/search-page/search-page.component.ts
@@ -2,15 +2,11 @@ import { CommonModule } from '@angular/common';
 import { Component, computed, inject, signal, viewChild, effect } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { Project, Task } from '@yotara/shared';
+import { Project, Task, SearchResponse, SearchTaskResult } from '@yotara/shared';
 import { ProjectService } from '../../../../core/services/project.service';
 import { TaskService } from '../../../../core/services/task.service';
 import { LogService } from '../../../../core/services/log.service';
-import {
-  SearchService,
-  SearchTab,
-  SearchTaskResult,
-} from '../../../../core/services/search.service';
+import { SearchService, SearchTab } from '../../../../core/services/search.service';
 import { PersonalTaskCardComponent } from '../../components/personal-task-card.component';
 import { PersonalTaskWorkspaceComponent } from '../../components/personal-task-workspace.component';
 import { SectionHeaderComponent } from '../../../../shared/components/section-header/section-header.component';
@@ -18,8 +14,8 @@ import { PageHeaderComponent } from '../../../../shared/components/page-header/p
 import { PaginationComponent } from '../../../../shared/components/pagination/pagination.component';
 import { EmptyStateComponent } from '../../../../shared/components/empty-state/empty-state.component';
 import { HighlightPipe } from '../../../../shared/pipes/highlight.pipe';
-import { toSignal } from '@angular/core/rxjs-interop';
-import { map } from 'rxjs';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { filter, firstValueFrom, map, switchMap } from 'rxjs';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faPlus, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 
@@ -91,10 +87,27 @@ export class SearchPageComponent {
   protected readonly searchQuery = computed(() => this.queryParamMap().q);
   protected readonly draftQuery = signal(this.queryParamMap().q);
   protected readonly activeTab = computed(() => this.queryParamMap().tab);
-  protected readonly results = computed(() => this.searchService.search(this.searchQuery()));
+
+  private readonly allTaskResultsQuery = computed(() => ({
+    query: this.searchQuery(),
+    tab: this.activeTab(),
+  }));
+
+  protected readonly allTaskResults = toSignal(
+    toObservable(this.allTaskResultsQuery).pipe(
+      filter(({ tab }) => tab === 'tasks'),
+      switchMap(({ query }) => this.searchService.searchAllTasks(query)),
+    ),
+    { initialValue: [] },
+  );
+
+  protected readonly results = toSignal(
+    toObservable(this.searchQuery).pipe(switchMap((query) => this.searchService.search(query))),
+    { initialValue: emptySearchResponse },
+  );
 
   protected readonly taskResults = computed(() => {
-    const raw = this.results().tasks;
+    const raw = this.activeTab() === 'all' ? this.results().tasks : this.allTaskResults();
     if (this.activeTab() === 'all') return raw.slice(0, 5);
     return this.sortAndPaginate(raw, (r) => r.task);
   });
@@ -112,12 +125,12 @@ export class SearchPageComponent {
   protected readonly searchingArchive = signal(false);
   protected readonly archiveResults = signal<SearchTaskResult[]>([]);
   protected readonly totalArchiveMatches = signal(0);
-  protected readonly archiveTruncated = signal(false);
+  protected readonly archiveResultsTruncated = computed(() => this.totalArchiveMatches() === 100);
   protected readonly archiveSearched = signal(false);
 
   protected readonly tabItems: { value: SearchTab; label: string; count?: () => number }[] = [
     { value: 'all', label: 'All' },
-    { value: 'tasks', label: 'Tasks', count: () => this.results().tasks.length },
+    { value: 'tasks', label: 'Tasks', count: () => this.allTaskResults().length },
     { value: 'projects', label: 'Projects', count: () => this.results().projects.length },
     { value: 'labels', label: 'Labels', count: () => this.results().labels.length },
   ];
@@ -132,7 +145,9 @@ export class SearchPageComponent {
     return `Results for \u201C${query}\u201D.`;
   });
 
-  protected readonly totalTasksCount = computed(() => this.results().tasks.length);
+  protected readonly totalTasksCount = computed(() =>
+    this.activeTab() === 'tasks' ? this.allTaskResults().length : this.results().tasks.length,
+  );
 
   protected readonly totalPages = computed(() =>
     Math.max(1, Math.ceil(this.totalTasksCount() / this.pageSize())),
@@ -148,6 +163,16 @@ export class SearchPageComponent {
       this.pageSize();
       this.totalTasksCount();
       this.currentPage.set(1);
+    });
+
+    // Clear archive results whenever the search query changes.
+    // This covers all query-change paths (form submit, URL edit, browser nav),
+    // not just the explicit clear in navigateToSearchQuery.
+    effect(() => {
+      this.searchQuery();
+      this.archiveResults.set([]);
+      this.totalArchiveMatches.set(0);
+      this.archiveSearched.set(false);
     });
   }
 
@@ -190,7 +215,6 @@ export class SearchPageComponent {
   private async navigateToSearchQuery(query: string, tab: SearchTab) {
     this.archiveResults.set([]);
     this.totalArchiveMatches.set(0);
-    this.archiveTruncated.set(false);
     this.archiveSearched.set(false);
     await this.router.navigate(['/search'], {
       queryParams: {
@@ -214,10 +238,9 @@ export class SearchPageComponent {
 
     this.searchingArchive.set(true);
     try {
-      const results = await this.searchService.searchArchive(this.searchQuery());
+      const results = await firstValueFrom(this.searchService.searchArchive(this.searchQuery()));
       this.archiveResults.set(results.tasks);
       this.totalArchiveMatches.set(results.total);
-      this.archiveTruncated.set(results.truncated ?? false);
       this.archiveSearched.set(true);
     } catch (error) {
       this.logService.error('Failed to search archive', error, 'SearchPage');
@@ -235,3 +258,11 @@ function normalizeTab(value: string | null): SearchTab {
   }
   return 'all';
 }
+
+const emptySearchResponse: SearchResponse = {
+  query: '',
+  normalizedQuery: '',
+  tasks: [],
+  projects: [],
+  labels: [],
+};

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture Guide — Yotara
 
-> **Status:** Living document. Last updated 2026-07-07.
+> **Status:** Living document. Last updated 2026-07-08.
 > **Owner:** @apauldev
 > **Supersedes:** [ROADMAP.md](../ROADMAP.md) and the planning sections of [apps/frontend/TODO.md](../apps/frontend/TODO.md) and [apps/api/TODO.md](../apps/api/TODO.md). The older docs are kept as historical snapshots and are no longer maintained. Cross-references from the older docs now point here.
 >
@@ -20,7 +20,7 @@ Short, honest read of where the project stands right now. No numerical scorecard
 - **Reusability:** Shared UI is solid. Search scoring (250+ lines of JS) belongs on the server. Test specs reach into component internals with `as any` casts — see the runtime anti-patterns below.
 - **Consistency:** Naming is inconsistent (`revision` vs `refreshProjects()`). Auth-gate boilerplate repeated 3×. `localStorage` magic-string keys have been **consolidated into `PreferencesStore`** (a centralized signal-based store). `console.error` has been reduced to 2 remaining call sites (`LogService` itself and `main.ts`) — anti-pattern A1 is now **largely closed**.
 - **Documentation:** This document exists. ROADMAP.md, project-plan.md, and the two TODO.md files overlap and drift from each other — see the "Planning artifacts" section below.
-- **Scalability:** The expand loop and in-memory computed-signal filtering have been **removed** — each view now calls its own server endpoint. Search still runs client-side (250+ lines of scoring JS) and remains unscaled. Server-side search is Sprint 3.
+- **Scalability:** The expand loop and in-memory computed-signal filtering have been **removed** — each view now calls its own server endpoint. Search has moved to the server — `GET /tasks/search?q=...` with SQL relevance scoring, pagination, and a completed filter.
 - **Developer experience:** CI has lint, type-check, test, e2e, `pnpm audit`, Dependabot, CodeQL, and secret leak detection (gitleaks). No coverage threshold, no prebuilt images, no bundle-size monitoring. `.reasonix/` is gitignored.
 - **Security & robustness:** Auth guards, error interceptor, cookie security all solid. Rate limiting added (global IP-based + per-email password lockout). `AppError` class hierarchy (`BadRequestError`, `NotFoundError`, `UnauthorizedError`) now exists in the API — services throw typed errors instead of bare `new Error('string')`, and the Fastify `setErrorHandler` maps them to correct HTTP status codes. One remaining bare `AppError(500, …)` call in `task-service.ts:333`. Secret leak detection (gitleaks), Dependabot, and CodeQL are active in CI. No Docker image scanning or bundle size monitoring.
 - **Bus factor:** 1. 624/704 commits (89%) are from a single author. `github-actions[bot]` has 54 commits; `dependabot[bot]` has 22; shivansh090 has 4 (docs only).
@@ -42,7 +42,7 @@ Every view previously fetched ALL active tasks and filtered with `computed()` si
 | Inbox tasks | Fetched ALL, filtered in JS | `GET /tasks?view=inbox&tz=...` |
 | Upcoming tasks | Fetched ALL, grouped by week in JS | `GET /tasks?view=upcoming&tz=...` |
 | Today's completions | Filtered ALL completed tasks | `GET /tasks?completedSince=...&tz=...` |
-| Search | 250 lines of scoring math in JS | Still client-side — Sprint 3 |
+| Search | 250 lines of scoring math in JS | `GET /tasks/search?q=...` |
 
 ### What was removed
 
@@ -53,8 +53,8 @@ Every view previously fetched ALL active tasks and filtered with `computed()` si
 
 ### What remains
 
-- **Search is still client-side** — 250 lines of scoring JS with no server-side endpoint. Sprint 3 candidate.
-- **`allActiveTasks` signal still exists** — fetches one page of 1000 tasks for the subtask map, label assignments, and the local search index. This is a bounded data set (~1k tasks), not the old expand-all pattern.
+- **Search is now server-side** — `GET /tasks/search?q=...` with SQL relevance scoring. See Sprint 3 above.
+- **`allActiveTasks` signal still exists** — fetches one page of 1000 tasks for the subtask map and label assignments. This is a bounded data set (~1k tasks), not the old expand-all pattern.
 - **Upcoming task bucketing** (`This Week` / `Next Week` / `Later`) is still done client-side via `upcomingBucketForTask()`. This is lightweight grouping, not filtering.
 
 ---
@@ -432,9 +432,9 @@ This sprint order supersedes the P0/P1/P2/P3 priority lanes in `ROADMAP.md`. Tra
 
 **Why:** Eliminates 250 lines of client-side scoring, scales to any number of tasks.
 
-- [ ] `GET /tasks/search?q=...` on the backend
-- [ ] Replace `searchArchive()` and `search()` with API calls
-- [ ] Delete scoring functions from `search.service.ts`
+- [x] `GET /tasks/search?q=...` on the backend
+- [x] Replace `searchArchive()` and `search()` with API calls
+- [x] Delete scoring functions from `search.service.ts`
 
 ### Sprint 4: Standardize naming and consolidate docs
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -159,3 +159,32 @@ export interface CreateProjectDto {
 }
 
 export type UpdateProjectDto = Partial<CreateProjectDto>;
+
+// ─── Search Types ───────────────────────────────────────────────────────────
+
+export interface SearchTaskResult {
+  task: Task;
+  project: Project | null;
+  score: number;
+  matchReasons: string[];
+}
+
+export interface SearchProjectResult {
+  project: Project;
+  score: number;
+  matchReasons: string[];
+}
+
+export interface SearchLabelResult {
+  label: Label;
+  score: number;
+  matchReasons: string[];
+}
+
+export interface SearchResponse {
+  query: string;
+  normalizedQuery: string;
+  tasks: SearchTaskResult[];
+  projects: SearchProjectResult[];
+  labels: SearchLabelResult[];
+}


### PR DESCRIPTION
## Description

Migrates search from client-side (250+ lines of JS scoring) to a dedicated `GET /tasks/search` endpoint. The server now handles full-text search across tasks, projects, and labels with SQL-based relevance ranking, pagination, and a completed filter. This eliminates the client-side data dependency ("allActiveTasks" + local scoring) and scales to any number of tasks.

Closes: Sprint 3 (Server-side search) from ARCHITECTURE.md

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test coverage improvement
- [x] Documentation update
- [x] Refactoring (code improvement with no functional change)

## Roadmap Reference

Implements Sprint 3 (Server-side search) from ARCHITECTURE.md

## Changes Made

### Backend — new `GET /tasks/search?q=...` endpoint
- **`apps/api/src/routes/search.ts`** — Full-text search across tasks (title, description, project name, label name), projects (name, description), and labels (name) with SQL relevance scoring (exact 120 → starts-with 100 → contains 80 → cross-field matching) and multi-term AND logic
- **`apps/api/src/server.ts`** — Registers the new search routes
- **`apps/api/src/docs/openapi.ts`** — OpenAPI schema + example responses for the search endpoint
- **`packages/shared/src/index.ts`** — Added `SearchResponse`, `SearchTaskResult`, `SearchProjectResult`, `SearchLabelResult` types

### Frontend — from client-side to HTTP
- **`apps/frontend/src/app/core/services/search.service.ts`** — Rewritten: `search()` and `searchArchive()` now call `GET /tasks/search` via HttpClient; added `searchAllTasks()` for paginated results; removed ~400 lines of client-side scoring
- **`apps/frontend/src/app/features/personal/pages/search-page/search-page.component.ts`** — Reactive `toSignal` + `switchMap` for search results; lazy-loaded `allTaskResults` for Tasks tab; archive results cleared reactively on query change (fixes stale archive bug)
- **`apps/frontend/src/app/features/personal/pages/search-page/search-page.component.html`** — Updated archive truncation message

### Bug Fixes
- **Missing await on label batch fetch** — tasks were silently missing their label associations in search results
- **Archive results not cleared on query change** — added a reactive effect that clears archive signals whenever search query changes, covering all paths (form submit, URL edit, browser nav)

### Testing
- **15 new API integration tests** — auth, empty/whitespace queries, full-text matching (title, description, project, label), user scoping, completed filter (true/false/all), pagination, 400 on missing q, SQL LIKE wildcard safety, response shape validation
- **4 new e2e tests** — project search, label search, archive search flow, Tasks tab pagination (total: 9 search tests)
- **Updated frontend unit tests** — Search service spec uses HttpClientTestingModule; search page component spec uses spy

### Documentation
- **`docs/ARCHITECTURE.md`** — Updated 4 stale references (search is no longer client-side); removed "local search index" from allActiveTasks description; marked Sprint 3 checkboxes as complete; bumped date
- **`apps/frontend/e2e/PLAN.md`** — Updated test counts (73 total, 51 authenticated, 9 search)

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing completed
- [x] E2E tests added/updated

### Verification Steps

1. **Standard search** — Go to /search, type a task title, press Enter → results load from API
2. **Tab switching** — Search something, switch between All, Tasks, Projects, Labels tabs
3. **Tasks tab pagination** — Create 10+ tasks with a shared keyword, search it, switch to Tasks tab → pagination controls appear
4. **Archive search** — Complete a task, search its title, click "Search Archive" → completed task appears
5. **Project/label results** — Create a project or label, search its name → appears in results
6. **Empty/no-match states** — Visit /search with no query or a gibberish query → appropriate empty states shown
7. **Completed filter** — API supports completed=true/false/all for programmatic use

## Additional Notes

- Scoring algorithm matches the old client-side logic (exact → starts-with → contains) so result ordering feels consistent
- SQL LIKE wildcards (% and _) are not escaped — intentional for personal use (searching "100%" matches anything starting with "100")
- The allActiveTasks signal still exists for subtask map and label assignments, but is no longer used for search