### PR TITLE
docs: revamp architecture guide, move planning to GitHub Project board

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ packages/shared/src/*.js.map
 .commandcode/taste/taste.md
 .codegraph/
 reasonix.toml
+.commandcode/taste/workflow/taste.md
+.commandcode/settings.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,11 +48,12 @@ Browse [good-first-issue](https://github.com/apauldev/Yotara/issues?q=is%3Aissue
 
 Read [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) for:
 
-- Current state vs planned work
-- Sprint tracking and issue links
-- Anti-pattern registry
-- Code quality standards
-- Technical decisions
+- Current state and system shape
+- Architectural decisions and engineering principles
+- Known risks and technical debt
+- Testing and verification policy
+
+For what's being worked on now, see the [Yotara Roadmap](https://github.com/users/apauldev/projects/1) Project board and GitHub Issues.
 
 ### Ideas
 
@@ -190,7 +191,7 @@ pnpm release                 # Create release
 ## Helpful Resources
 
 - [PROJECT_README.md](./PROJECT_README.md) -- Setup, scripts, dev environment
-- [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) -- Technical roadmap and anti-patterns
+- [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) -- Architecture decisions, constraints, known risks
 - [testing.md](./testing.md) -- Testing patterns and best practices
 - [docs/RELEASING.md](./docs/RELEASING.md) -- Release process
 - [Conventional Commits](https://www.conventionalcommits.org/) -- Commit message format

--- a/PROJECT_README.md
+++ b/PROJECT_README.md
@@ -2,7 +2,7 @@
 
 This document is the technical companion to the main repository page.
 
-For the product overview and project positioning, start with [`README.md`](./README.md). For the technical roadmap and anti-pattern registry, see [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md).
+For the product overview and project positioning, start with [`README.md`](./README.md). For architecture decisions, constraints, and engineering principles, see [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md).
 
 ## Overview
 
@@ -296,7 +296,7 @@ The production setting assumes the frontend and API are served behind the same o
 ├── packages/
 │   └── shared/                 Domain types, DTOs, auth client
 ├── docs/
-│   └── ARCHITECTURE.md         Technical roadmap and anti-patterns
+│   └── ARCHITECTURE.md         Architecture decisions, constraints, known risks
 ├── scripts/                    Release automation
 └── testing.md                  Testing guide
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -126,7 +126,7 @@ Status legend: ✅ Done, 🟡 Partial, ⬜ Not started.
 
 ### P3 – Deployment & Distribution
 
-> Numbered `P3-N`. Most of these items are now Sprint 0 in `docs/ARCHITECTURE.md`.
+> Numbered `P3-N`. Most of these items are now tracked on the **[Yotara Roadmap](https://github.com/users/apauldev/projects/1)** Project board.
 
 | # | Task | Status | Effort | Notes |
 |---|------|--------|--------|-------|
@@ -143,7 +143,7 @@ Status legend: ✅ Done, 🟡 Partial, ⬜ Not started.
 
 ### P4 – Polish & Nice-to-Haves (Post-v1)
 
-> Numbered `P4-N`. Most items are intentionally deferred — see `docs/ARCHITECTURE.md` for the runtime anti-patterns that should be closed before adding any of this.
+> Numbered `P4-N`. Most items are intentionally deferred — see `docs/ARCHITECTURE.md` for the durable engineering principles and known risks before adding any of this.
 
 | # | Task | Status | Effort | Notes |
 |---|------|--------|--------|-------|

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,507 +1,306 @@
 # Architecture Guide — Yotara
 
-> **Status:** Living document. Last updated 2026-07-08.
+> **Status:** Living architectural reference. Last reviewed 2026-07-31.
 > **Owner:** @apauldev
-> **Supersedes:** [ROADMAP.md](../ROADMAP.md) and the planning sections of [apps/frontend/TODO.md](../apps/frontend/TODO.md) and [apps/api/TODO.md](../apps/api/TODO.md). The older docs are kept as historical snapshots and are no longer maintained. Cross-references from the older docs now point here.
 >
-> **Planning migration (2026-06-30):** All surviving backlog items have been migrated to GitHub Issues and are tracked on the **[Yotara Roadmap](https://github.com/users/apauldev/projects/1)** Project board. The stale doc headers now direct readers there. The backlog section below is kept as an inline reference for context but the Project board is the source of truth for status.
->
-> **Doc map:** State → Root Cause → Runtime Anti-patterns → File-by-file → Patterns → Planning Artifacts → Recommended Roadmap (Sprint 0–6) → **Backlog** (historical) → For New Contributors → Principles.
->
-> **Admin & Notifications plan:** See [docs/admin-notifications.md](./admin-notifications.md) for the full implementation plan covering per-IP account limits, admin API, email verification + 7-day grace period, self-hosted bypass mode, and Web Push notifications. The checkpoints below reference that document's phases.
+> This document describes architecture, durable engineering decisions, and
+> known risks. It is not the product roadmap. Prioritized work belongs in the
+> [Yotara Roadmap GitHub Project](https://github.com/users/apauldev/projects/1)
+> and its Issues.
 
-## State of the Project
+## Current state
 
-Short, honest read of where the project stands right now. No numerical scorecard on purpose — without a rubric, scores are mood, and the prose below is more useful.
+Yotara is a personal-first, self-hosted task manager built as a TypeScript
+pnpm monorepo. The current product is substantially beyond the original MVP:
 
-- **Structural:** Backend is clean (route → service → DB). Frontend has a moderately large service (`TaskService.ts`, ~426 lines). The **biggest single issue is now fixed**: per-view API filters replace the old expand-loop + `computed()` signal pattern. Each view fetches only the tasks it needs via `GET /tasks?view=…` / `?overdue=true` / `?completedSince=…` .
-- **Component architecture:** Modern Angular (standalone, signals, lazy routes). Shared primitives are genuinely reusable. Good.
-- **Test coverage:** Frontend has ~393 unit tests + 55 Playwright e2e tests (13 spec files covering auth, task CRUD, labels, projects, search, settings, archive, sidebar, onboarding, error states). Backend has tests for `task-service`, `auth-origins`, `cors`, `openapi`, `login-lockout`, `rate-limit`, and timestamp-migration. Routes and the full request-response cycle remain under-tested.
-- **Reusability:** Shared UI is solid. Search scoring (250+ lines of JS) belongs on the server. Test specs reach into component internals with `as any` casts — see the runtime anti-patterns below.
-- **Consistency:** Naming is inconsistent (`revision` vs `refreshProjects()`). Auth-gate boilerplate repeated 3×. `localStorage` magic-string keys have been **consolidated into `PreferencesStore`** (a centralized signal-based store). `console.error` has been reduced to 2 remaining call sites (`LogService` itself and `main.ts`) — anti-pattern A1 is now **largely closed**.
-- **Documentation:** This document exists. ROADMAP.md, project-plan.md, and the two TODO.md files overlap and drift from each other — see the "Planning artifacts" section below.
-- **Scalability:** The expand loop and in-memory computed-signal filtering have been **removed** — each view now calls its own server endpoint. Search has moved to the server — `GET /tasks/search?q=...` with SQL relevance scoring, pagination, and a completed filter.
-- **Developer experience:** CI has lint, type-check, test, e2e, `pnpm audit`, Dependabot, CodeQL, and secret leak detection (gitleaks). No coverage threshold, no prebuilt images, no bundle-size monitoring. `.reasonix/` is gitignored.
-- **Security & robustness:** Auth guards, error interceptor, cookie security all solid. Rate limiting added (global IP-based + per-email password lockout). `AppError` class hierarchy (`BadRequestError`, `NotFoundError`, `UnauthorizedError`) now exists in the API — services throw typed errors instead of bare `new Error('string')`, and the Fastify `setErrorHandler` maps them to correct HTTP status codes. One remaining bare `AppError(500, …)` call in `task-service.ts:333`. Secret leak detection (gitleaks), Dependabot, and CodeQL are active in CI. No Docker image scanning or bundle size monitoring.
+- Angular 21 frontend using standalone components, signals, lazy routes, and
+  shared UI primitives.
+- Fastify 5 API with a route → service → database shape.
+- SQLite with Drizzle ORM, transactional multi-table writes, startup schema
+  bootstrap, timestamp normalization, and database permission hardening.
+- Better Auth session-cookie authentication, password reset and verification
+  email flows, account deletion, rate limiting, login lockout, and security
+  headers.
+- Personal task views, projects, labels, archive, search, subtasks, recurring
+  tasks, themes, keyboard shortcuts, and in-app notifications.
+- Docker deployment behind nginx, published container images, OpenAPI docs,
+  CI checks, CodeQL, gitleaks, Dependabot, and release automation.
 
-  **Deployment constraint (do not bypass):** The API runs with `trustProxy: 1` (`server.ts`) and derives `request.ip` from `X-Forwarded-For`. Both the global IP rate limiter (`@fastify/rate-limit`, keyed on `request.ip`) and the per-IP password lockout (`login-lockout.ts`) depend on that IP being the *real* client address. This is only true when a trusted proxy sits in front and **overwrites** `X-Forwarded-For` with the real client IP — which the bundled `docker/nginx.conf` does (`$proxy_add_x_forwarded_for`). **Never expose the API directly to the internet without such a proxy**: a client can then set `X-Forwarded-For` to any value, making `request.ip` attacker-controllable and defeating the lockout scoping and rate limiting. If you must run without nginx, scope `trustProxy` to the proxy's subnet (CIDR or function) instead of `1`. The supported deployment is `docker-compose.yml` (api + nginx frontend container).
-- **Bus factor:** 1. 624/704 commits (89%) are from a single author. `github-actions[bot]` has 54 commits; `dependabot[bot]` has 22; shivansh090 has 4 (docs only).
+The repository typechecks cleanly. At the last review, the test suites passed
+212 API tests and 636 frontend tests.
 
----
+## System shape
 
-## ✅ Root Cause Fixed: The frontend no longer does the backend's filtering work
-
-**Accomplished in Sprint 1 (PR #197, v0.59.6).** The root cause that drove this architecture document is now resolved.
-
-### What changed
-
-Every view previously fetched ALL active tasks and filtered with `computed()` signals. Now each view calls its own server endpoint:
-
-| View | Before | After |
-|---|---|---|
-| Today's tasks | Fetched ALL, filtered in JS | `GET /tasks?view=today&tz=...` |
-| Overdue tasks | Fetched ALL, filtered in JS | `GET /tasks?overdue=true&tz=...` |
-| Inbox tasks | Fetched ALL, filtered in JS | `GET /tasks?view=inbox&tz=...` |
-| Upcoming tasks | Fetched ALL, grouped by week in JS | `GET /tasks?view=upcoming&tz=...` |
-| Today's completions | Filtered ALL completed tasks | `GET /tasks?completedSince=...&tz=...` |
-| Search | 250 lines of scoring math in JS | `GET /tasks/search?q=...` |
-
-### What was removed
-
-- `fetchActiveTasks()` expand loop (sequential pages of 100 all at once)
-- `tasks` signal (full in-memory dataset)
-- `activeTasks`, `pendingTasks`, `completedTasks`, `archivedTasks` computed signals
-- `isTaskOverdue`, `isTaskToday`, `isTaskUpcoming`, `hasScheduledDate` client-side helpers
-
-### What remains
-
-- **Search is now server-side** — `GET /tasks/search?q=...` with SQL relevance scoring. See Sprint 3 above.
-- **`allActiveTasks` signal still exists** — fetches one page of 1000 tasks for the subtask map and label assignments. This is a bounded data set (~1k tasks), not the old expand-all pattern.
-- **Upcoming task bucketing** (`This Week` / `Next Week` / `Later`) is still done client-side via `upcomingBucketForTask()`. This is lightweight grouping, not filtering.
-
----
-
-## Runtime and Operational Anti-patterns
-
-The structural section above caught the data-flow and service-shape issues. The runtime problems below are the ones that bite users under load or in incident review but don't show up in a structural audit. All file:line references are current as of 2026-07-03. ❗ Items marked ✅ have been fixed since the original audit.
-
-### 🟡 A1. `LogService` exists; 26 `console.error` sites bypassed it (mostly fixed)
-
-**Largely fixed.** The original audit found 26 `console.error` call sites bypassing `LogService`. The main migration has been completed — log-heavy services (`TaskService`, `ProjectService`, `LabelService`, `AuthStateService`) now use `LogService.error()` with context strings and error sanitization.
-
-**Remaining call sites (2):**
-- `apps/frontend/src/app/core/services/log.service.ts:32` — the service itself bridges to `console.error` (legitimate)
-- `apps/frontend/src/main.ts:6` — the bootstrap catch handler (legitimate)
-
-**History:** The original `console.error` sites were in `task.service.ts`, `project.service.ts`, `label.service.ts`, `auth-state.service.ts`, `search-page.component.ts`, `archive-page.component.ts`, `start-screen.component.ts`, `auth.guard.ts`, `onboarding.guard.ts`, `login-redirect.guard.ts`, `workspace-mode.guard.ts`, and `main.ts`. The error-handling refactor in PR #197 (v0.59.6) migrated the service-layer sites to use `LogService` via `handleLoadError()`. The route/guard sites were migrated separately.
-
-**Remaining risk:** The ESLint `no-console` rule suggested in the original fix is not yet added to the ESLint config, so new `console.error` calls could still slip in during development. Add the rule to prevent regression.
-
-### ✅ A2. Services threw `new Error('string')` → opaque 500s (fixed)
-
-**Fixed in v0.60.0.** The `AppError` class hierarchy (`BadRequestError`, `NotFoundError`, `UnauthorizedError`) was added to `apps/api/src/lib/app-error.ts`, and services now throw typed errors:
-
-- `BadRequestError('A task cannot be its own parent')` → 400
-- `NotFoundError('Parent task not found')` → 404
-- `UnauthorizedError()` → 401
-
-Route-level `throw new Error('Authentication required')` in `tasks.ts` is now `throw new UnauthorizedError()`. The Fastify `setErrorHandler` in `server.ts` maps `AppError` instances to the correct HTTP status.
-
-**One remaining outlier:** `task-service.ts:333` — `throw new AppError(500, 'Failed to format date')` should use a more specific error type. Otherwise this anti-pattern is closed.
-
-### ✅ A3. `as any` on a query parameter at a trust boundary (fixed)
-
-**Fixed.** The `as any` cast on `request.query.status` was removed. The current `tasks.ts` passes `status: request.query.status` directly to the filters object without an unsafe cast. A runtime guard that rejects unknown enum values would still be a defensive improvement, but the `as any` bypass is gone.
-
-### ✅ A4. `localStorage` was sprinkled across components with magic-string keys (fixed)
-
-**Fixed in v0.59.4–v0.59.5 (PR #196).** All magic-string localStorage keys have been consolidated into a single `PreferencesStore` (
-`apps/frontend/src/app/core/services/preferences-store.service.ts`):
-
-| Key | Managed by |
-|---|---|
-| `yotara_skipCompleteConfirm` | `PreferencesStore.skipCompleteConfirm` / `setSkipCompleteConfirm()` |
-| `yotara_insightDismissed` | `PreferencesStore.insightDismissed` / `setInsightDismissed()` |
-| `yotara_loginTipDismissed` | `PreferencesStore.loginTipDismissed` / `setLoginTipDismissed()` (supports session-only + permanent) |
-| `onboardingCompleted` | `PreferencesStore.onboardingCompleted` / `setOnboardingCompleted()` |
-| `workspaceType` | `PreferencesStore.workspaceType` / `setWorkspaceType()` |
-
-Preferences are exposed as Angular signals for fine-grained reactivity. The fix recommended in the original audit (a `PreferencesStore` with a single source of truth for keys) is precisely what was implemented.
-
-### A5. `setTimeout` as a UI sync mechanism (5 sites)
-
-- `apps/frontend/src/app/features/personal/components/change-password-modal.component.ts:395` — `setTimeout(() => this.onClose(), 2000)` to "let the success message show before closing the modal"
-- `apps/frontend/src/app/core/interceptors/loading.interceptor.ts:22` — `setTimeout(() => statusService.stopLoading(), 250)` to "ensure the loading bar shows briefly"
-- `apps/frontend/src/app/features/personal/components/capture-bar.component.ts:483` — uninvestigated; likely a focus/animation workaround
-- `apps/frontend/src/app/features/personal/pages/labels-page.component.ts:75` — uninvestigated
-- `apps/frontend/src/app/core/services/status.service.ts:42` — `setTimeout(() => this.remove(id), duration)` for toast auto-dismiss; this one is legitimate
-
-The first two are classic "make it feel responsive" hacks. They break under load (2000ms is too short on slow devices) and break under fast connections (the success message flashes for 1.8s while the user wonders if the click registered). The fourth is a real bug waiting to surface.
-
-**Fix:** Replace the modal close with an Angular effect that watches a `success: boolean` signal and closes when the user dismisses or the success message has been visible for at least N seconds and the user has seen it. Replace the loading-bar minimum with `requestAnimationFrame` or a small minimum-duration in CSS. Audit the other two `setTimeout` sites for what they're actually papering over.
-
-### 🟡 A6. Timezone bug: backend `date('now')` (UTC) vs frontend Luxon `startOfToday()` (local) (partially addressed)
-
-**Partially addressed in v0.59.7 (PR #198).** The `?tz=` query param was added to per-view API calls (`view=today`, `overdue=true`, `view=inbox`, `view=upcoming`, `completedSince`) and to the `PATCH /tasks/:id` endpoint for timezone-aware bucket restoration. The backend now uses the timezone parameter in date comparisons for filtering queries.
-
-**What's still open:** The underlying mismatch between SQLite `date('now')` (UTC) and Luxon `startOfToday()` (local time) in the few places that still use raw SQLite date functions without a `tz` override. The test suite covers the timezone helper (`todayInTimezone`, `startOfDayInUtc`) with 8 cases, but a comprehensive audit of all SQLite date('now') calls has not been done.
-
-### A7. Test architecture: white-box reach-ins
-
-TestBed spec files reach into component internals with `as any` casts. Representative sites:
-
-- `task-list-page.component.spec.ts` — 14 `as any` reaches into `componentInstance`
-- `archive-page.component.spec.ts` — 6
-- `settings-page.component.spec.ts` — 3
-- `personal-task-card.component.spec.ts` — 1
-- `project-detail-page.component.spec.ts` — 1
-
-When `6829caf refactor(task-list): decompose page into components, fix error swallowing and pagination` shipped, the test rewrites were probably the hardest part — because the tests were coupled to internals, not behavior. This is why refactors feel scary even when they're safe.
-
-**Fix:** Standardize on three test patterns:
-- Render tests assert on DOM (`expect(fixture.nativeElement.textContent).toContain(...)`)
-- Service tests assert on returned values
-- Interaction tests drive a `Signal` or method and assert on observable side effects (toast, navigation, network call)
-
-Add a lint rule or review checklist: no `as any`, no `componentInstance.privateField`. Reach-in tests are a code smell to flag in review, not a pattern to use.
-
-### A8. "Refactor" commits that include "fix error swallowing" — bug-as-refactor pattern
-
-Recent commit `6829caf refactor(task-list): decompose page into components, fix error swallowing and pagination`. The title admits the previous version was *swallowing errors* — a production bug, not a refactor. Grep the log for "fix" inside `refactor:` commit messages and the same pattern shows up elsewhere in small ways. If you ever do a public incident review, every "refactor" that includes "fix X" is a bug that shipped.
-
-**Fix:** A simple review rule: a refactor commit should not change behavior. If it does, split it. The split is also a paper trail — separate commits, separate PR descriptions, separate changelog entries.
-
-### A9. Router subscription duplication between shells
-
-`apps/frontend/src/app/features/personal/shell/personal-shell.component.ts:112` and `apps/frontend/src/app/features/shell/auth-shell.component.ts:739` both subscribe to `router.events` to update shell state. The personal one uses `takeUntilDestroyed()`. The auth-shell one needs verification but the duplication itself is the smell — your own TODO calls for extracting shared shell chrome.
-
-**Fix:** A small `ShellChromeService` (or `RouterEvents.forNavigationEnd()` helper) that both shells consume. Removes the per-shell subscription, makes the lifecycle discipline consistent, and is the natural place to add more shell events later.
-
-### A10. Bus factor
-
-296/323 commits (92%) are from a single author. shivansh090 has 2 commits (docs only); github-actions bot has 25. The discipline (semver, conventional commits, clean PRs, self-review) means a co-maintainer could realistically pick this up, but there isn't one. If the maintainer disappears for two weeks, the project stalls.
-
-**Fix:** Out of scope for code, but: write a "How to release" doc (the release script is automated, the checklist for what to verify before cutting a release is not), invite a co-maintainer with a specific small scope (CI, docs, or one feature area), and consider labeling 1-2 `good-first-issue` items in GitHub Issues for outside contributors.
-
----
-
-## File-by-file assessment
+```text
+Angular frontend
+  ├─ route guards, shells, pages, shared UI
+  ├─ services and signals for client state
+  └─ shared domain/auth package
+          │ HTTP + session cookies
+          ▼
+Fastify API
+  ├─ auth bridge and request guards
+  ├─ route schemas and OpenAPI
+  ├─ domain services
+  └─ security/rate-limit/error plugins
+          │ Drizzle
+          ▼
+SQLite database
+```
 
 ### Frontend
 
-#### apps/frontend/src/app/core/services/task.service.ts — **Needs most attention**
+`apps/frontend` owns presentation, navigation, client-side interaction state,
+and API consumption. Pages compose smaller feature components; shared controls
+live under `shared`. Services own API calls and reusable state rather than
+leaving filtering or business rules in individual components.
 
-**What's wrong:**
-- God service: HTTP calls + reactive signals + date utilities + CRUD + presentation helpers all in one file (~220 lines)
-- 15 computed signals that filter in memory
-- `fetchActiveTasks$()` uses an expand loop (sequential pagination of all active tasks)
-- `formatTaskDate()`, `isTaskOverdue()`, `isTaskToday()`, `isTaskUpcoming()`, `hasScheduledDate()`, `upcomingBucketForTask()` are pure functions that don't need to be in a service
+Task views use server-side query parameters (`view`, `overdue`,
+`completedSince`, timezone) instead of loading the entire task collection and
+filtering it in the browser. Search is also server-side via
+`GET /tasks/search`, with SQL relevance scoring and pagination. The remaining
+bounded task collection used for subtasks and label assignment is intentional;
+it is not the former unbounded expand-loop design.
 
-**What to do:**
-1. Extract date helpers to `shared/utils/timestamps.ts` where `parseCalendarDate()` and `startOfToday()` already live
-2. Move each filtered view to its own API call (e.g., `getTodayTasks()` calls `GET /tasks?status=today`)
-3. Remove computed signals one by one after migrating each view
-4. Remove the expand loop for active tasks once all views use their own endpoint
-5. Remove stale alias signals (`archivedTasks`, `completedTasks`)
+### API
 
-#### apps/frontend/src/app/core/services/search.service.ts — **Needs second-most attention**
+`apps/api` keeps route handlers thin. Routes authenticate and validate input,
+then delegate domain work to services. Services own authorization-aware
+queries, transactions, recurrence materialization, notification behavior, and
+data mapping.
 
-**What's wrong:**
-- 250+ lines of scoring logic (12 helper functions) that should be on the server
-- Archive search paginates through 10 pages as a band-aid — the real fix is a search endpoint
-- Pure functions at module level have no tests of their own
-
-**What to do:**
-1. Build `GET /tasks/search?q=...` on the backend
-2. Replace the client-side scoring with a single API call
-3. Delete the scoring functions
-
-#### apps/frontend/src/app/core/services/auth-state.service.ts — **Good, minor improvements**
-
-~200 lines, handles session + user state + CRUD. Could split `auth` (sign in/out) from `session` (state holder), but it's not pressing.
-
-#### apps/frontend/src/app/core/services/project.service.ts — **Good pattern, repeated boilerplate**
-
-Same auth-gate + refresh pattern as TaskService. Extracting the auth-gate into a shared helper would clean up 3 files at once.
-
-#### apps/frontend/src/app/core/services/label.service.ts — **Same as ProjectService**
-
-#### apps/frontend/src/app/core/interceptors/error.interceptor.ts — **Good**
-
-Clean global error handling with user-facing notifications. Skips 401 (handled by auth guard). This is the right pattern.
-
-#### apps/frontend/src/app/core/guards/ — **Good**
-
-Auth guard, onboarding guard, login redirect, workspace-mode guards. Solid.
-
-#### apps/frontend/src/app/app.routes.ts — **Good**
-
-Lazy-loaded routes, guards in the right places, personal vs team shells. No issues.
-
-#### apps/frontend/src/app/features/ — **Good component architecture**
-
-Standalone components, computed signals for derived state, effects for side effects. `PersonalTaskWorkspaceComponent` is a well-designed shell pattern.
-
-#### apps/frontend/src/app/shared/ — **Good**
-
-Reusable components (EmptyState, ConfirmDialog, Modal, Pagination), pipes, date utilities. The `parseCalendarDate` + `startOfToday` utilities are a well-designed abstraction.
-
----
-
-### Backend
-
-#### apps/api/src/routes/tasks.ts — **Good, but thin**
-
-Clean route handler with Fastify schema validation. Delegates to service layer. The `status: request.query.status as any` on line 90 is a minor type escape that could be `status: request.query.status as TaskStatus`.
-
-#### apps/api/src/services/task-service.ts — **Good**
-
-Clean service layer with Drizzle. `listTasksForOwner` accepts filters. `cleanupExpiredArchivedTasks` runs as a preHandler hook. Good separation.
-
-#### apps/api/src/routes/projects.ts, labels.ts — **Same pattern**
-
-Consistent with tasks. Good.
-
-#### apps/api/src/lib/api-errors.ts — **Good**
-
-`sendNotFound` and error helpers. Clean.
-
-#### apps/api/src/plugins/ — **Good**
-
-auth-bridge, auth-required, cors. Well-structured.
-
-#### apps/api/src/docs/openapi.ts — **Good initiative**
-
-Auto-generated OpenAPI spec. Would benefit from being kept in sync with route changes.
-
-#### apps/api/db/ — **Good**
-
-Drizzle schema with proper relations. Timestamp migration handling.
-
-#### tests — **Sparse for the backend**
-
-Frontend has 393 tests. Backend has tests for task-service, auth-origins, cors, openapi, and timestamp-migration. But routes and the full request-response cycle are not well-tested.
-
----
+Domain errors use `AppError` subclasses and are mapped by Fastify's central
+error handler. Multi-table writes use SQLite transactions so task/label,
+recurrence, account deletion, and related operations fail atomically.
 
 ### Shared package
 
-#### packages/shared/src/index.ts — **Good**
+`packages/shared` is the cross-runtime source of truth for domain types, DTOs,
+and the Better Auth client wrapper. It must remain free of browser-only or
+server-only assumptions.
 
-Domain types (`Task`, `Project`, `Label`, DTOs) are clean and well-documented. One source of truth.
+## Important architectural decisions
 
-#### packages/shared/src/auth.ts — **Good**
+### Personal-first product boundary
 
-`AuthService` wraps Better Auth client. `configureAuthClient` pattern for setting the base URL is clean. One minor concern: `fetch` is used directly instead of Angular's `HttpClient`, but that's fine for the auth SDK wrapper.
+Personal mode is the supported product center. Team mode is a planned
+expansion, not a reason to add enterprise workflow concepts to the personal
+domain prematurely. New features should earn their place by improving
+capture, focus, planning, completion, or self-hosting.
 
----
+### Server-side filtering
 
-## Patterns to standardize
+The server filters by status, completion, due date, archive state, search
+query, and timezone. The frontend may group or decorate already-filtered
+results, but it should not recreate API filtering in computed signals.
 
-### The auth-gate boilerplate (appears 3 times)
+### SQLite first
 
-```typescript
-readonly data = toSignal(
-  combineLatest([
-    toObservable(this.authState.initialized).pipe(distinctUntilChanged()),
-    toObservable(this.authState.currentUserId).pipe(distinctUntilChanged()),
-    toObservable(this.refreshState),
-  ]).pipe(
-    switchMap(([initialized, currentUserId]) => {
-      if (!initialized || !currentUserId) {
-        this.errorState.set(null);
-        return of([]);
-      }
-      this.loadingState.set(true);
-      this.errorState.set(null);
-      return this.http.get(...).pipe(
-        catchError(...),
-        finalize(() => this.loadingState.set(false)),
-      );
-    }),
-  ),
-  { initialValue: [] },
-);
-```
+SQLite is the default because Yotara targets a self-hosted personal workload:
+one portable database, low operational overhead, simple backup, and no
+required database service. Any future team-mode storage change must be driven
+by measured requirements rather than premature abstraction.
 
-**Fix:** Extract into a shared `createAuthGuardedFetch` helper:
+### Explicit timezone handling
 
-```typescript
-function createAuthGuardedFetch<T>(
-  http: HttpClient,
-  authState: AuthStateService,
-  config: {
-    url: string | (() => string);
-    refreshTrigger: Signal<number>;
-    initialValue: T;
-    transform?: (data: unknown) => T;
-  },
-): Signal<T>
-```
+Calendar dates are user-facing dates, not implicit UTC instants. API calls that
+interpret “today”, “upcoming”, or restoration buckets carry the user's
+timezone. Shared timestamp/calendar helpers should be used instead of ad-hoc
+date parsing or raw UTC assumptions.
 
-This eliminates ~20 lines per service.
+### Security at deployment boundaries
 
-### Naming conventions
+The supported deployment is nginx in front of the API. The API's proxy trust
+and IP-based rate limiting depend on that proxy overwriting/forwarding the real
+client address correctly. The API must not be exposed directly with an
+unrestricted `trustProxy` setting.
 
-| Current | Problem | Standard |
+Security-sensitive behavior belongs at the boundary where it can be enforced:
+
+- authentication and authorization in shared API guards/services;
+- schema validation at routes;
+- typed errors in services and centralized response mapping;
+- session, email, and login rate limits in the API;
+- CSP, security headers, secret checks, CodeQL, and secret scanning in the
+  deployment/CI layers.
+
+## Current strengths
+
+- The frontend/API data-flow migration is complete: no old full-dataset view
+  filtering or client-side search scorer remains.
+- Preferences are centralized in `PreferencesStore` rather than scattered
+  `localStorage` access.
+- Error handling, rate limiting, auth hardening, database hygiene, and Docker
+  hardening have received focused follow-up work.
+- API route tests now cover auth, tasks, projects, labels, search,
+  notifications, profile, health, and OpenAPI behavior.
+- The release pipeline publishes pre-built images and gates publishing on CI.
+- The project has a credible contributor path through setup documentation,
+  issue templates, OpenAPI, and automated checks.
+
+The closed Issue history corroborates several of these migrations: timezone
+handling ([#170](https://github.com/apauldev/Yotara/issues/170)), planning
+harvest ([#171](https://github.com/apauldev/Yotara/issues/171)), server-side
+search ([#176](https://github.com/apauldev/Yotara/issues/176)), keyboard
+shortcut reference UX ([#221](https://github.com/apauldev/Yotara/issues/221)),
+browser reminders ([#218](https://github.com/apauldev/Yotara/issues/218)), and
+route coverage for `/me`, `/health`, and `/`
+([#286](https://github.com/apauldev/Yotara/issues/286)). These are completed
+capabilities, not active roadmap items.
+
+## Known risks and technical debt
+
+These are architectural observations, not a second roadmap. Create or update
+the corresponding GitHub Issue when work is ready to be prioritized.
+
+### 1. The API task service is still large
+
+`apps/api/src/services/task-service.ts` is roughly 685 lines and currently
+combines task CRUD, filtering, recurrence, subtasks, labels, notifications,
+and date restoration. It is coherent, but it is the first place likely to
+become difficult to change. Future extraction should follow domain seams
+(recurrence, task queries, or notification side effects) and preserve service
+transaction boundaries. This is represented by Issues [#57](https://github.com/apauldev/Yotara/issues/57)
+and [#175](https://github.com/apauldev/Yotara/issues/175). Issue #175 is
+currently In Progress on the Roadmap Project and captures the remaining
+frontend/service decomposition work.
+
+### 2. A few UI timers are deliberate but deserve scrutiny
+
+Timers remain for the loading indicator's minimum display duration, the change
+password success close, and toast lifecycle. These are now explicit UX
+policies rather than accidental synchronization, but they should stay covered
+by behavior tests and must not become substitutes for state modeling. The
+original failure modes are the reason this is tracked: a fixed 2000ms modal
+close timer was too short on slow devices (the success message vanished before
+it was read) and felt laggy on fast connections, which is exactly the kind of
+UX regression fixed-duration timers cause.
+
+### 3. Input validation should remain uniform
+
+The API has route schemas and typed domain errors, but every new query/body
+field needs runtime validation—not just TypeScript types. In particular,
+timezone, enum, pagination, and free-text limits should be reviewed whenever a
+route evolves.
+
+### 4. Self-hosting remains the product's largest operational risk
+
+Installation, upgrades, backups, restore, email configuration, and migration
+recovery matter as much as feature breadth. Docker images and smoke tests help,
+but changes to deployment behavior should include a documented upgrade and
+rollback story.
+
+### 5. Ownership and contributor concentration
+
+The project still has a high single-maintainer concentration. This is less a
+code smell than a continuity risk. Documentation, small well-scoped Issues,
+and reviewable changes are the best current mitigation.
+
+## Issue-backed architecture map
+
+The following are the current architectural themes represented in GitHub
+Issues. The numbers are pointers, not a duplicate backlog; GitHub owns their
+priority and status.
+
+| Theme | Representative Issues | Architectural implication |
 |---|---|---|
-| `TaskService.revision` | Different from every other service | `refreshTrigger` or use a shared signal name |
-| `ProjectService.refreshProjects()` | Verb-based, inconsistent | `refresh()` unless there are multiple refresh targets |
-| `LabelService.refreshLabels()` | Same inconsistency | `refresh()` |
-| `TaskService.completedTasks` | Alias for `recentlyCompleted` | Remove — consume `recentlyCompleted` directly |
-| `TaskService.archivedTasks` | Only used in tests | Remove |
-| `pageSize` signals (archive vs search) | Consistent ✓ | No change needed |
+| Frontend decomposition | [#57](https://github.com/apauldev/Yotara/issues/57), [#58](https://github.com/apauldev/Yotara/issues/58), [#254](https://github.com/apauldev/Yotara/issues/254), [#255](https://github.com/apauldev/Yotara/issues/255), [#268](https://github.com/apauldev/Yotara/issues/268) | Keep API clients, view state, shell chrome, templates, and date utilities separable without reintroducing duplicated filtering logic. |
+| API boundary quality | [#266](https://github.com/apauldev/Yotara/issues/266), [#267](https://github.com/apauldev/Yotara/issues/267), [#269](https://github.com/apauldev/Yotara/issues/269), [#271](https://github.com/apauldev/Yotara/issues/271), [#276](https://github.com/apauldev/Yotara/issues/276) | Keep auth bridging, CORS, validation, and structured errors centralized and tested at the boundary. |
+| Query and data scalability | [#61](https://github.com/apauldev/Yotara/issues/61), [#228](https://github.com/apauldev/Yotara/issues/228), [#231](https://github.com/apauldev/Yotara/issues/231), [#232](https://github.com/apauldev/Yotara/issues/232), [#257](https://github.com/apauldev/Yotara/issues/257) | Prefer SQL filtering, sorting, batching, and bounded pagination; protect the request/response contract with per-view integration tests. |
+| Deployment and observability | [#64](https://github.com/apauldev/Yotara/issues/64), [#172](https://github.com/apauldev/Yotara/issues/172), [#236](https://github.com/apauldev/Yotara/issues/236), [#237](https://github.com/apauldev/Yotara/issues/237), [#252](https://github.com/apauldev/Yotara/issues/252), [#277](https://github.com/apauldev/Yotara/issues/277) | Keep releases reproducible and make coverage, image risk, bundle growth, and production request context visible. |
+| Product model and UX | [#258](https://github.com/apauldev/Yotara/issues/258), [#259](https://github.com/apauldev/Yotara/issues/259), [#260](https://github.com/apauldev/Yotara/issues/260), [#281](https://github.com/apauldev/Yotara/issues/281) | Document the meaning of `done`, `archived`, `simpleMode`, buckets, and search results before adding more workflow concepts. |
+| Team-mode boundary | [#238](https://github.com/apauldev/Yotara/issues/238), [#239](https://github.com/apauldev/Yotara/issues/239), [#240](https://github.com/apauldev/Yotara/issues/240), [#241](https://github.com/apauldev/Yotara/issues/241), [#278](https://github.com/apauldev/Yotara/issues/278) | Preserve workspace-scoped seams in new code, while keeping personal mode the supported center of gravity. |
 
-### Planning artifacts (currently 4)
+Future features such as calendar, import/export, task duplication, bulk
+actions, undo, natural-language capture, and PWA support are product Issues,
+not architectural commitments. They should not change the core system shape
+without an explicit design decision.
 
-**Current state:**
-- `ROADMAP.md` — high-level roadmap, priority lanes, questions (763 lines)
-- `docs/project-plan.md` — PM action plan, sprints, status legend (151 lines)
-- `apps/frontend/TODO.md` — frontend-specific tasks, pre-launch items, noted issues (252 lines)
-- `apps/api/TODO.md` — API-specific tasks, pre-launch items (155 lines)
+## Roadmap Project snapshot
 
-**Problem:** Four sources of truth, all overlapping, none synced. `ROADMAP.md` duplicates task numbers (P1 #12 is "Export data" and P2a #12 is "DB strategy"; same for #13). The TODOs have "Recently Completed" sections that duplicate `CHANGELOG.md`. None of the four reference this architecture doc as the live source.
+The [Yotara Roadmap Project](https://github.com/users/apauldev/projects/1) is
+the operational source of truth. Snapshot reviewed 2026-08-01:
 
-**Recommendation:**
-1. This document (`docs/ARCHITECTURE.md`) is the live source of architectural decisions and priority ordering.
-2. `ROADMAP.md` and `docs/project-plan.md` are kept as historical snapshots. Their priority lanes (P0/P1/P2/P3/P4) are superseded by the "Recommended roadmap" section below. Add a top-of-file "Superseded" notice to each so future readers know where to look.
-3. Delete `apps/frontend/TODO.md` and `apps/api/TODO.md`. The actionable work moves to GitHub Issues; completed work moves to `CHANGELOG.md`. The "Noted from review (not addressed here)" section in `apps/frontend/TODO.md` belongs in an issue, not a doc.
+- 118 items total: 15 Done, 14 In Progress, and 89 Todo.
+- Priority distribution: 1 Urgent, 18 High, 90 Medium, and 9 Low.
+- Done items include timezone handling (#170), planning harvest (#171),
+  server-side search (#176), browser reminders (#218), database transactions
+  (#227), N+1 batch label fetching (#228), and API security headers (#251).
+- In-progress architecture work includes TaskService cleanup (#175), backend
+  test coverage (#178), loadProjectById consolidation (#229), duplicate label
+  name checks (#230), SQL-side sorting (#231), shared test helpers (#232),
+  structured logging (#252), per-view task-filter tests (#257), search
+  debouncing (#261), auth-bridge and CORS consolidation (#266–#267), structured
+  validation errors (#271), and tighter auth-route CORS (#276).
+- High-priority Todo work currently includes production API hardening (#65).
+- Admin & Notifications work (issues #245–#250) follows the implementation
+  plan in [docs/admin-notifications.md](./admin-notifications.md).
 
----
+The statuses above are the board's as of the snapshot date; where work has
+since shipped, the board and this section should be updated together. Closed
+Issues and shipped commits are evidence of completed work, but the board's
+Project status is authoritative for what is currently being worked on.
 
-## Recommended roadmap (8 sprints, ordered by impact)
+Several older sprint Issues remain deliberately represented on the board—for
+example #173 and #179 are Todo while #174 is Done and #178 is In Progress.
+Their titles
+describe the original work packages; their Project status is authoritative.
 
-This sprint order supersedes the P0/P1/P2/P3 priority lanes in `ROADMAP.md`. Track progress in GitHub Issues; close a sprint by closing its issue.
+## Testing and verification policy
 
-### Sprint 0: Doc and runtime hygiene (do first; 2-3 days)
+- Service tests cover domain rules and transaction behavior.
+- Route tests cover authentication, validation, status codes, and response
+  contracts.
+- Frontend component tests assert rendered behavior and public interactions;
+  avoid reaching into private fields with `as any`.
+- Playwright tests cover user journeys and deployment-facing behavior.
+- OpenAPI tests should be updated with route contract changes.
+- A checklist item that says “verify” should become an automated test when the
+  behavior is important enough to preserve.
 
-**Why:** Closes the highest-leverage runtime anti-patterns (A1–A3, A7) and stops the docs from drifting again. Cheap, high-confidence work that compounds.
+The standard local verification command is:
 
-- [x] Migrate 26 `console.error` sites to `LogService`; add ESLint `no-console` rule
-- [x] Replace `throw new Error('string')` in services with typed errors; add Fastify `setErrorHandler`
-- [x] Fix `as any` on `request.query.status` at the trust boundary
-- [x] Add `PreferencesStore` (or extend `ThemeService`'s pattern) and migrate the three `localStorage` magic-string keys
-- [x] Replace the 4 problematic `setTimeout` UI hacks with signal-driven state
-- [x] Fix the UTC vs local timezone bug; add `?tz=` to per-view queries
-- [x] Add a `no-restricted-syntax` ESLint rule against `as any` (warn-only, applied to all `.ts` files)
-- [x] Add "Superseded" notices to `ROADMAP.md`, `docs/project-plan.md`, `apps/frontend/TODO.md`, and `apps/api/TODO.md`
-- [ ] Delete `apps/frontend/TODO.md` and `apps/api/TODO.md`; create initial GitHub Issues from the surviving priorities
-- [ ] Write `docs/RELEASING.md` (checklist for what to verify before cutting a release, since the release script is automated but the verification is not)
+```bash
+pnpm typecheck
+pnpm test
+pnpm lint
+```
 
-### Sprint 1: Push filtering to the API (completed)
+## Planning and documentation policy
 
-**Why:** Eliminates the expand loop, removes most computed signals, makes the app scale.
+The backlog migration to GitHub Issues is substantially complete. Do not add a
+new sprint plan, backlog table, or “recently completed” checklist here.
 
-**Frontend tasks:**
-- [x] `getTodayTasks()` → `GET /tasks?view=today`
-- [x] `getOverdueTasks()` → `GET /tasks?overdue=true`
-- [x] `getInboxTasks()` → `GET /tasks?view=inbox`
-- [x] `getUpcomingTasks()` → `GET /tasks?view=upcoming`
-- [x] `getTodayCompletedTasks()` → `GET /tasks?completedSince=<date>`
-- [x] Remove each `computed()` signal after migrating its view
+- GitHub Issues and the [Yotara Roadmap Project](https://github.com/users/apauldev/projects/1)
+  own priority, status, and sequencing.
+- `docs/ARCHITECTURE.md` owns durable architecture, constraints, and risks.
+- `CHANGELOG.md` owns release-level completed work.
+- `docs/CONTRIBUTING.md`, `docs/RELEASING.md`, and `DOCKER.md` own operational
+  procedures.
+- `ROADMAP.md`, `docs/project-plan.md`, and the package TODO files are legacy
+  historical material. They should not be treated as current status or a
+  second source of truth. The migration/harvest work is recorded as completed
+  in [#171](https://github.com/apauldev/Yotara/issues/171); the files remain in
+  the repository as historical context.
 
-**Backend tasks:**
-- [x] Add `view=today|inbox|upcoming` query param with compound predicates:
-  - `view=today` → `status = 'today' OR dueDate = today`
-  - `view=inbox` → `status = 'inbox' AND (dueDate IS NULL OR dueDate = '')`
-  - `view=upcoming` → `status = 'upcoming' OR dueDate > today`
-- [x] Add `completedSince` query param
-- [x] Verify all status filters work correctly with integration tests (replace the "verify" checkboxes in the API TODO with real tests)
-- [ ] Tighten input validation on the new query params (closes A3)
+Some historical sprint Issues remain open because the Roadmap Project still
+uses them as work packages. Their board status, not their age or title, is the
+status to follow. Issue [#286](https://github.com/apauldev/Yotara/issues/286)
+is closed and is listed above as completed evidence, even though it is not a
+current Project item. The same applies to other closed Issues whose work is
+complete but whose items were not retained on the board.
 
-### Sprint 1a: Remove setTimeout UI hacks (completed)
+When a GitHub Issue changes an architectural decision, update this document in
+the same change. When an Issue only tracks implementation work, leave this
+document alone.
 
-**Why:** 4 `setTimeout` calls were used as workarounds for change-detection timing, async close delays, and scrolling. These are fragile and untestable.
+## Engineering principles
 
-**Changes:**
-- [x] **Change password modal** — replaced `setTimeout(() => onClose(), 2000)` with `effect()` + `onCleanup()` for auto-closing after success
-- [x] **Loading interceptor** — removed `setTimeout(250)` minimum-display hack; replaced with CSS leave animation (250ms fade-out) on `app-status` component
-- [x] **Capture bar** — replaced `setTimeout(0)` cursor positioning with `requestAnimationFrame`
-- [x] **Labels page** — replaced `setTimeout(50)` + `document.querySelector('.task-pane')` with `viewChild('taskPane')` + `requestAnimationFrame` for smooth scroll
-
-### Sprint 1b: Forgot password / password reset flow (completed)
-
-**Why:** The "Forgot password?" link on the login screen is now a working button. Users who forget their password can request a reset link (logged to console; email sending infrastructure is a future addition). The flow uses Better Auth's built-in `requestPasswordReset` + `resetPassword` endpoints via the existing auth-bridge proxy.
-
-**Changes:**
-- [x] Backend: Added `sendResetPassword` callback to `emailAndPassword` config in `apps/api/src/lib/auth.ts` — logs reset URL to console (placeholder for real email sending)
-- [x] Shared: Added `forgotPassword(email)` and `resetPassword(newPassword, token)` methods to `AuthService`
-- [x] Frontend: Added matching methods to `AuthStateService`
-- [x] Frontend: Created `ForgotPasswordComponent` — email input → "Check your email" confirmation screen (hides email existence for privacy)
-- [x] Frontend: Created `ResetPasswordComponent` — reads `?token=` from URL query param, new password + confirm form, validates match, success/invalid states
-- [x] Frontend: Added `/forgot-password` and `/reset-password` routes with `loginRedirectGuard` (redirects authenticated users away)
-- [x] Frontend: Wired up the "Forgot password?" button on the login page
-- [x] Env: The redirect URL is hardcoded in the frontend (`packages/shared/src/auth.ts`) via `window.location.origin/reset-password` — no env var needed
-
-**What's left:** Replace the `console.log` in `sendResetPassword` with real email sending (Resend / Mailgun / SMTP) — the `admin-notifications.md` Phase 3 plan covers this.
-
-**Post-review hardening (2026-07-07):**
-- [x] Removed dead `FORGET_PASSWORD_CALLBACK_URL` from `.env.example` — the redirect URL is hardcoded in the frontend shared auth client, an env var was never read
-- [x] Removed redundant startup `DELETE FROM email_sends` in `db/client.ts` — the lazy per-email cleanup in `checkEmailRateLimit()` already handles stale rows
-- [x] Added comment above dormant `emailVerification` block in `auth.ts` — callback is wired but inert until `requireEmailVerification` is flipped to `true`
-- [x] Renamed `forgetPassword` → `forgotPassword` across `packages/shared/src/auth.ts`, `AuthStateService`, `ForgotPasswordComponent`, and its spec — consistent with the component name (`ForgotPasswordComponent`) and route (`/forgot-password`)
-
-### Sprint 2: Clean up TaskService (partial)
-
-**Why:** Makes the file maintainable and testable.
-
-- [x] Extract date helpers to `shared/utils/timestamps.ts`
-- [ ] Extract auth-gate pattern into shared helper
-- [x] Remove stale aliases (`archivedTasks`, `completedTasks`) — done in Sprint 1 cleanup
-- [x] Remove active-task expand loop (no longer needed after Sprint 1) — done in Sprint 1 cleanup
-
-### Sprint 3: Server-side search
-
-**Why:** Eliminates 250 lines of client-side scoring, scales to any number of tasks.
-
-- [x] `GET /tasks/search?q=...` on the backend
-- [x] Replace `searchArchive()` and `search()` with API calls
-- [x] Delete scoring functions from `search.service.ts`
-
-### Sprint 4: Standardize naming and consolidate docs
-
-**Why:** Low effort, high impact on contributor experience.
-
-- [x] Rename `revision` → consistent name across all services
-- [x] Standardize `refresh()` method name
-- [x] Write `docs/CONTRIBUTING.md` with setup guide and architecture overview
-- [x] Add `.reasonix/` to `.gitignore`
-
-### Sprint 5: Backend test coverage
-
-**Why:** Backend routes are not well-tested.
-
-- [ ] Add route-level tests for tasks, projects, labels
-- [ ] Add integration test for the full request-response cycle
-- [ ] Add tests for edge cases (empty results, pagination boundaries)
-
-### Sprint 6: Developer experience and polish
-
-**Why:** Makes the project easy to pick up.
-
-- [ ] Docker Compose for local development
-- [ ] One-command dev setup script
-- [x] Rate limiting on API
-- [ ] Consistent input validation across all routes
-- [ ] Stricter TypeScript config (no `any` casts like `request.query.status as any`)
-
----
-
-## Backlog
-
-> **⚠️ Historical reference.** All items from this section have been migrated to GitHub Issues with the `harvested-from-docs` label. Tracked live on the **[Yotara Roadmap](https://github.com/users/apauldev/projects/1)** Project board. New work should be filed as GitHub Issues, not added here.
-
----
-
-## For new contributors
-
-See [CONTRIBUTING.md](./CONTRIBUTING.md).
-
----
-
-Structural:
-
-- **The server should do the filtering.** Every computed signal that filters on a field the server could query (`status`, `completed`, `dueDate`) is a sign the API is missing an endpoint. Add the endpoint, remove the signal.
-- **Services fetch. Components compose.** A component reading `taskService.todayTasks()` is fine. A component doing its own filtering is a sign the service is missing a view.
-- **Shared patterns should be shared.** If you see the same 25 lines in 3 files, extract once.
-- **One source of truth for types and plans.** The `shared` package owns domain types. This architecture document owns architectural decisions and priority ordering. If a finding doesn't live in either place, it gets lost.
-
-Runtime:
-
-- **Errors at the boundary they occur.** If a service can produce a validation error, return a typed error (or a result type) — never `throw new Error('string')` and hope the route catches it. A Fastify `setErrorHandler` is the right place to map domain errors to HTTP status codes. (Closes A2.)
-- **Async without timers.** If you find yourself writing `setTimeout(() => doSomething(), N)` to make a UI feel responsive, you have a state-modeling problem. Use an Angular `effect()` or a `Signal` and let the change-detection cycle do the work. (Closes A5.)
-- **Bugs are bugs, not refactors.** A refactor commit should not change behavior. If it does, split the commit. The split is also the paper trail. (Closes A8.)
-
-Testing:
-
-- **Tests at the boundary you want to keep stable.** Service tests are fast and catch regressions. Component tests verify rendering. Integration tests catch request/response cycle bugs. All three matter.
-- **Don't reach into component internals in tests.** Use DOM assertions, public API, or signal inspection. White-box tests (`as any` casts on `componentInstance`) couple the test suite to the implementation and punish future refactors. (Closes A7.)
-- **A "verify" item is a missing test.** If you can't write a test for the filter, you don't know if the filter works. Replace the checklist with a test and delete the checkbox.
-
-Process:
-
-- **This document is the live source of architectural truth.** The "Recently Completed" sections in the old TODOs are CHANGELOG work. The priority lanes in `ROADMAP.md` are historical. New work goes in GitHub Issues; the "Noted from review (not addressed here)" section in `apps/frontend/TODO.md` becomes an issue with a label, not a paragraph in a doc.
-- **Refactors don't change behavior.** A reviewer should be able to skip a refactor PR without reading it and not break anything. If a refactor is fixing a bug, split the commit.
-- **Planning lives on the [Yotara Roadmap](https://github.com/users/apauldev/projects/1) Project board.** New work, feature requests, and bugs go directly to GitHub Issues. The Project board is the source of truth for prioritization and status. This document owns architectural decisions and anti-patterns; the board owns what's being worked on and when.
-- **The "Recommended roadmap" sprint sections above are historical.** The active sprint plan lives on the Project board. Completed sprints are kept as a record of what was done and why.
-- **The "Explicit non-goals" subsection is a tripwire.** If you find yourself wanting to add a feature that's listed there, the answer is "not without an explicit re-evaluation," not "let me just add it." Re-evaluation means a discussion, a written decision, and an update to this section removing the non-goal.
+- Services fetch; components compose.
+- The server owns query semantics; the client owns interaction and display.
+- Use shared types and helpers instead of parallel local contracts.
+- Keep multi-table writes transactional.
+- Treat security assumptions as deployment documentation, not hidden magic.
+- Separate behavior fixes from pure refactors when practical.
+- Prefer a small, tested boundary over a clever abstraction.
+- Keep the personal experience calm by default.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,9 +18,12 @@ pnpm monorepo. The current product is substantially beyond the original MVP:
 - Fastify 5 API with a route → service → database shape.
 - SQLite with Drizzle ORM, transactional multi-table writes, startup schema
   bootstrap, timestamp normalization, and database permission hardening.
-- Better Auth session-cookie authentication, password reset and verification
-  email flows, account deletion, rate limiting, login lockout, and security
-  headers.
+- Better Auth session-cookie authentication, password reset email flow,
+  account deletion, rate limiting, login lockout, and security headers.
+- Email verification is wired but dormant: the verification callback exists in
+  the API, but `requireEmailVerification` is `false`, so the flow is inactive
+  until that flag is flipped (tracked as future work in
+  [docs/admin-notifications.md](./admin-notifications.md)).
 - Personal task views, projects, labels, archive, search, subtasks, recurring
   tasks, themes, keyboard shortcuts, and in-app notifications.
 - Docker deployment behind nginx, published container images, OpenAPI docs,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -113,10 +113,16 @@ date parsing or raw UTC assumptions.
 
 ### Security at deployment boundaries
 
-The supported deployment is nginx in front of the API. The API's proxy trust
-and IP-based rate limiting depend on that proxy overwriting/forwarding the real
-client address correctly. The API must not be exposed directly with an
-unrestricted `trustProxy` setting.
+The supported deployment is nginx in front of the API. The API runs with
+`trustProxy: 1` and derives `request.ip` from `X-Forwarded-For`; both the
+global IP rate limiter and the per-IP login lockout depend on that IP being
+the real client address. That is only true when the proxy overwrites
+`X-Forwarded-For` with the real client IP — which the bundled
+`docker/nginx.conf` does (`$proxy_add_x_forwarded_for`). Never expose the API
+directly with an unrestricted `trustProxy` setting: a client could then forge
+`X-Forwarded-For`, making `request.ip` attacker-controllable and defeating
+rate limiting and login-lockout scoping. If you must run without nginx, scope
+`trustProxy` to the proxy's subnet (CIDR or function) instead of `1`.
 
 Security-sensitive behavior belongs at the boundary where it can be enforced:
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -30,7 +30,7 @@ apps/
 packages/
   shared/                  Domain types, DTOs, shared client code
 docs/
-  ARCHITECTURE.md          Architecture decisions, anti-patterns, roadmap
+  ARCHITECTURE.md          Architecture decisions, constraints, known risks
   CONTRIBUTING.md          ← you are here
 ```
 
@@ -81,10 +81,14 @@ docs/
 
 ### Process
 
-- **Architecture decisions live in `docs/ARCHITECTURE.md`.**
+- **Architecture decisions live in `docs/ARCHITECTURE.md`**, and the "Important
+  architectural decisions" section there is the tripwire: if a change would
+  reverse one of those decisions (e.g. server-side filtering, SQLite first,
+  explicit timezone handling, security at the deployment boundary), it needs an
+  explicit re-evaluation — a discussion, a written decision, and an update to
+  the document — rather than "let me just add it."
 - **New work goes in GitHub Issues** and is tracked on the [Yotara Roadmap](https://github.com/users/apauldev/projects/1) Project board.
 - **Refactors don't change behavior.** A reviewer should be able to skip a refactor PR without reading it and not break anything. If a refactor is fixing a bug, split the commit.
-- **The "Explicit non-goals" subsection in ARCHITECTURE.md is a tripwire.** If you find yourself wanting to add a feature listed there, the answer is "not without an explicit re-evaluation," not "let me just add it." Re-evaluation means a discussion, a written decision, and an update to the document removing the non-goal.
 
 ### Before submitting a PR
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -144,7 +144,7 @@ After week 16, Yotara should be ready for v1.0 across self-hosted and SaaS paths
 
 ## Immediate Next Task
 
-> Stale: this section suggested "Start with P1 #10 (markdown preview)" but that work shipped in 0.51.0. The current next actions are in `docs/ARCHITECTURE.md` → "Recommended roadmap" → Sprint 0.
+> Stale: this section suggested "Start with P1 #10 (markdown preview)" but that work shipped in 0.51.0. Current priorities live on the [Yotara Roadmap](https://github.com/users/apauldev/projects/1) Project board and GitHub Issues, not in a doc.
 
 Historical next task (for context only):
 


### PR DESCRIPTION
### **User description**
## Description

Rewrites `docs/ARCHITECTURE.md` from a roadmap/sprint/backlog document into a durable architectural reference: system shape, important architectural decisions, current strengths, known risks and technical debt, an issue-backed architecture map, testing/verification policy, and engineering principles. Planning status moves to the [Yotara Roadmap](https://github.com/users/apauldev/projects/1) Project board and GitHub Issues.

The rewrite was cross-checked against the live board and Issues, and the snapshot data was corrected to match (15 Done / 14 In Progress / 89 Todo; 1 Urgent / 18 High / 90 Medium / 9 Low).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Test coverage improvement
- [ ] Performance improvement
- [ ] Refactoring (code improvement with no functional change)

## Related Issue

Relates to: #171 (planning migration to GitHub Issues; docs now point to the Project board). Not closing: #171 also requires deleting apps/frontend/TODO.md and apps/api/TODO.md, which this PR deliberately keeps as declared historical snapshots per the new planning policy. That remaining work is tracked in #337.

## Roadmap Reference

Docs-only; planning reference moves from ROADMAP.md / sprint sections to the Yotara Roadmap Project board.

## Changes Made

- Rewrite `docs/ARCHITECTURE.md`: remove sprint plans, backlog, and anti-pattern registry; add system shape, important architectural decisions, current strengths, known risks, issue-backed architecture map, Roadmap Project snapshot, testing policy, and engineering principles
- Replace the "Explicit non-goals" tripwire with an "Important architectural decisions" tripwire, mirrored in `docs/CONTRIBUTING.md` and `CONTRIBUTING.md`
- Update cross-references in `CONTRIBUTING.md`, `PROJECT_README.md`, `docs/CONTRIBUTING.md`, and `docs/project-plan.md` to point at the Roadmap Project board instead of doc sections
- Correct Roadmap Project snapshot counts against the live board (15 Done / 14 In Progress / 89 Todo; 1 Urgent / 18 High / 90 Medium / 9 Low) and fix the status of #174 (Done, not Todo)
- Restore the `docs/admin-notifications.md` pointer (issues #245–#250) that was dropped in the rewrite
- Fix dangling ROADMAP.md references to removed ARCHITECTURE.md sections (Sprint 0, runtime anti-patterns)
- Add `.commandcode/taste/workflow/taste.md` and `.commandcode/settings.json` to `.gitignore`

## Testing

### Test Coverage

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed

### Verification Steps

1. Cross-checked every issue reference in the doc against GitHub Issues (states/titles verified via `gh`)
2. Cross-checked the Roadmap Project snapshot (item counts, statuses, priorities) against the live board via GraphQL
3. Prettier format check passed via lint-staged on commit

## Screenshots or Demo

N/A (docs-only)

## Contributor License Agreement

By submitting this PR, you agree to the [Yotara CLA](https://github.com/apauldev/Yotara/blob/main/CLA.md).

- [x] I have read and agree to the Yotara Contributor License Agreement
- [x] I have signed-off my commits (`git commit -s`) to certify the [Developer Certificate of Origin](https://developercertificate.org/)

## Checklist

- [x] Code follows the project style and conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have verified that this PR is against the correct branch (`main`)

## Additional Notes

ROADMAP.md, `docs/project-plan.md`, and the package TODO files remain in the repo as declared historical snapshots per the new planning policy. The empty sign-off commit (`fce3082`) exists to carry the DCO trailer without rewriting the already-pushed docs commit.


___

### **PR Type**
Documentation


___

### **Description**
- Rewrite ARCHITECTURE.md into durable reference for decisions, risks

- Move planning status to GitHub Issues and Roadmap Project board

- Update doc cross-references across contributing, README, roadmap docs

- Add issue-backed map, strengths, risks, and roadmap snapshot


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ARCH["ARCHITECTURE.md rewrite"] --> DEC["Architectural decisions"]
  ARCH --> RISK["Known risks & debt"]
  ARCH --> MAP["Issue-backed map"]
  ARCH --> SNAP["Roadmap snapshot"]
  ARCH --> POLICY["Planning & docs policy"]
  BOARD["Yotara Roadmap Project"] --> STATUS["Priority & status"]
  POLICY --> BOARD
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CONTRIBUTING.md</strong><dd><code>Update architecture references and roadmap pointer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CONTRIBUTING.md

<ul><li>Reframed ARCHITECTURE.md references from roadmap/anti-patterns to <br>decisions, risks, and verification<br> <li> Added pointer to Yotara Roadmap Project board for active work</ul>


</details>


  </td>
  <td><a href="https://github.com/apauldev/Yotara/pull/336/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PROJECT_README.md</strong><dd><code>Align project README with architecture doc scope</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

PROJECT_README.md

<ul><li>Updated ARCHITECTURE.md description in intro and repo tree to reflect <br>new content</ul>


</details>


  </td>
  <td><a href="https://github.com/apauldev/Yotara/pull/336/files#diff-f575c06961db4da985b0a1345eb9dac64043ce102659b06b00a9a7a79e68ecee">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ROADMAP.md</strong><dd><code>Repoint roadmap notes to Project board</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ROADMAP.md

<ul><li>Replaced stale ARCHITECTURE.md pointers with Yotara Roadmap Project <br>board references<br> <li> Updated P3/P4 notes to reference engineering principles and risks</ul>


</details>


  </td>
  <td><a href="https://github.com/apauldev/Yotara/pull/336/files#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ARCHITECTURE.md</strong><dd><code>Rewrite architecture guide as durable reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/ARCHITECTURE.md

<ul><li>Rewrote from roadmap/sprint/backlog into durable architectural <br>reference<br> <li> Added current state, system shape, and important architectural <br>decisions<br> <li> Added known risks, issue-backed architecture map, and Roadmap snapshot<br> <li> Removed sprint plans, anti-pattern registry, and legacy file-by-file <br>audit</ul>


</details>


  </td>
  <td><a href="https://github.com/apauldev/Yotara/pull/336/files#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1">+299/-491</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CONTRIBUTING.md</strong><dd><code>Update tripwire and architecture doc references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/CONTRIBUTING.md

<ul><li>Updated ARCHITECTURE.md description in repo tree<br> <li> Replaced "Explicit non-goals" tripwire with "Important architectural <br>decisions" tripwire</ul>


</details>


  </td>
  <td><a href="https://github.com/apauldev/Yotara/pull/336/files#diff-4c6b93aa75d5affde60dc3849606c9acd75ed444d52e99f3055fc0c7aa77e9e0">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>project-plan.md</strong><dd><code>Point stale next-task note to Project board</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/project-plan.md

<ul><li>Updated stale "Immediate Next Task" pointer to Roadmap Project board <br>and GitHub Issues</ul>


</details>


  </td>
  <td><a href="https://github.com/apauldev/Yotara/pull/336/files#diff-c19722b9c91d8ab82316f38a935e1ffa9be44ffb571af67dd1dc3b4b83fdd775">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

