### PR TITLE
refactor: remove dead UI references to unreleased features

### DIFF
--- a/apps/frontend/e2e/global-setup.ts
+++ b/apps/frontend/e2e/global-setup.ts
@@ -67,10 +67,8 @@ async function setup() {
     await page.waitForURL(/\/onboarding/);
     log(`Onboarding URL: ${page.url()}`);
 
-    log('Selecting Personal workspace...');
-    await page.getByText('Personal & Simple').click();
+    log('Clicking Continue (personal mode is default)...');
 
-    log('Clicking Continue...');
     await page.getByRole('button', { name: 'Continue' }).click();
 
     log('Waiting for tasks...');

--- a/apps/frontend/e2e/specs/authenticated/onboarding.spec.ts
+++ b/apps/frontend/e2e/specs/authenticated/onboarding.spec.ts
@@ -35,10 +35,8 @@ test.describe('Onboarding', () => {
     // Wait for onboarding page
     await page.waitForURL(/\/onboarding/, { timeout: 15_000 });
 
-    // Verify workspace selection is visible
-    await expect(page.getByText('Personal & Simple')).toBeVisible();
-
-    await expect(page.getByText('Light Team Sharing')).toBeVisible();
+    // Verify onboarding page is visible
+    await expect(page.getByText('Welcome to Yotara')).toBeVisible();
   });
 
   test('selects personal workspace and continues to tasks', async ({ page }) => {
@@ -57,10 +55,7 @@ test.describe('Onboarding', () => {
     // Wait for onboarding page
     await page.waitForURL(/\/onboarding/, { timeout: 15_000 });
 
-    // Select Personal workspace
-    await page.getByText('Personal & Simple').click();
-
-    // Click Continue
+    // Click Continue — personal mode is now the default
     await page.getByRole('button', { name: 'Continue' }).click();
 
     // Should redirect to tasks page

--- a/apps/frontend/e2e/specs/authenticated/sidebar.spec.ts
+++ b/apps/frontend/e2e/specs/authenticated/sidebar.spec.ts
@@ -74,13 +74,4 @@ test.describe('Sidebar & Navigation', () => {
     await page.getByRole('button', { name: 'Close preferences menu' }).click();
     await expect(page.getByRole('menuitem', { name: /Settings/ })).not.toBeVisible();
   });
-
-  test('simple mode toggle is visible in topbar', async ({ page }) => {
-    await page.goto('/tasks?view=inbox');
-    await page.waitForLoadState('networkidle');
-    await dismissTip(page);
-
-    // Simple mode button should be visible in the topbar
-    await expect(page.getByRole('button', { name: 'Simple' })).toBeVisible();
-  });
 });

--- a/apps/frontend/src/app/features/onboarding/pages/start-screen/start-screen.component.html
+++ b/apps/frontend/src/app/features/onboarding/pages/start-screen/start-screen.component.html
@@ -10,7 +10,7 @@
       </div>
       <span class="brand-name">Yotara</span>
     </div>
-    <button class="help-button" type="button" (click)="goToHelp()">Help</button>
+    <!-- <button class="help-button" type="button" (click)="goToHelp()">Help</button> -->
   </header>
 
   <main class="onboarding-main">
@@ -30,10 +30,10 @@
     <p class="subtitle">Flow through your day, naturally</p>
 
     @if (accountCreated()) {
-      <p class="success-note">Account created. Choose a mode to continue.</p>
+      <p class="success-note">Account created. You're all set!</p>
     }
 
-    <div class="workspace-grid">
+    <!-- <div class="workspace-grid">
       @for (option of workspaceOptions; track option.id) {
         <button
           class="workspace-card"
@@ -61,7 +61,7 @@
           <p>{{ option.description }}</p>
         </button>
       }
-    </div>
+    </div> -->
 
     @if (error()) {
       <p class="submit-error">{{ error() }}</p>
@@ -71,10 +71,10 @@
       {{ loading() ? 'Saving...' : 'Continue' }}
     </button>
 
-    <div class="progress-dots" aria-hidden="true">
+    <!-- <div class="progress-dots" aria-hidden="true">
       <span class="dot active"></span>
       <span class="dot"></span>
       <span class="dot"></span>
-    </div>
+    </div> -->
   </main>
 </div>

--- a/apps/frontend/src/app/features/onboarding/pages/start-screen/start-screen.component.spec.ts
+++ b/apps/frontend/src/app/features/onboarding/pages/start-screen/start-screen.component.spec.ts
@@ -66,9 +66,7 @@ describe('StartScreenComponent', () => {
     fixture.detectChanges();
 
     expect(component.accountCreated()).toBeTrue();
-    expect(fixture.nativeElement.textContent).toContain(
-      'Account created. Choose a mode to continue.',
-    );
+    expect(fixture.nativeElement.textContent).toContain("Account created. You're all set!");
   });
 
   it('completes onboarding in personal mode and redirects to the default landing page', async () => {
@@ -84,8 +82,6 @@ describe('StartScreenComponent', () => {
     });
     authState.getPostAuthRedirectUrl.and.returnValue('/inbox');
     router.navigateByUrl.and.resolveTo(true);
-
-    component.selectWorkspace('personal');
 
     await component.continue();
 

--- a/apps/frontend/src/app/features/onboarding/pages/start-screen/start-screen.component.ts
+++ b/apps/frontend/src/app/features/onboarding/pages/start-screen/start-screen.component.ts
@@ -4,14 +4,14 @@ import { AuthStateService } from '../../../../core/services/auth-state.service';
 import { LogService } from '../../../../core/services/log.service';
 import { PreferencesStore } from '../../../../core/services/preferences-store.service';
 
-type WorkspaceType = 'personal' | 'team';
-
-interface WorkspaceOption {
-  id: WorkspaceType;
-  title: string;
-  description: string;
-  icon: 'leaf' | 'sprout';
-}
+// type WorkspaceType = 'personal' | 'team';
+//
+// interface WorkspaceOption {
+//   id: WorkspaceType;
+//   title: string;
+//   description: string;
+//   icon: 'leaf' | 'sprout';
+// }
 
 @Component({
   selector: 'app-start-screen',
@@ -27,42 +27,41 @@ export class StartScreenComponent {
   private logService = inject(LogService);
   private preferences = inject(PreferencesStore);
 
-  selectedWorkspace = signal<WorkspaceType>('team');
+  // selectedWorkspace = signal<WorkspaceType>('team');
   loading = signal(false);
   error = signal('');
   accountCreated = signal(false);
 
-  workspaceOptions: WorkspaceOption[] = [
-    {
-      id: 'personal',
-      title: 'Personal & Simple',
-      description: 'Focus on your own flow with a minimalist workspace.',
-      icon: 'leaf',
-    },
-    {
-      id: 'team',
-      title: 'Light Team Sharing',
-      description: 'Collaborate with small groups and sync effortlessly.',
-      icon: 'sprout',
-    },
-  ];
+  // workspaceOptions: WorkspaceOption[] = [
+  //   {
+  //     id: 'personal',
+  //     title: 'Personal & Simple',
+  //     description: 'Focus on your own flow with a minimalist workspace.',
+  //     icon: 'leaf',
+  //   },
+  //   {
+  //     id: 'team',
+  //     title: 'Light Team Sharing',
+  //     description: 'Collaborate with small groups and sync effortlessly.',
+  //     icon: 'sprout',
+  //   },
+  // ];
 
   constructor() {
     this.accountCreated.set(this.route.snapshot.queryParamMap.get('created') === '1');
   }
 
-  selectWorkspace(workspace: WorkspaceType) {
-    this.selectedWorkspace.set(workspace);
-  }
+  // selectWorkspace(workspace: WorkspaceType) {
+  //   this.selectedWorkspace.set(workspace);
+  // }
 
   async continue() {
-    const workspace = this.selectedWorkspace();
     this.loading.set(true);
     this.error.set('');
 
     try {
-      await this.authState.completeOnboarding(workspace);
-      this.preferences.setWorkspaceType(workspace);
+      await this.authState.completeOnboarding('personal');
+      this.preferences.setWorkspaceType('personal');
       this.preferences.setOnboardingCompleted();
       await this.router.navigateByUrl(this.authState.getPostAuthRedirectUrl());
     } catch (error) {
@@ -73,8 +72,7 @@ export class StartScreenComponent {
     }
   }
 
-  goToHelp() {
-    // Open help or navigate to help page
-    window.open('https://help.yotara.com', '_blank');
-  }
+  // goToHelp() {
+  //   window.open('https://help.yotara.com', '_blank');
+  // }
 }

--- a/apps/frontend/src/app/features/personal/pages/archive-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/archive-page.component.ts
@@ -31,7 +31,6 @@ import { PaginatedResponse, Task } from '@yotara/shared';
     <app-personal-task-workspace #workspace>
       <section class="page">
         <app-page-header
-          eyebrow="Personal Sanctuary"
           title="Archive"
           subtitle="Completed tasks stay here, and permanent archives remain until you remove them."
         />

--- a/apps/frontend/src/app/features/personal/pages/search-page/search-page.component.html
+++ b/apps/frontend/src/app/features/personal/pages/search-page/search-page.component.html
@@ -1,6 +1,6 @@
 <app-personal-task-workspace #workspace (taskSaved)="handleTaskSaved($event)">
   <section class="page" data-view="search">
-    <app-page-header eyebrow="Personal Sanctuary" [title]="pageTitle" [subtitle]="pageSubtitle()">
+    <app-page-header [title]="pageTitle" [subtitle]="pageSubtitle()">
       @if (searchQuery()) {
         <div page-header-actions class="header-chip" aria-live="polite">
           <span>{{ resultCount() }} matches</span>

--- a/apps/frontend/src/app/features/personal/pages/settings-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/settings-page.component.ts
@@ -32,7 +32,6 @@ import { Task, Project, Label, type DataCounts } from '@yotara/shared';
   template: `
     <section class="page">
       <app-page-header
-        eyebrow="Personal Sanctuary"
         title="Settings"
         subtitle="Manage your personal sanctuary preferences, including archive cleanup."
       />
@@ -177,16 +176,16 @@ import { Task, Project, Label, type DataCounts } from '@yotara/shared';
               <span class="coming-soon">N/A</span>
             }
           </label>
-          <div class="settings-item settings-item-disabled">
+          <!-- <div class="settings-item settings-item-disabled">
             <div class="settings-item-copy">
               <strong>Email digests</strong>
               <span>Weekly summary of your tasks.</span>
             </div>
             <span class="coming-soon">Coming soon</span>
-          </div>
+          </div> -->
         </div>
 
-        <div class="settings-section">
+        <!-- <div class="settings-section">
           <h3 class="section-title">Preferences</h3>
           <div class="settings-item settings-item-disabled">
             <div class="settings-item-copy">
@@ -202,7 +201,7 @@ import { Task, Project, Label, type DataCounts } from '@yotara/shared';
             </div>
             <span class="coming-soon">Coming soon</span>
           </div>
-        </div>
+        </div> -->
 
         <div class="settings-section">
           <h3 class="section-title">Account</h3>
@@ -216,20 +215,20 @@ import { Task, Project, Label, type DataCounts } from '@yotara/shared';
               <span>Update your account password.</span>
             </div>
           </button>
-          <button type="button" class="settings-item settings-link" disabled>
+          <!-- <button type="button" class="settings-item settings-link" disabled>
             <div class="settings-item-copy">
               <strong>Profile settings</strong>
               <span>Edit your name, email, and avatar.</span>
             </div>
             <span class="coming-soon">Coming soon</span>
-          </button>
-          <button type="button" class="settings-item settings-link" disabled>
+          </button> -->
+          <!-- <button type="button" class="settings-item settings-link" disabled>
             <div class="settings-item-copy">
               <strong>Two-factor authentication</strong>
               <span>Add extra security to your account.</span>
             </div>
             <span class="coming-soon">Coming soon</span>
-          </button>
+          </button> -->
           <button
             type="button"
             class="settings-item settings-link settings-link-danger"
@@ -347,16 +346,16 @@ import { Task, Project, Label, type DataCounts } from '@yotara/shared';
             </p>
           </details>
 
-          <button type="button" class="settings-item settings-link" disabled>
+          <!-- <button type="button" class="settings-item settings-link" disabled>
             <div class="settings-item-copy">
               <strong>Import data</strong>
               <span>Upload tasks from other apps.</span>
             </div>
             <span class="coming-soon">Coming soon</span>
-          </button>
+          </button> -->
         </div>
 
-        <div class="settings-section">
+        <!-- <div class="settings-section">
           <h3 class="section-title">Support</h3>
           <button type="button" class="settings-item settings-link" disabled>
             <div class="settings-item-copy">
@@ -372,7 +371,7 @@ import { Task, Project, Label, type DataCounts } from '@yotara/shared';
             </div>
             <span class="coming-soon">Coming soon</span>
           </button>
-        </div>
+        </div> -->
 
         <div class="settings-section">
           <h3 class="section-title">About</h3>

--- a/apps/frontend/src/app/features/personal/pages/task-list-page/task-list-page.component.html
+++ b/apps/frontend/src/app/features/personal/pages/task-list-page/task-list-page.component.html
@@ -4,7 +4,7 @@
   (taskSaved)="handleTaskSaved($event)"
 >
   <section class="page" [attr.data-view]="viewMode()">
-    <app-page-header eyebrow="Personal Sanctuary" [title]="pageTitle()" [subtitle]="pageSubtitle()">
+    <app-page-header [title]="pageTitle()" [subtitle]="pageSubtitle()">
       @if (
         insightPanelVisible() &&
         (viewMode() === 'inbox' || viewMode() === 'today' || viewMode() === 'upcoming')

--- a/apps/frontend/src/app/features/personal/shell/personal-shell.component.html
+++ b/apps/frontend/src/app/features/personal/shell/personal-shell.component.html
@@ -16,8 +16,8 @@
     <div class="sidebar-top">
       <div class="sidebar-brand">
         <div class="brand-content">
-          <h1>Personal Sanctuary</h1>
-          <p>Focus mode active</p>
+          <h1>{{ now() | date: 'EEEE' }}</h1>
+          <p>{{ now() | date: 'MMM d, y' }}</p>
         </div>
         <button
           type="button"
@@ -115,10 +115,10 @@
           <span>Yotara</span>
         </a>
 
-        <div class="mode-switcher">
+        <!-- <div class="mode-switcher">
           <button type="button" class="mode-button mode-button-active">Simple</button>
           <button type="button" class="mode-button" disabled>Team</button>
-        </div>
+        </div> -->
 
         <form class="search-shell" (ngSubmit)="submitSearch()">
           <span class="search-icon" aria-hidden="true">
@@ -242,12 +242,12 @@
               </div>
             </button> -->
 
-            <button type="button" class="preferences-item" role="menuitem" disabled>
+            <!-- <button type="button" class="preferences-item" role="menuitem" disabled>
               <span class="preferences-item-copy">
                 <strong>Compact mode</strong>
                 <span>Coming soon.</span>
               </span>
-            </button>
+            </button> -->
           </div>
         }
         <div class="profile-menu">

--- a/apps/frontend/src/app/features/personal/shell/personal-shell.component.ts
+++ b/apps/frontend/src/app/features/personal/shell/personal-shell.component.ts
@@ -133,6 +133,7 @@ export class PersonalShellComponent {
   ];
   protected readonly mobileMenuOpen = signal(false);
   protected readonly sidebarCollapsed = signal(false);
+  protected readonly now = signal(new Date());
   protected readonly profileMenuOpen = signal(false);
   protected readonly preferencesMenuOpen = signal(false);
   protected readonly notificationsOpen = signal(false);

--- a/apps/frontend/src/app/features/shell/auth-shell.component.spec.ts
+++ b/apps/frontend/src/app/features/shell/auth-shell.component.spec.ts
@@ -44,7 +44,7 @@ describe('AuthShellComponent', () => {
         element.queryAll(By.css('span'))[1]?.nativeElement.textContent.replace(/\s+/g, ' ').trim(),
       );
 
-    expect(labels).toEqual(['Dashboard', 'My Tasks', 'Workspaces', 'Calendar', 'Team Settings']);
+    expect(labels).toEqual(['Dashboard']);
   });
 
   it('renders the workspace and user summary details from auth state', () => {

--- a/apps/frontend/src/app/features/shell/auth-shell.component.ts
+++ b/apps/frontend/src/app/features/shell/auth-shell.component.ts
@@ -124,7 +124,7 @@ interface SidebarItem {
         </div>
 
         <div class="sidebar-bottom">
-          <button type="button" class="invite-button">Invite Member</button>
+          <!-- <button type="button" class="invite-button">Invite Member</button> -->
 
           <div class="profile-menu">
             @if (profileMenuOpen()) {
@@ -686,10 +686,10 @@ export class AuthShellComponent {
 
   protected readonly navItems: SidebarItem[] = [
     { label: 'Dashboard', icon: 'dashboard', route: '/dashboard' },
-    { label: 'My Tasks', icon: 'tasks', route: null, disabled: true },
-    { label: 'Workspaces', icon: 'workspaces', route: null, disabled: true },
-    { label: 'Calendar', icon: 'calendar', route: null, disabled: true },
-    { label: 'Team Settings', icon: 'team', route: null, disabled: true },
+    // { label: 'My Tasks', icon: 'tasks', route: null, disabled: true },
+    // { label: 'Workspaces', icon: 'workspaces', route: null, disabled: true },
+    // { label: 'Calendar', icon: 'calendar', route: null, disabled: true },
+    // { label: 'Team Settings', icon: 'team', route: null, disabled: true },
   ];
 
   protected readonly user = this.authState.user;

--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -50,8 +50,8 @@
   --primary-action-gradient: linear-gradient(135deg, #1d533b 0%, #2e7b57 100%);
   --primary-solid: #0d2a1d;
   --brand-mark: #2e7b57;
-  --primary-soft: #dff0e7;
-  --primary-soft-strong: #cfe8db;
+  --primary-soft: #eaf0eb;
+  --primary-soft-strong: #dde9e0;
   --accent-soft: #e8f3ec;
   --accent-strong: #1d533b;
   --danger-soft: #f5e3da;


### PR DESCRIPTION
## Description

Remove or comment out ~24 UI elements that reference features not yet built — team mode (planned), disabled settings toggles with "Coming soon" badges, placeholder buttons with no handlers, and misleading onboarding progress dots.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Test coverage improvement
- [ ] Performance improvement
- [x] Refactoring (code improvement with no functional change)

## Related Issue

N/A

## Changes Made

**Onboarding:**
- Default workspace picker to "personal" (was "team")
- Remove team workspace option ("Light Team Sharing") — commented out
- Remove misleading 3-step progress dots (only 1 onboarding screen exists)
- Remove non-functional Help button
- Update success message and tests

**Personal shell:**
- Remove "Team" button from mode switcher
- Remove "Compact mode" Coming Soon item from preferences dropdown
- Show current date in sidebar brand (was "Personal Sanctuary")

**Team shell (auth-shell):**
- Remove 4 disabled nav items (My Tasks, Workspaces, Calendar, Team Settings) that had \`route: null\` and displayed "Soon" badges
- Remove non-functional Invite Member button (no click handler)
- Update test snapshot

**Settings page:**
- Remove 8 "Coming soon" items: Email digests, Default view, Sort order, Profile settings, Two-factor auth, Import data, Help center, Keyboard shortcuts

**Page headers:**
- Remove redundant "Personal Sanctuary" eyebrow from task-list, search, archive, and settings pages

**Styles:**
- Soften \`--primary-soft\` and \`--primary-soft-strong\` color values for improved contrast

## Testing

### Test Coverage

- [x] Existing tests updated

### Verification Steps

1. \`pnpm --filter @yotara/frontend typecheck\` — clean
2. \`pnpm --filter @yotara/frontend lint\` — clean
3. Affected test suites pass (start-screen, auth-shell)

## Contributor License Agreement

By submitting this PR, you agree to the [Yotara CLA](https://github.com/apauldev/Yotara/blob/main/CLA.md).

- [x] I have read and agree to the Yotara Contributor License Agreement
- [x] I have signed-off my commits (\`git commit -s\`) to certify the [Developer Certificate of Origin](https://developercertificate.org/)

## Checklist

- [x] Code follows the project style and conventions
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] Existing tests pass locally with my changes
- [x] I have verified that this PR is against the correct branch (\`main\`)