### PR TITLE
fix(frontend): add global focus ring

### DIFF
--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -437,6 +437,11 @@
 
     font-family: var(--font-sans);
   }
+
+  :focus-visible {
+    outline: 2px solid var(--primary-solid);
+    outline-offset: 2px;
+  }
 }
 
 /* Inline command highlighting for capture bar — chip style */


### PR DESCRIPTION
## Description

Adds a global `:focus-visible` rule using the active theme primary color so keyboard focus remains visible across buttons, links, inputs, navigation items, and custom focusable controls.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Test coverage improvement
- [ ] Performance improvement
- [ ] Refactoring (code improvement with no functional change)

## Related Issue

Closes: #188

## Roadmap Reference

Accessibility backlog in `docs/ARCHITECTURE.md`.

## Changes Made

- Added a two-pixel primary-color outline for `:focus-visible`.
- Added a two-pixel offset so the ring remains distinguishable from control borders.

## Testing

### Test Coverage

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed

### Verification Steps

1. `pnpm exec prettier --check apps/frontend/src/styles.css`
2. `pnpm --filter @yotara/frontend lint`
3. `pnpm --filter @yotara/frontend exec stylelint src/styles.css`

## Screenshots or Demo

Not included; the rule uses each theme's existing `--primary-solid` token.

## Contributor License Agreement

- [x] I have read and agree to the Yotara Contributor License Agreement
- [x] I have signed-off my commits (`git commit -s`) to certify the Developer Certificate of Origin

## Checklist

- [x] Code follows the project style and conventions
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] New and existing relevant checks pass locally
- [x] I have verified that this PR is against the correct branch (`main`)

## Additional Notes

Node 22.22.0 emitted the repository's `>=22.22.1` engine warning, but the focused formatting, TypeScript, and Stylelint checks passed.