### PR TITLE
fix: use clean URLs, remove _redirects, restructure privacy page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 <a href="https://github.com/apauldev/Yotara/graphs/contributors"><img src="https://img.shields.io/github/contributors/apauldev/Yotara?style=for-the-badge&color=24473c" alt="Contributors" /></a>
 <a href="https://github.com/apauldev/Yotara"><img src="https://img.shields.io/github/stars/apauldev/Yotara?style=for-the-badge&logo=github&color=B7D3C3&logoColor=173F35" alt="Stars" /></a>
 <a href="https://github.com/users/apauldev/projects/1"><img src="https://img.shields.io/badge/roadmap-project-24473c?style=for-the-badge&logo=github&logoColor=white" alt="Roadmap" /></a>
+<a href="https://yotara.website"><img src="https://img.shields.io/badge/website-yotara.website-173F35?style=for-the-badge&logo=cloudflare&logoColor=white" alt="Website" /></a>
 
 <br />
 

--- a/apps/yotara-website/404.html
+++ b/apps/yotara-website/404.html
@@ -532,8 +532,8 @@
     >
       <div class="max-w-7xl mx-auto flex flex-col sm:flex-row items-start sm:items-center gap-4">
         <p class="text-sm leading-relaxed flex-grow">
-          Yotara does not use cookies. The Cloudflare CDN may process your IP address and
-          approximate location for routing and caching. No tracking or personal data is stored.
+          This site does not use cookies. Cloudflare CDN handles routing and Google Fonts serve
+          typography. No tracking or personal data is stored.
           <a
             href="/privacy/"
             class="text-primary-fixed underline hover:no-underline whitespace-nowrap"

--- a/apps/yotara-website/404.html
+++ b/apps/yotara-website/404.html
@@ -5,14 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>404 — Page Not Found — Yotara</title>
     <meta name="description" content="The page you're looking for doesn't exist." />
-    <link rel="canonical" href="https://yotara.website/404.html" />
+    <link rel="canonical" href="https://yotara.website/404" />
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg" />
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
 
     <!-- Open Graph / Social -->
     <meta property="og:title" content="404 — Yotara" />
     <meta property="og:description" content="The page you're looking for doesn't exist." />
-    <meta property="og:url" content="https://yotara.website/404.html" />
+    <meta property="og:url" content="https://yotara.website/404" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Yotara" />
     <meta property="og:locale" content="en_US" />
@@ -310,7 +310,7 @@
       >
         <a
           class="text-[1.375rem] font-bold text-primary tracking-wide font-headline flex items-center gap-2"
-          href="index.html"
+          href="/"
         >
           <img src="assets/logo.svg" alt="Yotara" class="h-8 w-8" />
           Yotara
@@ -321,22 +321,22 @@
         >
           <a
             class="nav-link text-on-surface-variant hover:text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="index.html"
+            href="/"
             >Home</a
           >
           <a
             class="nav-link text-on-surface-variant hover:text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="features.html"
+            href="/features"
             >Features</a
           >
           <a
             class="nav-link text-on-surface-variant hover:text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="install.html"
+            href="/install"
             >Install</a
           >
           <a
             class="nav-link text-on-surface-variant hover:text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="blog.html"
+            href="/blog"
             >Blog</a
           >
         </div>
@@ -391,7 +391,7 @@
           </p>
           <a
             class="btn-primary inline-flex items-center gap-2 bg-primary text-on-primary px-8 py-4 rounded-full font-bold text-lg tracking-wide shadow-[0_8px_30px_rgb(0,0,0,0.08)]"
-            href="index.html"
+            href="/"
           >
             <span class="material-symbols-outlined" aria-hidden="true">arrow_back</span>
             Go home
@@ -415,21 +415,21 @@
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="index.html"
+                href="/"
                 >Home</a
               >
             </li>
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="features.html"
+                href="/features"
                 >Features</a
               >
             </li>
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="install.html"
+                href="/install"
                 >Install</a
               >
             </li>
@@ -448,14 +448,14 @@
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="blog.html"
+                href="/blog"
                 >Blog</a
               >
             </li>
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="privacy.html"
+                href="/privacy/"
                 >Privacy</a
               >
             </li>
@@ -535,7 +535,7 @@
           Yotara does not use cookies. The Cloudflare CDN may process your IP address and
           approximate location for routing and caching. No tracking or personal data is stored.
           <a
-            href="privacy.html"
+            href="/privacy/"
             class="text-primary-fixed underline hover:no-underline whitespace-nowrap"
             >Learn more</a
           >

--- a/apps/yotara-website/_redirects
+++ b/apps/yotara-website/_redirects
@@ -1,7 +1,0 @@
-# Cloudflare Pages redirects
-/home / 301
-/features /features.html 200
-/install /install.html 200
-/blog /blog.html 200
-/privacy /privacy.html 200
-/* /404.html 404

--- a/apps/yotara-website/blog.html
+++ b/apps/yotara-website/blog.html
@@ -296,8 +296,8 @@
     >
       <div class="max-w-7xl mx-auto flex flex-col sm:flex-row items-start sm:items-center gap-4">
         <p class="text-sm leading-relaxed flex-grow">
-          Yotara does not use cookies. The Cloudflare CDN may process your IP address and
-          approximate location for routing and caching. No tracking or personal data is stored.
+          This site does not use cookies. Cloudflare CDN handles routing and Google Fonts serve
+          typography. No tracking or personal data is stored.
           <a
             href="/privacy/"
             class="text-primary-fixed underline hover:no-underline whitespace-nowrap"

--- a/apps/yotara-website/blog.html
+++ b/apps/yotara-website/blog.html
@@ -8,7 +8,7 @@
       name="description"
       content="Thoughts, updates, and deep dives into building focused digital environments."
     />
-    <link rel="canonical" href="https://yotara.website/blog.html" />
+    <link rel="canonical" href="https://yotara.website/blog" />
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg" />
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
 
@@ -18,7 +18,7 @@
       property="og:description"
       content="Thoughts, updates, and deep dives into building focused digital environments."
     />
-    <meta property="og:url" content="https://yotara.website/blog.html" />
+    <meta property="og:url" content="https://yotara.website/blog" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Yotara" />
     <meta property="og:locale" content="en_US" />
@@ -132,7 +132,7 @@
       >
         <a
           class="text-[1.375rem] font-bold text-primary tracking-wide font-headline flex items-center gap-2"
-          href="index.html"
+          href="/"
         >
           <img src="assets/logo.svg" alt="Yotara" class="h-8 w-8" />
           Yotara
@@ -143,22 +143,22 @@
         >
           <a
             class="nav-link text-on-surface-variant hover:text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="index.html"
+            href="/"
             >Home</a
           >
           <a
             class="nav-link text-on-surface-variant hover:text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="features.html"
+            href="/features"
             >Features</a
           >
           <a
             class="nav-link text-on-surface-variant hover:text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="install.html"
+            href="/install"
             >Install</a
           >
           <a
             class="nav-link nav-link-active text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="blog.html"
+            href="/blog"
             aria-current="page"
             >Blog</a
           >
@@ -213,21 +213,21 @@
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="index.html"
+                href="/"
                 >Home</a
               >
             </li>
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="features.html"
+                href="/features"
                 >Features</a
               >
             </li>
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="install.html"
+                href="/install"
                 >Install</a
               >
             </li>
@@ -246,14 +246,14 @@
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="blog.html"
+                href="/blog"
                 >Blog</a
               >
             </li>
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="privacy.html"
+                href="/privacy/"
                 >Privacy</a
               >
             </li>
@@ -299,7 +299,7 @@
           Yotara does not use cookies. The Cloudflare CDN may process your IP address and
           approximate location for routing and caching. No tracking or personal data is stored.
           <a
-            href="privacy.html"
+            href="/privacy/"
             class="text-primary-fixed underline hover:no-underline whitespace-nowrap"
             >Learn more</a
           >

--- a/apps/yotara-website/features.html
+++ b/apps/yotara-website/features.html
@@ -711,7 +711,7 @@
                   >
                 </div>
               </div>
-              <p class="text-sm text-on-surface-variant">Plenty of choices to match your mood.</p>
+              <p class="text-sm text-on-surface-variant">Light and dark modes in every theme.</p>
             </div>
             <div
               class="relative w-full h-[300px] md:h-[400px] rounded-2xl overflow-hidden shadow-[0_20px_50px_rgba(28,28,23,0.08)] ring-1 ring-outline-variant/15 bg-surface"
@@ -906,8 +906,8 @@
     >
       <div class="max-w-7xl mx-auto flex flex-col sm:flex-row items-start sm:items-center gap-4">
         <p class="text-sm leading-relaxed flex-grow">
-          Yotara does not use cookies. The Cloudflare CDN may process your IP address and
-          approximate location for routing and caching. No tracking or personal data is stored.
+          This site does not use cookies. Cloudflare CDN handles routing and Google Fonts serve
+          typography. No tracking or personal data is stored.
           <a
             href="/privacy/"
             class="text-primary-fixed underline hover:no-underline whitespace-nowrap"

--- a/apps/yotara-website/features.html
+++ b/apps/yotara-website/features.html
@@ -8,7 +8,7 @@
       name="description"
       content="Every feature in Yotara serves one purpose: helping you focus on what matters. Task management, projects, recurring tasks, markdown, and more."
     />
-    <link rel="canonical" href="https://yotara.website/features.html" />
+    <link rel="canonical" href="https://yotara.website/features" />
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg" />
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
 
@@ -18,7 +18,7 @@
       property="og:description"
       content="Every feature in Yotara serves one purpose: helping you focus on what matters."
     />
-    <meta property="og:url" content="https://yotara.website/features.html" />
+    <meta property="og:url" content="https://yotara.website/features" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Yotara" />
     <meta property="og:locale" content="en_US" />
@@ -128,7 +128,7 @@
       >
         <a
           class="text-[1.375rem] font-bold text-primary tracking-wide font-headline flex items-center gap-2"
-          href="index.html"
+          href="/"
         >
           <img src="assets/logo.svg" alt="Yotara" class="h-8 w-8" />
           Yotara
@@ -139,23 +139,23 @@
         >
           <a
             class="nav-link text-on-surface-variant hover:text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="index.html"
+            href="/"
             >Home</a
           >
           <a
             class="nav-link nav-link-active text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="features.html"
+            href="/features"
             aria-current="page"
             >Features</a
           >
           <a
             class="nav-link text-on-surface-variant hover:text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="install.html"
+            href="/install"
             >Install</a
           >
           <a
             class="nav-link text-on-surface-variant hover:text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="blog.html"
+            href="/blog"
             >Blog</a
           >
         </div>
@@ -823,21 +823,21 @@
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="index.html"
+                href="/"
                 >Home</a
               >
             </li>
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="features.html"
+                href="/features"
                 >Features</a
               >
             </li>
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="install.html"
+                href="/install"
                 >Install</a
               >
             </li>
@@ -856,14 +856,14 @@
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="blog.html"
+                href="/blog"
                 >Blog</a
               >
             </li>
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="privacy.html"
+                href="/privacy/"
                 >Privacy</a
               >
             </li>
@@ -909,7 +909,7 @@
           Yotara does not use cookies. The Cloudflare CDN may process your IP address and
           approximate location for routing and caching. No tracking or personal data is stored.
           <a
-            href="privacy.html"
+            href="/privacy/"
             class="text-primary-fixed underline hover:no-underline whitespace-nowrap"
             >Learn more</a
           >

--- a/apps/yotara-website/index.html
+++ b/apps/yotara-website/index.html
@@ -128,7 +128,7 @@
       >
         <a
           class="text-[1.375rem] font-bold text-primary tracking-wide font-headline flex items-center gap-2"
-          href="index.html"
+          href="/"
         >
           <img src="assets/logo.svg" alt="Yotara" class="h-8 w-8" />
           Yotara
@@ -139,23 +139,23 @@
         >
           <a
             class="nav-link nav-link-active text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="index.html"
+            href="/"
             aria-current="page"
             >Home</a
           >
           <a
             class="nav-link text-on-surface-variant hover:text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="features.html"
+            href="/features"
             >Features</a
           >
           <a
             class="nav-link text-on-surface-variant hover:text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="install.html"
+            href="/install"
             >Install</a
           >
           <a
             class="nav-link text-on-surface-variant hover:text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="blog.html"
+            href="/blog"
             >Blog</a
           >
         </div>
@@ -328,21 +328,21 @@
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="index.html"
+                href="/"
                 >Home</a
               >
             </li>
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="features.html"
+                href="/features"
                 >Features</a
               >
             </li>
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="install.html"
+                href="/install"
                 >Install</a
               >
             </li>
@@ -361,14 +361,14 @@
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="blog.html"
+                href="/blog"
                 >Blog</a
               >
             </li>
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="privacy.html"
+                href="/privacy/"
                 >Privacy</a
               >
             </li>
@@ -414,7 +414,7 @@
           Yotara does not use cookies. The Cloudflare CDN may process your IP address and
           approximate location for routing and caching. No tracking or personal data is stored.
           <a
-            href="privacy.html"
+            href="/privacy/"
             class="text-primary-fixed underline hover:no-underline whitespace-nowrap"
             >Learn more</a
           >

--- a/apps/yotara-website/index.html
+++ b/apps/yotara-website/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <title>Yotara — Focused Task Management</title>
+    <title>Yotara — Self-hosted task manager</title>
     <meta
       name="description"
       content="A lightweight, self-hosted task manager that puts your privacy first. Capture, organize, and focus — without the noise."
@@ -13,7 +13,7 @@
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
 
     <!-- Open Graph / Social -->
-    <meta property="og:title" content="Yotara — Focused Task Management" />
+    <meta property="og:title" content="Yotara — Self-hosted task manager" />
     <meta
       property="og:description"
       content="A lightweight, self-hosted task manager that puts your privacy first. Capture, organize, and focus — without the noise."
@@ -192,14 +192,14 @@
               <h1
                 class="hero-fade-in hero-fade-in-delay-2 text-[2rem] md:text-[4rem] leading-[1.1] font-display font-extrabold text-on-surface mb-6 tracking-tight"
               >
-                Your sanctuary for <br /><span class="text-primary">focused task</span> management.
+                A lightweight, self-hosted<br /><span class="text-primary">task manager</span> that
+                puts your privacy first.
               </h1>
               <p
                 class="hero-fade-in hero-fade-in-delay-3 text-xl text-on-surface-variant mb-10 leading-relaxed"
               >
-                Escape the noise of modern work. Yotara is a beautifully minimal, self-hosted
-                workspace designed to bring clarity to your day, without the clutter of conventional
-                tools.
+                Capture, organize, and focus — without the noise. Your data stays on your server,
+                under your control.
               </p>
               <div
                 class="hero-fade-in hero-fade-in-delay-3 flex flex-col sm:flex-row items-start sm:items-center gap-6"
@@ -212,7 +212,7 @@
                 </a>
                 <a
                   class="btn-ghost group flex items-center gap-2 text-primary font-semibold text-lg hover:text-primary-container transition-colors py-4"
-                  href="#features"
+                  href="#steps"
                 >
                   How it works
                   <span
@@ -245,17 +245,64 @@
         ></div>
       </section>
 
+      <section class="py-32 bg-surface-container-low animate-in">
+        <div class="max-w-7xl mx-auto px-8">
+          <div class="mb-16 max-w-3xl">
+            <h2
+              class="text-[1.75rem] md:text-[2.5rem] font-display font-bold mb-6 tracking-tight text-on-surface"
+            >
+              A quieter alternative
+            </h2>
+            <p class="text-xl text-on-surface-variant leading-relaxed">
+              Todoist asks for a subscription. Vikunja asks for a lot of setup. Notion asks you to
+              build your own system from a blank page. Yotara just works, on your own server.
+            </p>
+          </div>
+          <div
+            class="flex gap-6 overflow-x-auto pb-4 snap-x snap-mandatory scrollbar-thin scrollbar-thumb-outline-variant scrollbar-track-transparent"
+          >
+            <div class="snap-start shrink-0 w-[280px] md:w-1/4 p-8 rounded-2xl bg-surface">
+              <h3 class="text-lg font-bold text-on-surface mb-4 font-headline">Todoist</h3>
+              <p class="text-on-surface-variant leading-relaxed">
+                Solid app. Ongoing subscription. Your data lives on their servers.
+              </p>
+            </div>
+            <div class="snap-start shrink-0 w-[280px] md:w-1/4 p-8 rounded-2xl bg-surface">
+              <h3 class="text-lg font-bold text-on-surface mb-4 font-headline">Vikunja</h3>
+              <p class="text-on-surface-variant leading-relaxed">
+                Self-hosted, like Yotara. Heavier to set up and run.
+              </p>
+            </div>
+            <div class="snap-start shrink-0 w-[280px] md:w-1/4 p-8 rounded-2xl bg-surface">
+              <h3 class="text-lg font-bold text-on-surface mb-4 font-headline">Notion</h3>
+              <p class="text-on-surface-variant leading-relaxed">
+                Flexible enough to build anything. You have to build it yourself.
+              </p>
+            </div>
+            <div
+              class="snap-start shrink-0 w-[280px] md:w-1/4 p-8 rounded-2xl bg-primary text-on-primary"
+            >
+              <h3 class="text-lg font-bold mb-4 font-headline text-on-primary">Yotara</h3>
+              <p class="text-on-primary leading-relaxed">
+                Self-hosted, opinionated out of the box, free forever. Your data never leaves your
+                server.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <section class="py-32 bg-surface animate-in" id="features">
         <div class="max-w-7xl mx-auto px-8">
           <div class="mb-20 max-w-3xl">
             <h2
               class="text-[1.75rem] md:text-[2.5rem] font-display font-bold mb-6 tracking-tight text-on-surface"
             >
-              Designed for clarity.
+              Focus on what matters
             </h2>
             <p class="text-xl text-on-surface-variant leading-relaxed">
-              Everything you need to organize your mind, carefully refined into a seamless
-              experience. No bloated features, just focus.
+              Projects and labels for organizing work without forcing a schema on it. Capture
+              quickly, triage when you're ready.
             </p>
           </div>
           <div class="stagger-container grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
@@ -270,8 +317,8 @@
               </div>
               <h3 class="text-xl font-bold mb-3 font-headline text-on-surface">Quick Capture</h3>
               <p class="text-on-surface-variant leading-relaxed">
-                Instantly record thoughts before they vanish. Global shortcuts and a seamless entry
-                flow keep you in the zone.
+                Hit the capture bar, type your task, and move on. Natural language parsing means
+                &ldquo;buy milk tomorrow&rdquo; just works.
               </p>
             </div>
             <div
@@ -287,8 +334,8 @@
                 Projects &amp; Labels
               </h3>
               <p class="text-on-surface-variant leading-relaxed">
-                Organize complex workflows effortlessly with nested projects and flexible tagging
-                systems tailored to you.
+                Group related tasks, set dates, tag with labels. Your inbox stays clean &mdash;
+                triage when you&rsquo;re ready, not when the task arrives.
               </p>
             </div>
             <div
@@ -304,10 +351,143 @@
                 Subtasks &amp; Recurring
               </h3>
               <p class="text-on-surface-variant leading-relaxed">
-                Break monumental goals into manageable steps. Set it and forget it with powerful
-                recurring schedules.
+                Break big tasks into steps. Set recurring schedules once and let them run &mdash;
+                daily, weekly, or custom.
               </p>
             </div>
+            <div
+              class="stagger-item feature-card p-8 rounded-2xl bg-surface-container-low hover:bg-surface-container-high group"
+            >
+              <div
+                class="w-14 h-14 rounded-2xl bg-surface-container-highest flex items-center justify-center mb-6 group-hover:bg-primary-fixed/30 transition-colors"
+                aria-hidden="true"
+              >
+                <span class="material-symbols-outlined text-3xl text-primary">edit_note</span>
+              </div>
+              <h3 class="text-xl font-bold mb-3 font-headline text-on-surface">Rich Markdown</h3>
+              <p class="text-on-surface-variant leading-relaxed">
+                Write with markdown formatting and preview live. Format with the built-in toolbar
+                &mdash; no syntax to memorize.
+              </p>
+            </div>
+            <div
+              class="stagger-item feature-card p-8 rounded-2xl bg-surface-container-low hover:bg-surface-container-high group"
+            >
+              <div
+                class="w-14 h-14 rounded-2xl bg-surface-container-highest flex items-center justify-center mb-6 group-hover:bg-primary-fixed/30 transition-colors"
+                aria-hidden="true"
+              >
+                <span class="material-symbols-outlined text-3xl text-primary">palette</span>
+              </div>
+              <h3 class="text-xl font-bold mb-3 font-headline text-on-surface">
+                7 Handcrafted Themes
+              </h3>
+              <p class="text-on-surface-variant leading-relaxed">
+                From Light Forest to Deep Trench. Every theme is handmade, not auto-generated. Light
+                and dark modes included.
+              </p>
+            </div>
+            <div
+              class="stagger-item feature-card p-8 rounded-2xl bg-surface-container-low hover:bg-surface-container-high group"
+            >
+              <div
+                class="w-14 h-14 rounded-2xl bg-surface-container-highest flex items-center justify-center mb-6 group-hover:bg-primary-fixed/30 transition-colors"
+                aria-hidden="true"
+              >
+                <span class="material-symbols-outlined text-3xl text-primary">shield</span>
+              </div>
+              <h3 class="text-xl font-bold mb-3 font-headline text-on-surface">Self-Hosted</h3>
+              <p class="text-on-surface-variant leading-relaxed">
+                Your data stays on your server. No vendor lock-in. No tracking, no telemetry, no
+                privacy concerns.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-32 bg-surface-container-low animate-in" id="steps">
+        <div class="max-w-7xl mx-auto px-8">
+          <div class="mb-16 max-w-3xl">
+            <h2
+              class="text-[1.75rem] md:text-[2.5rem] font-display font-bold mb-6 tracking-tight text-on-surface"
+            >
+              Three steps to clarity
+            </h2>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-12">
+            <div class="text-center">
+              <div
+                class="w-16 h-16 rounded-full bg-primary text-on-primary flex items-center justify-center mx-auto mb-6 text-2xl font-bold font-headline"
+                aria-hidden="true"
+              >
+                1
+              </div>
+              <h3 class="text-xl font-bold mb-3 font-headline text-on-surface">Capture</h3>
+              <p class="text-on-surface-variant leading-relaxed">
+                Hit the capture bar, type your task, and move on. Natural language parsing means
+                &ldquo;buy milk tomorrow&rdquo; just works.
+              </p>
+            </div>
+            <div class="text-center">
+              <div
+                class="w-16 h-16 rounded-full bg-primary text-on-primary flex items-center justify-center mx-auto mb-6 text-2xl font-bold font-headline"
+                aria-hidden="true"
+              >
+                2
+              </div>
+              <h3 class="text-xl font-bold mb-3 font-headline text-on-surface">Organize</h3>
+              <p class="text-on-surface-variant leading-relaxed">
+                Add to a project, set a date, tag with labels. Your inbox stays clean &mdash; triage
+                when you&rsquo;re ready, not when the task arrives.
+              </p>
+            </div>
+            <div class="text-center">
+              <div
+                class="w-16 h-16 rounded-full bg-primary text-on-primary flex items-center justify-center mx-auto mb-6 text-2xl font-bold font-headline"
+                aria-hidden="true"
+              >
+                3
+              </div>
+              <h3 class="text-xl font-bold mb-3 font-headline text-on-surface">Focus</h3>
+              <p class="text-on-surface-variant leading-relaxed">
+                Let Today and Upcoming views guide your attention to what matters.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="py-32 bg-inverse-surface text-surface-bright">
+        <div class="max-w-7xl mx-auto px-8 text-center">
+          <h2 class="text-[1.75rem] md:text-[2.5rem] font-display font-bold mb-6 tracking-tight">
+            Built in public. Self-hosted. Yours.
+          </h2>
+          <p class="text-xl text-surface-variant leading-relaxed max-w-2xl mx-auto mb-10">
+            Yotara is open source under the MIT license. Deploy your own instance in one command. No
+            tracking, no telemetry, no data collection.
+          </p>
+          <div
+            class="inline-block bg-[#1a1a18] text-surface-bright rounded-xl px-6 py-4 mb-10 font-mono text-sm text-left w-full max-w-xl mx-auto overflow-x-auto"
+          >
+            <span class="text-surface-variant">$</span>
+            <span class="text-primary-fixed"
+              >docker run -d --name yotara -p 8080:80 apauldev/yotara:latest</span
+            >
+          </div>
+          <div class="flex flex-col sm:flex-row items-center justify-center gap-6">
+            <a
+              class="bg-primary text-on-primary px-8 py-4 rounded-2xl font-bold text-lg tracking-wide w-full sm:w-auto text-center hover:opacity-90 transition-opacity"
+              href="https://github.com/apauldev/yotara"
+            >
+              Star on GitHub
+            </a>
+            <a
+              class="bg-surface-bright text-inverse-surface px-8 py-4 rounded-2xl font-bold text-lg tracking-wide w-full sm:w-auto text-center hover:opacity-90 transition-opacity"
+              href="https://github.com/apauldev/yotara"
+            >
+              Read the Documentation
+            </a>
           </div>
         </div>
       </section>

--- a/apps/yotara-website/index.html
+++ b/apps/yotara-website/index.html
@@ -198,8 +198,7 @@
               <p
                 class="hero-fade-in hero-fade-in-delay-3 text-xl text-on-surface-variant mb-10 leading-relaxed"
               >
-                Capture, organize, and focus — without the noise. Your data stays on your server,
-                under your control.
+                Capture, organize, and focus. Your data stays on your server, under your control.
               </p>
               <div
                 class="hero-fade-in hero-fade-in-delay-3 flex flex-col sm:flex-row items-start sm:items-center gap-6"
@@ -258,30 +257,26 @@
               build your own system from a blank page. Yotara just works, on your own server.
             </p>
           </div>
-          <div
-            class="flex gap-6 overflow-x-auto pb-4 snap-x snap-mandatory scrollbar-thin scrollbar-thumb-outline-variant scrollbar-track-transparent"
-          >
-            <div class="snap-start shrink-0 w-[280px] md:w-1/4 p-8 rounded-2xl bg-surface">
+          <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div class="p-6 rounded-2xl bg-surface">
               <h3 class="text-lg font-bold text-on-surface mb-4 font-headline">Todoist</h3>
               <p class="text-on-surface-variant leading-relaxed">
                 Solid app. Ongoing subscription. Your data lives on their servers.
               </p>
             </div>
-            <div class="snap-start shrink-0 w-[280px] md:w-1/4 p-8 rounded-2xl bg-surface">
+            <div class="p-6 rounded-2xl bg-surface">
               <h3 class="text-lg font-bold text-on-surface mb-4 font-headline">Vikunja</h3>
               <p class="text-on-surface-variant leading-relaxed">
                 Self-hosted, like Yotara. Heavier to set up and run.
               </p>
             </div>
-            <div class="snap-start shrink-0 w-[280px] md:w-1/4 p-8 rounded-2xl bg-surface">
+            <div class="p-6 rounded-2xl bg-surface">
               <h3 class="text-lg font-bold text-on-surface mb-4 font-headline">Notion</h3>
               <p class="text-on-surface-variant leading-relaxed">
                 Flexible enough to build anything. You have to build it yourself.
               </p>
             </div>
-            <div
-              class="snap-start shrink-0 w-[280px] md:w-1/4 p-8 rounded-2xl bg-primary text-on-primary"
-            >
+            <div class="p-6 rounded-2xl bg-primary text-on-primary">
               <h3 class="text-lg font-bold mb-4 font-headline text-on-primary">Yotara</h3>
               <p class="text-on-primary leading-relaxed">
                 Self-hosted, opinionated out of the box, free forever. Your data never leaves your
@@ -317,8 +312,8 @@
               </div>
               <h3 class="text-xl font-bold mb-3 font-headline text-on-surface">Quick Capture</h3>
               <p class="text-on-surface-variant leading-relaxed">
-                Hit the capture bar, type your task, and move on. Natural language parsing means
-                &ldquo;buy milk tomorrow&rdquo; just works.
+                Hit the capture bar, type your task, and move on. Set dates with the date picker and
+                flag priorities with simple markers.
               </p>
             </div>
             <div
@@ -334,8 +329,8 @@
                 Projects &amp; Labels
               </h3>
               <p class="text-on-surface-variant leading-relaxed">
-                Group related tasks, set dates, tag with labels. Your inbox stays clean &mdash;
-                triage when you&rsquo;re ready, not when the task arrives.
+                Group related tasks, set dates, tag with labels. Stay organized across work,
+                personal, and everything in between.
               </p>
             </div>
             <div
@@ -366,8 +361,8 @@
               </div>
               <h3 class="text-xl font-bold mb-3 font-headline text-on-surface">Rich Markdown</h3>
               <p class="text-on-surface-variant leading-relaxed">
-                Write with markdown formatting and preview live. Format with the built-in toolbar
-                &mdash; no syntax to memorize.
+                Write with markdown formatting and preview live. Built-in toolbar for bold, lists,
+                and links — no syntax to memorize.
               </p>
             </div>
             <div
@@ -425,8 +420,8 @@
               </div>
               <h3 class="text-xl font-bold mb-3 font-headline text-on-surface">Capture</h3>
               <p class="text-on-surface-variant leading-relaxed">
-                Hit the capture bar, type your task, and move on. Natural language parsing means
-                &ldquo;buy milk tomorrow&rdquo; just works.
+                Hit the capture bar, type your task, and move on. Add dates and priorities as you go
+                &mdash; or just dump it in the inbox for later.
               </p>
             </div>
             <div class="text-center">
@@ -486,7 +481,7 @@
               class="bg-surface-bright text-inverse-surface px-8 py-4 rounded-2xl font-bold text-lg tracking-wide w-full sm:w-auto text-center hover:opacity-90 transition-opacity"
               href="https://github.com/apauldev/yotara"
             >
-              Read the Documentation
+              Explore the Repo
             </a>
           </div>
         </div>
@@ -591,8 +586,8 @@
     >
       <div class="max-w-7xl mx-auto flex flex-col sm:flex-row items-start sm:items-center gap-4">
         <p class="text-sm leading-relaxed flex-grow">
-          Yotara does not use cookies. The Cloudflare CDN may process your IP address and
-          approximate location for routing and caching. No tracking or personal data is stored.
+          This site does not use cookies. Cloudflare CDN handles routing and Google Fonts serve
+          typography. No tracking or personal data is stored.
           <a
             href="/privacy/"
             class="text-primary-fixed underline hover:no-underline whitespace-nowrap"

--- a/apps/yotara-website/install.html
+++ b/apps/yotara-website/install.html
@@ -579,8 +579,8 @@
     >
       <div class="max-w-7xl mx-auto flex flex-col sm:flex-row items-start sm:items-center gap-4">
         <p class="text-sm leading-relaxed flex-grow">
-          Yotara does not use cookies. The Cloudflare CDN may process your IP address and
-          approximate location for routing and caching. No tracking or personal data is stored.
+          This site does not use cookies. Cloudflare CDN handles routing and Google Fonts serve
+          typography. No tracking or personal data is stored.
           <a
             href="/privacy/"
             class="text-primary-fixed underline hover:no-underline whitespace-nowrap"

--- a/apps/yotara-website/install.html
+++ b/apps/yotara-website/install.html
@@ -8,7 +8,7 @@
       name="description"
       content="Get started with Yotara in 2 minutes. Deploy on your own server with Docker or Docker Compose. Self-hosted, no vendor lock-in."
     />
-    <link rel="canonical" href="https://yotara.website/install.html" />
+    <link rel="canonical" href="https://yotara.website/install" />
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg" />
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
 
@@ -18,7 +18,7 @@
       property="og:description"
       content="Get started with Yotara in 2 minutes. Self-hosted with Docker."
     />
-    <meta property="og:url" content="https://yotara.website/install.html" />
+    <meta property="og:url" content="https://yotara.website/install" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Yotara" />
     <meta property="og:locale" content="en_US" />
@@ -128,7 +128,7 @@
       >
         <a
           class="text-[1.375rem] font-bold text-primary tracking-wide font-headline flex items-center gap-2"
-          href="index.html"
+          href="/"
         >
           <img src="assets/logo.svg" alt="Yotara" class="h-8 w-8" />
           Yotara
@@ -139,23 +139,23 @@
         >
           <a
             class="nav-link text-on-surface-variant hover:text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="index.html"
+            href="/"
             >Home</a
           >
           <a
             class="nav-link text-on-surface-variant hover:text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="features.html"
+            href="/features"
             >Features</a
           >
           <a
             class="nav-link nav-link-active text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="install.html"
+            href="/install"
             aria-current="page"
             >Install</a
           >
           <a
             class="nav-link text-on-surface-variant hover:text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="blog.html"
+            href="/blog"
             >Blog</a
           >
         </div>
@@ -496,21 +496,21 @@
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="index.html"
+                href="/"
                 >Home</a
               >
             </li>
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="features.html"
+                href="/features"
                 >Features</a
               >
             </li>
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="install.html"
+                href="/install"
                 >Install</a
               >
             </li>
@@ -529,14 +529,14 @@
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="blog.html"
+                href="/blog"
                 >Blog</a
               >
             </li>
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="privacy.html"
+                href="/privacy/"
                 >Privacy</a
               >
             </li>
@@ -582,7 +582,7 @@
           Yotara does not use cookies. The Cloudflare CDN may process your IP address and
           approximate location for routing and caching. No tracking or personal data is stored.
           <a
-            href="privacy.html"
+            href="/privacy/"
             class="text-primary-fixed underline hover:no-underline whitespace-nowrap"
             >Learn more</a
           >

--- a/apps/yotara-website/privacy/index.html
+++ b/apps/yotara-website/privacy/index.html
@@ -8,7 +8,7 @@
       name="description"
       content="Yotara does not collect any personal data. Self-hosted means your data stays on your server. Privacy is a fundamental right, not a feature."
     />
-    <link rel="canonical" href="https://yotara.website/privacy" />
+    <link rel="canonical" href="https://yotara.website/privacy/" />
     <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg" />
     <link rel="icon" type="image/x-icon" href="../assets/favicon.ico" />
 
@@ -18,7 +18,7 @@
       property="og:description"
       content="Yotara does not collect any personal data. Self-hosted means your data stays on your server."
     />
-    <meta property="og:url" content="https://yotara.website/privacy" />
+    <meta property="og:url" content="https://yotara.website/privacy/" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Yotara" />
     <meta property="og:locale" content="en_US" />

--- a/apps/yotara-website/privacy/index.html
+++ b/apps/yotara-website/privacy/index.html
@@ -8,9 +8,9 @@
       name="description"
       content="Yotara does not collect any personal data. Self-hosted means your data stays on your server. Privacy is a fundamental right, not a feature."
     />
-    <link rel="canonical" href="https://yotara.website/privacy.html" />
-    <link rel="icon" type="image/svg+xml" href="assets/favicon.svg" />
-    <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
+    <link rel="canonical" href="https://yotara.website/privacy" />
+    <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg" />
+    <link rel="icon" type="image/x-icon" href="../assets/favicon.ico" />
 
     <!-- Open Graph / Social -->
     <meta property="og:title" content="Privacy — Yotara" />
@@ -18,7 +18,7 @@
       property="og:description"
       content="Yotara does not collect any personal data. Self-hosted means your data stays on your server."
     />
-    <meta property="og:url" content="https://yotara.website/privacy.html" />
+    <meta property="og:url" content="https://yotara.website/privacy" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Yotara" />
     <meta property="og:locale" content="en_US" />
@@ -112,7 +112,7 @@
         },
       };
     </script>
-    <link rel="stylesheet" href="css/styles.css" />
+    <link rel="stylesheet" href="../css/styles.css" />
   </head>
   <body
     class="bg-surface text-on-surface font-body antialiased min-h-screen flex flex-col selection:bg-primary-fixed selection:text-on-primary-fixed"
@@ -128,9 +128,9 @@
       >
         <a
           class="text-[1.375rem] font-bold text-primary tracking-wide font-headline flex items-center gap-2"
-          href="index.html"
+          href="/"
         >
-          <img src="assets/logo.svg" alt="Yotara" class="h-8 w-8" />
+          <img src="../assets/logo.svg" alt="Yotara" class="h-8 w-8" />
           Yotara
         </a>
         <div
@@ -139,22 +139,22 @@
         >
           <a
             class="nav-link text-on-surface-variant hover:text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="index.html"
+            href="/"
             >Home</a
           >
           <a
             class="nav-link text-on-surface-variant hover:text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="features.html"
+            href="/features"
             >Features</a
           >
           <a
             class="nav-link text-on-surface-variant hover:text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="install.html"
+            href="/install"
             >Install</a
           >
           <a
             class="nav-link text-on-surface-variant hover:text-primary rounded-xl px-4 py-2 font-medium transition-colors hover:bg-surface-container-high/50"
-            href="blog.html"
+            href="/blog"
             >Blog</a
           >
         </div>
@@ -260,8 +260,7 @@
         <section class="animate-in mb-12">
           <h2 class="text-[1.5rem] font-display font-bold text-on-surface mb-4">Contact</h2>
           <p class="text-on-surface-variant leading-relaxed">
-            Yotara is built by Adam Paul. If you have questions about privacy or security, open an
-            issue on GitHub or email
+            If you have questions about privacy or security, open an issue on GitHub or email
             <span class="text-primary">privacy at yotara dot website</span>.
           </p>
         </section>
@@ -290,21 +289,21 @@
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="index.html"
+                href="/"
                 >Home</a
               >
             </li>
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="features.html"
+                href="/features"
                 >Features</a
               >
             </li>
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="install.html"
+                href="/install"
                 >Install</a
               >
             </li>
@@ -323,14 +322,14 @@
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="blog.html"
+                href="/blog"
                 >Blog</a
               >
             </li>
             <li>
               <a
                 class="text-surface-variant hover:text-surface-bright transition-colors hover:underline decoration-primary-fixed/30"
-                href="privacy.html"
+                href="/privacy/"
                 >Privacy</a
               >
             </li>
@@ -376,7 +375,7 @@
           Yotara does not use cookies. The Cloudflare CDN may process your IP address and
           approximate location for routing and caching. No tracking or personal data is stored.
           <a
-            href="privacy.html"
+            href="/privacy/"
             class="text-primary-fixed underline hover:no-underline whitespace-nowrap"
             >Learn more</a
           >
@@ -390,6 +389,6 @@
       </div>
     </div>
 
-    <script src="js/scripts.js"></script>
+    <script src="../js/scripts.js"></script>
   </body>
 </html>

--- a/apps/yotara-website/privacy/index.html
+++ b/apps/yotara-website/privacy/index.html
@@ -372,8 +372,8 @@
     >
       <div class="max-w-7xl mx-auto flex flex-col sm:flex-row items-start sm:items-center gap-4">
         <p class="text-sm leading-relaxed flex-grow">
-          Yotara does not use cookies. The Cloudflare CDN may process your IP address and
-          approximate location for routing and caching. No tracking or personal data is stored.
+          This site does not use cookies. Cloudflare CDN handles routing and Google Fonts serve
+          typography. No tracking or personal data is stored.
           <a
             href="/privacy/"
             class="text-primary-fixed underline hover:no-underline whitespace-nowrap"

--- a/apps/yotara-website/sitemap.xml
+++ b/apps/yotara-website/sitemap.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://yotara.website/</loc><priority>1.0</priority></url>
-  <url><loc>https://yotara.website/features.html</loc><priority>0.9</priority></url>
-  <url><loc>https://yotara.website/install.html</loc><priority>0.9</priority></url>
-  <url><loc>https://yotara.website/blog.html</loc><priority>0.8</priority></url>
-  <url><loc>https://yotara.website/privacy.html</loc><priority>0.5</priority></url>
+  <url><loc>https://yotara.website/features</loc><priority>0.9</priority></url>
+  <url><loc>https://yotara.website/install</loc><priority>0.9</priority></url>
+  <url><loc>https://yotara.website/blog</loc><priority>0.8</priority></url>
+  <url><loc>https://yotara.website/privacy</loc><priority>0.5</priority></url>
 </urlset>

--- a/apps/yotara-website/sitemap.xml
+++ b/apps/yotara-website/sitemap.xml
@@ -4,5 +4,5 @@
   <url><loc>https://yotara.website/features</loc><priority>0.9</priority></url>
   <url><loc>https://yotara.website/install</loc><priority>0.9</priority></url>
   <url><loc>https://yotara.website/blog</loc><priority>0.8</priority></url>
-  <url><loc>https://yotara.website/privacy</loc><priority>0.5</priority></url>
+  <url><loc>https://yotara.website/privacy/</loc><priority>0.5</priority></url>
 </urlset>


### PR DESCRIPTION
Replace `.html` links with clean URLs, remove `_redirects` (Cloudflare auto-308 loop), restructure `privacy.html` to `privacy/index.html` to avoid zone-level redirect rule.