### PR TITLE
fix(frontend): make notifications dropdown scrollable, aligned, and mobile-safe

### DIFF
--- a/apps/frontend/src/app/features/personal/pages/notifications-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/notifications-page.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, computed, inject, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { faBell, faCheck, faCheckDouble, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faCheck, faCheckDouble, faEnvelope, faTrash } from '@fortawesome/free-solid-svg-icons';
 import type { Notification } from '@yotara/shared';
 import { NotificationService } from '../../../core/services/notification.service';
 import { PageHeaderComponent } from '../../../shared/components/page-header/page-header.component';
@@ -20,7 +20,7 @@ import { PageHeaderComponent } from '../../../shared/components/page-header/page
       <div class="notifications-card">
         @if (service.notifications().length === 0) {
           <div class="empty-state">
-            <fa-icon [icon]="faBell" class="empty-icon"></fa-icon>
+            <fa-icon [icon]="faEnvelope" class="empty-icon"></fa-icon>
             <p class="empty-title">No notifications yet</p>
             <p class="empty-subtitle">When tasks are due or overdue, you'll see them here.</p>
           </div>
@@ -177,7 +177,7 @@ import { PageHeaderComponent } from '../../../shared/components/page-header/page
       .notifications-list {
         display: flex;
         flex-direction: column;
-        gap: 0.35rem;
+        gap: 0.625rem;
       }
 
       .notification-item {
@@ -265,6 +265,15 @@ import { PageHeaderComponent } from '../../../shared/components/page-header/page
           border-radius: 1.25rem;
         }
 
+        .notifications-header {
+          flex-wrap: wrap;
+          gap: 0.5rem;
+        }
+
+        .notifications-actions {
+          flex-wrap: wrap;
+        }
+
         .notification-item {
           padding: 0.6rem;
           gap: 0.5rem;
@@ -275,7 +284,7 @@ import { PageHeaderComponent } from '../../../shared/components/page-header/page
 })
 export class NotificationsPageComponent implements OnInit {
   protected readonly service = inject(NotificationService);
-  protected readonly faBell = faBell;
+  protected readonly faEnvelope = faEnvelope;
   protected readonly faCheck = faCheck;
   protected readonly faCheckDouble = faCheckDouble;
   protected readonly faTrash = faTrash;

--- a/apps/frontend/src/app/features/personal/shell/personal-shell.component.css
+++ b/apps/frontend/src/app/features/personal/shell/personal-shell.component.css
@@ -667,6 +667,11 @@
     justify-content: flex-end;
   }
 
+  .notifications-dropdown {
+    right: 0;
+    max-height: min(24rem, calc(100dvh - 14rem));
+  }
+
   .topbar-brand {
     order: 1;
     font-size: 1.35rem;
@@ -841,6 +846,20 @@
 /* Notification dropdown */
 .notifications-dropdown {
   width: min(20rem, calc(100vw - 2rem));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Desktop: align the right edge with the bell button (bell + sliders + avatar
+   buttons plus two 0.75rem gaps from the right edge of .topbar-actions) and cap
+   the height. Mobile uses right: 0 and a shorter cap from the responsive section
+   below, which must not be overridden by these desktop-only values. */
+@media (width > 720px) {
+  .notifications-dropdown {
+    right: 6.5rem;
+    max-height: min(26rem, calc(100dvh - 8rem));
+  }
 }
 
 .notifications-dropdown-header {
@@ -848,6 +867,16 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.5rem 0.85rem 0.25rem;
+  flex-shrink: 0;
+}
+
+.notifications-dropdown-list {
+  overflow-y: auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0.1rem 0.15rem 0.3rem;
 }
 
 .notifications-dropdown-header strong {

--- a/apps/frontend/src/app/features/personal/shell/personal-shell.component.html
+++ b/apps/frontend/src/app/features/personal/shell/personal-shell.component.html
@@ -147,7 +147,7 @@
           aria-label="Notifications"
           (click)="toggleNotifications()"
         >
-          <fa-icon [icon]="faBell" aria-hidden="true"></fa-icon>
+          <fa-icon [icon]="faEnvelope" aria-hidden="true"></fa-icon>
           @if (notificationService.unreadCount() > 0) {
             <span class="notification-badge">{{ notificationService.unreadCount() }}</span>
           }
@@ -174,23 +174,25 @@
                 >View all</a
               >
             </div>
-            @if (notificationService.notifications().length === 0) {
-              <p class="notifications-empty">No notifications yet</p>
-            } @else {
-              @for (notif of notificationService.notifications(); track notif.id) {
-                <button
-                  type="button"
-                  class="notification-dropdown-item"
-                  [class.notification-unread]="!notif.read"
-                  (click)="onNotificationClick(notif)"
-                >
-                  <span class="notification-dropdown-type">{{
-                    notif.type === 'due_today' ? 'Today' : 'Overdue'
-                  }}</span>
-                  <span class="notification-dropdown-body">{{ notif.body }}</span>
-                </button>
+            <div class="notifications-dropdown-list">
+              @if (notificationService.notifications().length === 0) {
+                <p class="notifications-empty">No notifications yet</p>
+              } @else {
+                @for (notif of notificationService.notifications(); track notif.id) {
+                  <button
+                    type="button"
+                    class="notification-dropdown-item"
+                    [class.notification-unread]="!notif.read"
+                    (click)="onNotificationClick(notif)"
+                  >
+                    <span class="notification-dropdown-type">{{
+                      notif.type === 'due_today' ? 'Today' : 'Overdue'
+                    }}</span>
+                    <span class="notification-dropdown-body">{{ notif.body }}</span>
+                  </button>
+                }
               }
-            }
+            </div>
           </div>
         }
         <button

--- a/apps/frontend/src/app/features/personal/shell/personal-shell.component.spec.ts
+++ b/apps/frontend/src/app/features/personal/shell/personal-shell.component.spec.ts
@@ -234,6 +234,45 @@ describe('PersonalShellComponent', () => {
     expect(notifService.fetchUnreadCount).toHaveBeenCalled();
   });
 
+  it('keeps the notification list scrollable when there are many notifications', () => {
+    const notifService = TestBed.inject(NotificationService) as any;
+    notifService.notifications.set(
+      Array.from({ length: 25 }, (_, i) => ({
+        id: `n${i}`,
+        type: 'due_today' as const,
+        title: `Task ${i}`,
+        body: `Body ${i}`,
+        read: false,
+        readAt: null,
+        createdAt: '2026-07-17T10:00:00.000Z',
+      })),
+    );
+
+    const fixture = TestBed.createComponent(PersonalShellComponent);
+    fixture.detectChanges();
+
+    const bellButton = fixture.debugElement.queryAll(By.css('.icon-button'))[0];
+    bellButton.nativeElement.click();
+    fixture.detectChanges();
+
+    const dropdown = fixture.debugElement.query(By.css('.notifications-dropdown'));
+    const list = fixture.debugElement.query(By.css('.notifications-dropdown-list'));
+
+    expect(dropdown).toBeTruthy();
+    expect(list).toBeTruthy();
+    expect(list.nativeElement.querySelectorAll('.notification-dropdown-item').length).toBe(25);
+
+    const dropdownStyle = getComputedStyle(dropdown.nativeElement);
+    const listStyle = getComputedStyle(list.nativeElement);
+    expect(dropdownStyle.maxHeight).not.toBe('none');
+    expect(listStyle.overflowY).toBe('auto');
+
+    // The header stays fixed while only the list scrolls.
+    const header = fixture.debugElement.query(By.css('.notifications-dropdown-header'));
+    expect(header.nativeElement.parentElement).toBe(dropdown.nativeElement);
+    expect(list.nativeElement.parentElement).toBe(dropdown.nativeElement);
+  });
+
   it('calls markAsRead when clicking an unread notification in the dropdown', async () => {
     const notifService = TestBed.inject(NotificationService) as any;
     notifService.notifications.set([

--- a/apps/frontend/src/app/features/personal/shell/personal-shell.component.ts
+++ b/apps/frontend/src/app/features/personal/shell/personal-shell.component.ts
@@ -19,7 +19,7 @@ import { FormsModule } from '@angular/forms';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import {
   faBars,
-  faBell,
+  faEnvelope,
   faCalendarDays,
   faBoxArchive,
   faInbox,
@@ -107,7 +107,7 @@ interface PersonalNavItem {
 export class PersonalShellComponent {
   protected readonly appVersion = APP_VERSION;
   protected readonly faBars = faBars;
-  protected readonly faBell = faBell;
+  protected readonly faEnvelope = faEnvelope;
   protected readonly faArrowRightLong = faArrowRightLong;
   protected readonly faCalendarDays = faCalendarDays;
   protected readonly faBoxArchive = faBoxArchive;


### PR DESCRIPTION
### **User description**
## Description

The notifications dropdown (bell menu in the top bar) had no scrolling when there were many notifications — it grew past the bottom of the viewport with no way to reach lower items. It was also misaligned on desktop (not anchored under the bell) and broken on mobile (the desktop right-offset and height cap leaked into the `≤720px` layout). The notification cards on the page and in the dropdown were spaced too tightly, making them visually merge.

This PR makes the dropdown height-capped with an internal scrollable list (header stays fixed), aligns it under the bell on desktop, restores the mobile-friendly full-width positioning, gives the notification cards proper spacing, and swaps the notification icon to the closed envelope.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Test coverage improvement
- [ ] Performance improvement
- [ ] Refactoring (code improvement with no functional change)

## Related Issue

Closes: #(n/a)

## Roadmap Reference

N/A — frontend polish on the personal-mode notifications experience.

## Changes Made

- `apps/frontend/src/app/features/personal/shell/personal-shell.component.html` — wrap dropdown notification items in a scrollable list container so the header stays fixed
- `apps/frontend/src/app/features/personal/shell/personal-shell.component.css` — cap the dropdown height with internal scroll; align the right edge under the bell on desktop (scoped to `>720px` so mobile overrides apply); increase dropdown item spacing
- `apps/frontend/src/app/features/personal/shell/personal-shell.component.ts` — swap notification icon from `faBell` to `faEnvelope`
- `apps/frontend/src/app/features/personal/pages/notifications-page.component.ts` — swap empty-state icon to `faEnvelope`; increase card spacing; let the header actions wrap on small screens
- `apps/frontend/src/app/features/personal/shell/personal-shell.component.spec.ts` — regression spec for the scrollable dropdown list

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed

### Verification Steps

1. Seed many notifications, open the bell dropdown — the list scrolls internally and the header stays fixed
2. Desktop: dropdown right edge aligns under the bell; mobile (`≤720px`): dropdown is full-width and on-screen with a shorter height cap
3. `ng test` on `personal-shell.component.spec.ts` (26/26) and `notifications-page.component.spec.ts` (9/9); `tsc -p tsconfig.typecheck.json --noEmit` clean; stylelint clean

## Screenshots or Demo

N/A

## Contributor License Agreement

By submitting this PR, you agree to the [Yotara CLA](https://github.com/apauldev/Yotara/blob/main/CLA.md).

- [x] I have read and agree to the Yotara Contributor License Agreement
- [x] I have signed-off my commits (`git commit -s`) to certify the Developer Certificate of Origin

## Checklist

- [x] Code follows the project style and conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have verified that this PR is against the correct branch (`main`)

## Additional Notes

Includes the notification icon swap (`faBell` → `faEnvelope`) requested alongside the scroll fix. The sign-off commit `chore: add DCO sign-off for Developer Certificate of Origin` carries the `Signed-off-by` trailer per the project's DCO requirement.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix dropdown height, alignment, and mobile responsiveness

- Wrap notification items in an internal scrollable list

- Unify envelope icon and improve card spacing

- Add regression test for dropdown scrollability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Topbar bell button"] -- "click" --> B["Notifications dropdown"]
  B --> C["Fixed header"]
  B --> D["Scrollable notifications list"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>personal-shell.component.html</strong><dd><code>Wrap dropdown notifications in scrollable container</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/frontend/src/app/features/personal/shell/personal-shell.component.html

<ul><li>Wrap notification items in a scrollable <code>.notifications-dropdown-list</code> <br>container<br> <li> Move empty state and list inside the scrollable container<br> <li> Keep the dropdown header fixed outside the scroll area</ul>


</details>


  </td>
  <td><a href="https://github.com/apauldev/Yotara/pull/347/files#diff-f2f5090528ca019108d9e8a7b8ff1d3ed3182b70a3b3b9a9989d69bd977c673b">+19/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>personal-shell.component.css</strong><dd><code>Add scrollable dropdown styles and responsive alignment</code>&nbsp; &nbsp; </dd></summary>
<hr>

apps/frontend/src/app/features/personal/shell/personal-shell.component.css

<ul><li>Cap dropdown height and enable internal scrolling via <code>overflow-y: auto</code><br> <li> Align dropdown right edge under the bell on desktop with <code>@media (width </code><br><code>> 720px)</code><br> <li> Add mobile positioning with <code>right: 0</code> and a shorter max-height<br> <li> Add <code>flex-shrink: 0</code> to the header and spacing to list items</ul>


</details>


  </td>
  <td><a href="https://github.com/apauldev/Yotara/pull/347/files#diff-36f2c216a2a2c57c0a7270d22a161b933f9f5113ee6b8ff07e1d09738cc57088">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>personal-shell.component.ts</strong><dd><code>Swap notification icon to envelope</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/frontend/src/app/features/personal/shell/personal-shell.component.ts

<ul><li>Replace <code>faBell</code> with <code>faEnvelope</code> for the notification icon<br> <li> Update the component icon binding accordingly</ul>


</details>


  </td>
  <td><a href="https://github.com/apauldev/Yotara/pull/347/files#diff-5bdf2dba36f0786e1336e9a7dbed63c75bd356d7b5d4a74ba565e76613978346">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>notifications-page.component.ts</strong><dd><code>Update notifications page icons and responsive spacing</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/frontend/src/app/features/personal/pages/notifications-page.component.ts

<ul><li>Replace empty-state icon with <code>faEnvelope</code><br> <li> Increase notification list gap spacing<br> <li> Allow header and actions to wrap on small screens</ul>


</details>


  </td>
  <td><a href="https://github.com/apauldev/Yotara/pull/347/files#diff-f66afd9c2f8320ef35a8301b9f2c3c92492baa8242a3e6c392b2480bff537f11">+13/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>personal-shell.component.spec.ts</strong><dd><code>Add dropdown scrollability regression test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/frontend/src/app/features/personal/shell/personal-shell.component.spec.ts

<ul><li>Add regression test for dropdown scrollability with 25 notifications<br> <li> Verify list container exists and has <code>overflow-y: auto</code><br> <li> Assert max-height is set on the dropdown and header stays fixed</ul>


</details>


  </td>
  <td><a href="https://github.com/apauldev/Yotara/pull/347/files#diff-025b68040d098e037bee5d4d712b40aa560c76a342d76a48ea92b1d88df2d63a">+39/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

