### PR TITLE
fix: make logo clearly show theme color in light themes

### DIFF
--- a/apps/frontend/src/app/features/auth/login.component.scss
+++ b/apps/frontend/src/app/features/auth/login.component.scss
@@ -27,7 +27,7 @@
   height: 5.75rem;
   border-radius: 999px;
   background: var(--surface-container-high);
-  color: var(--primary-solid);
+  color: var(--brand-mark);
   display: grid;
   place-items: center;
   margin: 0 auto 1.2rem;

--- a/apps/frontend/src/app/features/onboarding/pages/start-screen/start-screen.component.css
+++ b/apps/frontend/src/app/features/onboarding/pages/start-screen/start-screen.component.css
@@ -25,7 +25,7 @@
 .brand-mark {
   width: 2rem;
   height: 2rem;
-  color: var(--primary-solid);
+  color: var(--brand-mark);
 }
 
 .brand-mark svg {
@@ -66,7 +66,7 @@
   height: 4.8rem;
   border-radius: 999px;
   background: var(--surface-container-low);
-  color: var(--primary-solid);
+  color: var(--brand-mark);
   display: grid;
   place-items: center;
   margin-bottom: 1rem;

--- a/apps/frontend/src/app/features/personal/shell/personal-shell.component.css
+++ b/apps/frontend/src/app/features/personal/shell/personal-shell.component.css
@@ -324,7 +324,7 @@
   display: inline-flex;
   align-items: center;
   gap: 0.75rem;
-  color: var(--primary-solid);
+  color: var(--brand-mark);
   text-decoration: none;
   font-size: 1.5rem;
   font-weight: 800;
@@ -336,11 +336,11 @@
   height: 2.25rem;
   border-radius: 0.85rem;
   background: var(--surface-container-high);
-  color: var(--primary-solid);
+  color: var(--brand-mark);
   display: grid;
   place-items: center;
   flex: 0 0 auto;
-  box-shadow: 0 2px 8px color-mix(in srgb, var(--primary-solid) 10%, transparent);
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--brand-mark) 10%, transparent);
 }
 
 .topbar-brand-mark svg {

--- a/apps/frontend/src/app/features/shell/auth-shell.component.ts
+++ b/apps/frontend/src/app/features/shell/auth-shell.component.ts
@@ -266,7 +266,7 @@ interface SidebarItem {
         height: 2.15rem;
         border-radius: 999px;
         background: var(--surface-container-low);
-        color: var(--primary-solid);
+        color: var(--brand-mark);
         display: grid;
         place-items: center;
       }

--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -49,6 +49,7 @@
   --primary-gradient: linear-gradient(135deg, #0d2a1d 0%, #1d533b 100%);
   --primary-action-gradient: linear-gradient(135deg, #1d533b 0%, #2e7b57 100%);
   --primary-solid: #0d2a1d;
+  --brand-mark: #2e7b57;
   --primary-soft: #dff0e7;
   --primary-soft-strong: #cfe8db;
   --accent-soft: #e8f3ec;
@@ -107,6 +108,7 @@
   --primary-gradient: linear-gradient(135deg, #a5d6a7 0%, #81c784 100%);
   --primary-action-gradient: linear-gradient(135deg, #81c784 0%, #66bb6a 100%);
   --primary-solid: #a5d6a7;
+  --brand-mark: #a5d6a7;
   --primary-soft: rgb(165 214 167 / 22%);
   --primary-soft-strong: rgb(165 214 167 / 30%);
   --accent-soft: rgb(165 214 167 / 18%);
@@ -165,6 +167,7 @@
   --primary-gradient: linear-gradient(135deg, #1a365d 0%, #2a4365 100%);
   --primary-action-gradient: linear-gradient(135deg, #2a4365 0%, #2c5282 100%);
   --primary-solid: #1a365d;
+  --brand-mark: #2c5282;
   --primary-soft: #e8f1f7;
   --primary-soft-strong: #d1e3ef;
   --accent-soft: #f0f4f8;
@@ -223,6 +226,7 @@
   --primary-gradient: linear-gradient(135deg, #1a1c1e 0%, #2a2d30 100%);
   --primary-action-gradient: linear-gradient(135deg, #2a2d30 0%, #3a3f44 100%);
   --primary-solid: #1a1c1e;
+  --brand-mark: #555560;
   --primary-soft: #ececed;
   --primary-soft-strong: #e1e1e3;
   --accent-soft: #fff7e6;
@@ -281,6 +285,7 @@
   --primary-gradient: linear-gradient(135deg, #9575cd 0%, #b39ddb 100%);
   --primary-action-gradient: linear-gradient(135deg, #b39ddb 0%, #d1c4e9 100%);
   --primary-solid: #9575cd;
+  --brand-mark: #9575cd;
   --primary-soft: rgb(149 117 205 / 22%);
   --primary-soft-strong: rgb(149 117 205 / 30%);
   --accent-soft: rgb(149 117 205 / 18%);
@@ -339,6 +344,7 @@
   --primary-gradient: linear-gradient(135deg, #8b5e3c 0%, #a67c52 100%);
   --primary-action-gradient: linear-gradient(135deg, #a67c52 0%, #c19a6b 100%);
   --primary-solid: #8b5e3c;
+  --brand-mark: #a67c52;
   --primary-soft: #fdf2e9;
   --primary-soft-strong: #fae5d3;
   --accent-soft: #fff9e6;
@@ -397,6 +403,7 @@
   --primary-gradient: linear-gradient(135deg, #009688 0%, #00bfa5 100%);
   --primary-action-gradient: linear-gradient(135deg, #00bfa5 0%, #1de9b6 100%);
   --primary-solid: #009688;
+  --brand-mark: #009688;
   --primary-soft: rgb(0 150 136 / 22%);
   --primary-soft-strong: rgb(0 150 136 / 30%);
   --accent-soft: rgb(0 150 136 / 18%);


### PR DESCRIPTION
Adds a --brand-mark CSS variable with mid-tone values for light themes so the logo reads as the theme color (green, blue, slate, bronze) instead of appearing near-black. Dark themes keep the existing --primary-solid value which already looked correct.

Updates all logo/brand components (topbar, login, onboarding, auth shell) to reference --brand-mark instead of --primary-solid.

