### PR TITLE
feat(auth): email verification, dev mode, and beta-release hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,11 +128,13 @@ jobs:
         run: pnpm --filter @yotara/shared build
       - name: Start API
         run: |
-          RATE_LIMIT_MAX=10000 EMAIL_RATE_IP_CAP=100 pnpm --filter @yotara/api dev &
+          RATE_LIMIT_MAX=10000 EMAIL_RATE_IP_CAP=100 E2E_API_LOG="$GITHUB_WORKSPACE/api-e2e.log" pnpm --filter @yotara/api dev > api-e2e.log 2>&1 &
+          echo $! > api.pid
           pnpm --filter @yotara/frontend e2e:wait --timeout 60000 http-get://localhost:3000/health
       - name: Start Frontend
         run: |
-          pnpm --filter @yotara/frontend dev &
+          pnpm --filter @yotara/frontend dev > frontend-e2e.log 2>&1 &
+          echo $! > frontend.pid
           pnpm --filter @yotara/frontend e2e:wait --timeout 60000 http-get://localhost:4200
       - name: Install Playwright browsers
         run: pnpm --filter @yotara/frontend exec playwright install chromium
@@ -140,12 +142,27 @@ jobs:
         run: pnpm --filter @yotara/frontend e2e
         env:
           CI: true
-      - name: Upload Playwright report
+          E2E_API_LOG: ${{ github.workspace }}/api-e2e.log
+          E2E_API_URL: http://localhost:3000
+          E2E_BASE_URL: http://localhost:4200
+      - name: Upload E2E diagnostics
         uses: actions/upload-artifact@v4
-        if: failure()
+        if: always()
         with:
-          name: playwright-report
-          path: apps/frontend/e2e/playwright-report/
+          name: e2e-diagnostics
+          path: |
+            apps/frontend/e2e/playwright-report/
+            apps/frontend/e2e/test-results/
+            api-e2e.log
+            frontend-e2e.log
+          if-no-files-found: ignore
+      - name: Stop E2E services
+        if: always()
+        run: |
+          if [ -f api.pid ]; then kill "$(cat api.pid)" 2>/dev/null || true; fi
+          if [ -f frontend.pid ]; then kill "$(cat frontend.pid)" 2>/dev/null || true; fi
+          pkill -f 'tsx watch src/server.ts' 2>/dev/null || true
+          pkill -f 'ng serve --port 4200' 2>/dev/null || true
 
   docker-and-smoke:
     runs-on: ubuntu-latest
@@ -213,7 +230,11 @@ jobs:
           pnpm smoke:docker
         env:
           DOCKER_SMOKE_BASE_URL: http://localhost:8080
-          BETTER_AUTH_SECRET: ci-test-secret-not-for-production-use-abc123
+          BETTER_AUTH_SECRET: 903d44f75ea956577ae15335bbbef8532a867cdeae599cccac72357d40f14214
+          # The API refuses to boot with NODE_ENV=production and no key
+          # (fail-loud contract); this canonical test key is not used for
+          # production signing.
+          RESEND_API_KEY: ci-fake-key-for-boot-only
 
       - name: Logs on failure
         if: failure()
@@ -222,6 +243,16 @@ jobs:
             docker compose -f docker-compose.yml -f docker-compose.ci.yml logs
           else
             docker compose -f docker-compose.yml logs
+          fi
+
+      - name: Tear down stack
+        # Always run so containers never leak past the job, even on failure.
+        if: always()
+        run: |
+          if [ -f docker-compose.ci.yml ]; then
+            docker compose -f docker-compose.yml -f docker-compose.ci.yml down -v
+          else
+            docker compose -f docker-compose.yml down -v
           fi
 
   docker-api-native:
@@ -259,6 +290,12 @@ jobs:
           cache-to: type=gha,mode=max,scope=api-${{ matrix.architecture }}
 
       - name: Create API Compose override
+        # The native smoke signs up and creates a task, which requires a
+        # session. Production sign-up is email-first (no session until the
+        # email is verified), so the smoke runs the API in dev mode — the
+        # deliberate double opt-in for test instances. The production boot
+        # guard (fail-loud on secret/email config) is covered by the host-level
+        # docker-and-smoke job, which runs without dev mode.
         run: |
           cat > docker-compose.api-ci.yml <<'EOF'
           services:
@@ -270,6 +307,8 @@ jobs:
               environment:
                 APP_BASE_URL: http://localhost:3000
                 TRUSTED_ORIGINS: http://localhost:3000
+                DEV_MODE: "true"
+                ALLOW_DEV_MODE_IN_PRODUCTION: "true"
           EOF
 
       - name: Install pnpm
@@ -282,11 +321,14 @@ jobs:
           cache: pnpm
 
       - name: Run API native and database smoke test
+        # No RESEND_API_KEY here: dev mode deliberately ignores it and logs
+        # emails to the console instead, so this job also proves the API boots
+        # the dev-mode stack without any email provider configured.
         run: |
           docker compose -f docker-compose.yml -f docker-compose.api-ci.yml up -d api
           pnpm smoke:docker:api
         env:
-          BETTER_AUTH_SECRET: ci-test-secret-${{ matrix.architecture }}-not-for-production-use
+          BETTER_AUTH_SECRET: 903d44f75ea956577ae15335bbbef8532a867cdeae599cccac72357d40f14214
           DOCKER_SMOKE_COMPOSE_FILES: -f docker-compose.yml -f docker-compose.api-ci.yml
           DOCKER_SMOKE_SERVICE: api
 
@@ -298,4 +340,4 @@ jobs:
         if: always()
         run: docker compose -f docker-compose.yml -f docker-compose.api-ci.yml down -v
         env:
-          BETTER_AUTH_SECRET: ci-test-secret-${{ matrix.architecture }}-not-for-production-use
+          BETTER_AUTH_SECRET: 903d44f75ea956577ae15335bbbef8532a867cdeae599cccac72357d40f14214

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,8 @@ jobs:
           else
             docker compose -f docker-compose.yml logs
           fi
+        env:
+          BETTER_AUTH_SECRET: 903d44f75ea956577ae15335bbbef8532a867cdeae599cccac72357d40f14214
 
       - name: Tear down stack
         # Always run so containers never leak past the job, even on failure.
@@ -254,6 +256,8 @@ jobs:
           else
             docker compose -f docker-compose.yml down -v
           fi
+        env:
+          BETTER_AUTH_SECRET: 903d44f75ea956577ae15335bbbef8532a867cdeae599cccac72357d40f14214
 
   docker-api-native:
     strategy:
@@ -335,6 +339,8 @@ jobs:
       - name: Logs on failure
         if: failure()
         run: docker compose -f docker-compose.yml -f docker-compose.api-ci.yml logs api
+        env:
+          BETTER_AUTH_SECRET: 903d44f75ea956577ae15335bbbef8532a867cdeae599cccac72357d40f14214
 
       - name: Stop API containers
         if: always()

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -21,8 +21,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           config.model: 'openrouter/dots-studio/dots-3-note-preview:free'
           config.fallback_models: '["openrouter/nvidia/nemotron-3-ultra-550b-a55b:free"]'
-          OPENAI.KEY: ${{ secrets.OPENROUTER_REVIEW_KEY }}
-          config.openai_api_base: 'https://openrouter.ai/api/v1'
+          openrouter__key: ${{ secrets.OPENROUTER_REVIEW_KEY }}
           github_action_config.auto_review: 'true'
           github_action_config.auto_describe: 'true'
           github_action_config.auto_improve: 'true'

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -21,7 +21,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           config.model: 'openrouter/dots-studio/dots-3-note-preview:free'
           config.fallback_models: '["openrouter/nvidia/nemotron-3-ultra-550b-a55b:free"]'
-          config.custom_model_max_tokens: '65536'
+          config.custom_model_max_tokens: '524288'
           openrouter__key: ${{ secrets.OPENROUTER_REVIEW_KEY }}
           github_action_config.auto_review: 'true'
           github_action_config.auto_describe: 'true'

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -21,7 +21,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           config.model: 'openrouter/dots-studio/dots-3-note-preview:free'
           config.fallback_models: '["openrouter/nvidia/nemotron-3-ultra-550b-a55b:free"]'
-          openrouter__key: ${{ secrets.OPENROUTER_REVIEW_KEY }}
+          OPENROUTER__KEY: ${{ secrets.OPENROUTER_REVIEW_KEY }}
           github_action_config.auto_review: 'true'
           github_action_config.auto_describe: 'true'
           github_action_config.auto_improve: 'true'

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -21,7 +21,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           config.model: 'openrouter/dots-studio/dots-3-note-preview:free'
           config.fallback_models: '["openrouter/nvidia/nemotron-3-ultra-550b-a55b:free"]'
-          OPENROUTER__KEY: ${{ secrets.OPENROUTER_REVIEW_KEY }}
+          openrouter__key: ${{ secrets.OPENROUTER_REVIEW_KEY }}
           github_action_config.auto_review: 'true'
           github_action_config.auto_describe: 'true'
           github_action_config.auto_improve: 'true'

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -21,6 +21,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           config.model: 'openrouter/dots-studio/dots-3-note-preview:free'
           config.fallback_models: '["openrouter/nvidia/nemotron-3-ultra-550b-a55b:free"]'
+          config.custom_model_max_tokens: '65536'
           openrouter__key: ${{ secrets.OPENROUTER_REVIEW_KEY }}
           github_action_config.auto_review: 'true'
           github_action_config.auto_describe: 'true'

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -19,8 +19,8 @@ jobs:
         uses: the-pr-agent/pr-agent@v0.41.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          config.model: 'dots-studio/dots-3-note-preview:free'
-          config.fallback_models: '["nvidia/nemotron-3-ultra-550b-a55b:free"]'
+          config.model: 'openrouter/dots-studio/dots-3-note-preview:free'
+          config.fallback_models: '["openrouter/nvidia/nemotron-3-ultra-550b-a55b:free"]'
           OPENAI.KEY: ${{ secrets.OPENROUTER_REVIEW_KEY }}
           config.openai_api_base: 'https://openrouter.ai/api/v1'
           github_action_config.auto_review: 'true'

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -19,9 +19,10 @@ jobs:
         uses: the-pr-agent/pr-agent@v0.41.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          config.model: 'deepseek/deepseek-v4-flash'
-          config.fallback_models: '["deepseek/deepseek-v4-pro"]'
-          DEEPSEEK.KEY: ${{ secrets.REVIEW_API_KEY }}
+          config.model: 'dots-studio/dots-3-note-preview:free'
+          config.fallback_models: '["nvidia/nemotron-3-ultra-550b-a55b:free"]'
+          OPENAI.KEY: ${{ secrets.OPENROUTER_REVIEW_KEY }}
+          config.openai_api_base: 'https://openrouter.ai/api/v1'
           github_action_config.auto_review: 'true'
           github_action_config.auto_describe: 'true'
           github_action_config.auto_improve: 'true'

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -17,3 +17,9 @@ paths = [
   '''.*\.test\.ts$''',
   '''.*__tests__/.*''',
 ]
+# CI smoke-test secrets: the BETTER_AUTH_SECRET here is a well-known test-only
+# value used so the API can boot during Docker smoke tests. It is never used
+# for production signing.
+regexes = [
+  '''(?i)BETTER_AUTH_SECRET.*=.*[0-9a-f]{64}''',
+]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -21,5 +21,5 @@ paths = [
 # value used so the API can boot during Docker smoke tests. It is never used
 # for production signing.
 regexes = [
-  '''(?i)BETTER_AUTH_SECRET.*=.*[0-9a-f]{64}''',
+  '''903d44f75ea956577ae15335bbbef8532a867cdeae599cccac72357d40f14214''',
 ]

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,6 @@
+#!/bin/sh
+# Strip AI-agent attribution trailers (Co-authored-by: CommandCodeBot) that
+# tooling adds without consent. The git history should credit the author only.
+stripped=$(grep -v '^Co-authored-by: CommandCodeBot <noreply@commandcode.ai>$' "$1")
+printf '%s\n' "$stripped" > "$1"
 npx --no -- commitlint --edit "$1"

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -92,6 +92,7 @@ random generator rather than a hand-written value.
 | `DATABASE_URL` | `./apps/api/data/yotara.db` | SQLite path (inside container or volume) |
 | `APP_BASE_URL` | `http://localhost:8080/api` | Public URL for Better Auth callbacks |
 | `TRUSTED_ORIGINS` | `http://localhost:8080` | Allowed auth/CORS origins |
+| `TRUST_PROXY` | `172.16.0.0/12` in Compose | Trusted reverse-proxy IPs/CIDRs; unset for direct API access |
 | `PORT` | `3000` | API container port |
 | `CONTENT_SECURITY_POLICY` | *(see below)* | Override the CSP for both nginx and the API |
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -70,24 +70,46 @@ docker compose down
 ## Environment Variables
 
 `BETTER_AUTH_SECRET` is **required** — `docker compose config` fails with a clear error if
-it is unset, and the API refuses to boot with the old placeholder value. This secret signs
-session tokens; without a strong secret, an attacker can forge sessions for any account.
+it is unset, and the API refuses to boot with placeholders, plain-text passphrases,
+malformed values, or values representing fewer than 32 bytes. This secret signs session tokens; without a
+strong unique value, an attacker can forge sessions for any account.
 
 Generate it on every deploy and never commit a real value:
 
 ```bash
 export BETTER_AUTH_SECRET=$(openssl rand -base64 32)
+# Or: export BETTER_AUTH_SECRET=$(openssl rand -hex 32)
 docker compose up -d
 ```
 
+Production accepts canonical hex or Base64 representing at least 32 decoded random bytes.
+The validator cannot prove how a value was generated, so use a cryptographically secure
+random generator rather than a hand-written value.
+
 | Variable | Default / Req'd | Purpose |
 |:---|:---:|:---|
-| `BETTER_AUTH_SECRET` | **Required** | Session signing key (min 32 chars, use `openssl rand -base64 32`) |
+| `BETTER_AUTH_SECRET` | **Required** | Session signing key (canonical hex/Base64, at least 32 decoded bytes) |
 | `DATABASE_URL` | `./apps/api/data/yotara.db` | SQLite path (inside container or volume) |
 | `APP_BASE_URL` | `http://localhost:8080/api` | Public URL for Better Auth callbacks |
 | `TRUSTED_ORIGINS` | `http://localhost:8080` | Allowed auth/CORS origins |
 | `PORT` | `3000` | API container port |
 | `CONTENT_SECURITY_POLICY` | *(see below)* | Override the CSP for both nginx and the API |
+
+### Secret validation by environment
+
+- `NODE_ENV=production` (the Compose default): `BETTER_AUTH_SECRET` is mandatory and must
+  satisfy the generated hex/Base64 contract before the API serves traffic.
+- `NODE_ENV=development` or `test`: the API intentionally permits a missing secret for
+  local development and automated tests.
+- `DEV_MODE` is separate from secret validation. In production it requires the explicit
+  `ALLOW_DEV_MODE_IN_PRODUCTION=true` opt-in and disables several auth protections; do not
+  enable it on a public deployment.
+
+To verify the boot guard and valid-secret control:
+
+```bash
+pnpm --filter @yotara/api exec tsx --test src/lib/auth-secret.test.ts src/lib/security-audit.test.ts
+```
 
 ### Content-Security-Policy
 

--- a/PROJECT_README.md
+++ b/PROJECT_README.md
@@ -64,9 +64,12 @@ The Fastify API exposes:
 - `POST /auth/sign-in/email` — Sign in
 - `POST /auth/sign-out` — Sign out
 - `GET /auth/session` — Current session
+- `POST /auth/send-verification-email` — Resend verification email
+- `GET /config` — Runtime auth configuration
 - `GET /me` — Authenticated user profile
 - `PATCH /me` — Update user (display_name, timezone)
 - `PATCH /me/password` — Change password
+- `POST /me/password/set` — Set the initial password after verification
 - `GET /tasks` — List tasks (paginated, filterable by status, completion, overdue)
 - `GET /tasks/:id` — Get task
 - `POST /tasks` — Create task
@@ -139,7 +142,7 @@ The API uses SQLite through Drizzle and bootstraps the required tables automatic
 
 **Tables:**
 - Better Auth: `user`, `session`, `account`, `verification`
-- App: `projects`, `tasks`, `labels`, `task_labels`
+- App: `projects`, `tasks`, `labels`, `task_labels`, `email_sends`, `blocked_ips`
 
 Default local database path:
 
@@ -255,11 +258,13 @@ pnpm lint             # TypeScript compile check
 | `CORS_ORIGIN` | inherits trusted origins | Extra CORS origins |
 | `PORT` | `3000` | API port |
 | `HOST` | `0.0.0.0` | API bind host |
-| `NODE_ENV` | unset | Enables secure cookies in production |
-| `BETTER_AUTH_SECRET` | required | Session signing secret |
+| `NODE_ENV` | unset (`production` in Compose) | Enables secure cookies and secret validation in production |
+| `BETTER_AUTH_SECRET` | required in production | Canonical hex or Base64 session key representing at least 32 decoded bytes |
 
 Notes:
 - Better Auth secure cookies are enabled when `NODE_ENV=production` or `APP_BASE_URL` starts with `https://`.
+- In production, the API rejects missing, placeholder, plain-text passphrase, malformed, or undersized secrets before serving traffic.
+- Development and test environments intentionally allow a missing secret for local and CI flows; see [DOCKER.md](./DOCKER.md) for deployment requirements.
 - The API bootstraps the SQLite schema on startup.
 - If frontend and API run on different origins, update `APP_BASE_URL`, `TRUSTED_ORIGINS`, and `CORS_ORIGIN` together.
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ docker compose up --build -d
 # Open http://localhost:8080
 ```
 
-**`BETTER_AUTH_SECRET` is mandatory.** Compose fails fast with a clear error if it's unset, and the API refuses to boot with the old default placeholder. This key signs session tokens — without a strong secret, an attacker can forge sessions for any account. Set it on every deploy and never commit a real value.
+**`BETTER_AUTH_SECRET` is mandatory.** Compose fails fast if it's unset, and the API refuses to boot with placeholders, plain-text passphrases, malformed values, or values representing fewer than 32 decoded bytes. Generate a unique canonical hex or Base64 value with `openssl rand -hex 32` or `openssl rand -base64 32`; never commit a real value.
 
 The stack includes security hardening by default:
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -8,6 +8,10 @@ BETTER_AUTH_SECRET=
 # SQLite database file path for the API
 DATABASE_URL=./data/yotara.db
 
+# Public frontend URL used in verification email links. In production this defaults
+# to APP_BASE_URL with a trailing /api path removed; set this for split-origin deployments.
+# FRONTEND_BASE_URL=http://localhost:4200
+
 # API bind settings
 PORT=3000
 HOST=0.0.0.0

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,12 +1,29 @@
-# Secret used to sign session tokens (Better Auth). REQUIRED in production —
-# generate a strong unique value and keep it secret, e.g. `openssl rand -hex 32`
-# (pure hex, no special characters) or `openssl rand -base64 32`. Quote the value
-# and never commit a real secret. Using the default placeholder in production is a
-# critical security risk: session tokens become forgeable for any account.
+# Secret used to sign session tokens (Better Auth). REQUIRED in production.
+# Use a unique generated value representing at least 32 random bytes, e.g.
+# `openssl rand -hex 32` or `openssl rand -base64 32`. The API accepts canonical
+# hex or Base64 only; plain-text passphrases, placeholders, malformed values, and
+# whitespace are rejected. Quote the value and never commit a real secret.
 BETTER_AUTH_SECRET=
 
 # SQLite database file path for the API
 DATABASE_URL=./data/yotara.db
+
+# DEV MODE — the single switch for frictionless local/test development.
+#
+# `pnpm dev` sets DEV_MODE=true automatically; `pnpm dev:email` runs the full
+# email-first flow with real Resend emails. You can also flip it here or in
+# `apps/api/dev-mode.json` (env wins over the file).
+#
+# When on: email verification is forced off (requireEmailVerification=false),
+# emails are logged to the console instead of being sent (even with
+# RESEND_API_KEY set), and email rate limits, login lockout, and honeypot IP
+# bans are bypassed.
+#
+# In production (NODE_ENV=production) dev mode additionally requires
+# ALLOW_DEV_MODE_IN_PRODUCTION=true — a deliberate double opt-in for test
+# instances. Never enable either on a public production instance.
+# DEV_MODE=true
+# ALLOW_DEV_MODE_IN_PRODUCTION=true
 
 # Public frontend URL used in verification email links. In production this defaults
 # to APP_BASE_URL with a trailing /api path removed; set this for split-origin deployments.

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -29,6 +29,11 @@ DATABASE_URL=./data/yotara.db
 # to APP_BASE_URL with a trailing /api path removed; set this for split-origin deployments.
 # FRONTEND_BASE_URL=http://localhost:4200
 
+# Trusted reverse-proxy addresses or CIDRs, comma-separated. Leave unset when
+# accessing the API directly; the bundled Docker Compose stack sets its private
+# nginx network explicitly.
+# TRUST_PROXY=172.16.0.0/12
+
 # API bind settings
 PORT=3000
 HOST=0.0.0.0

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -50,12 +50,17 @@ RUN node -e "require('./apps/api/node_modules/better-sqlite3'); console.log('bet
 COPY --from=build /app/packages/shared/dist /app/packages/shared/dist
 COPY --from=build /app/apps/api/dist /app/apps/api/dist
 COPY --from=build /app/apps/api/drizzle /app/apps/api/drizzle
+# Dev-mode config (defaults to disabled in the image; override at runtime via
+# the DEV_MODE env var or a mounted file).
+COPY --from=build /app/apps/api/dev-mode.json /app/apps/api/dev-mode.json
 
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0
 ENV PORT=3000
 ENV DATABASE_URL=./apps/api/data/yotara.db
-ENV APP_BASE_URL=http://localhost:8080/api
+# No /api path: the frontend nginx strips the /api prefix before proxying, so
+# Better Auth must match /auth/* (its baseURL path must be empty).
+ENV APP_BASE_URL=http://localhost:8080
 ENV TRUSTED_ORIGINS=http://localhost:8080
 
 EXPOSE 3000

--- a/apps/api/dev-mode.json
+++ b/apps/api/dev-mode.json
@@ -1,0 +1,7 @@
+{
+  "enabled": false,
+  "emailToConsole": true,
+  "bypassEmailRateLimits": true,
+  "bypassLoginLockout": true,
+  "bypassIpBan": true
+}

--- a/apps/api/src/db/client.ts
+++ b/apps/api/src/db/client.ts
@@ -14,6 +14,7 @@ const SQLITE_BOOTSTRAP_SQL = `
     name TEXT NOT NULL,
     email TEXT NOT NULL,
     emailVerified INTEGER NOT NULL,
+    passwordSetupRequired INTEGER NOT NULL DEFAULT 0,
     image TEXT,
     workspaceMode TEXT,
     onboardingCompleted INTEGER NOT NULL DEFAULT 0,
@@ -435,6 +436,13 @@ function ensureSqliteSchema(sqlite: Database.Database): void {
       last_attempt_at INTEGER NOT NULL,
       PRIMARY KEY (ip, email)
     )`);
+    }
+
+    const userColumns = sqlite.prepare(`PRAGMA table_info('user')`).all() as Array<{
+      name: string;
+    }>;
+    if (!userColumns.some((column) => column.name === 'passwordSetupRequired')) {
+      sqlite.exec(`ALTER TABLE user ADD COLUMN passwordSetupRequired INTEGER NOT NULL DEFAULT 0`);
     }
 
     // 3g. Add ip column to email_sends for IP-based per-email rate limiting

--- a/apps/api/src/db/client.ts
+++ b/apps/api/src/db/client.ts
@@ -131,13 +131,19 @@ const SQLITE_BOOTSTRAP_SQL = `
   CREATE TABLE IF NOT EXISTS email_sends (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     email TEXT NOT NULL,
-    type TEXT NOT NULL CHECK(type IN ('signup', 'reset')),
+    type TEXT NOT NULL CHECK(type IN ('signup', 'reset', 'verify')),
     ip TEXT NOT NULL DEFAULT '',
     created_at INTEGER NOT NULL
   );
 
   CREATE INDEX IF NOT EXISTS idx_email_sends_email ON email_sends(email);
   CREATE INDEX IF NOT EXISTS idx_email_sends_created ON email_sends(created_at);
+
+  CREATE TABLE IF NOT EXISTS blocked_ips (
+    ip TEXT PRIMARY KEY NOT NULL,
+    blocked_until INTEGER NOT NULL,
+    created_at INTEGER NOT NULL
+  );
 
   CREATE TABLE IF NOT EXISTS notifications (
     id TEXT PRIMARY KEY NOT NULL,
@@ -440,6 +446,41 @@ function ensureSqliteSchema(sqlite: Database.Database): void {
     }
     // Create the index after the column exists (safe for fresh and migrated DBs)
     sqlite.exec(`CREATE INDEX IF NOT EXISTS idx_email_sends_ip ON email_sends(ip)`);
+
+    // The email_sends CHECK only allowed ('signup','reset') before the 'verify'
+    // resend type was added. SQLite can't alter a CHECK, so recreate the table
+    // when the constraint is outdated. The rows are transient rate-limit data,
+    // so dropping and recreating on upgrade is safe (matching the existing
+    // login_attempts migration pattern).
+    const emailSendCreateSql = sqlite
+      .prepare(`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'email_sends'`)
+      .get() as { sql: string } | undefined;
+    const hasVerifyType = emailSendCreateSql?.sql?.includes("'verify'") ?? false;
+    if (!hasVerifyType) {
+      sqlite.exec(`
+        ALTER TABLE email_sends RENAME TO email_sends_old;
+        CREATE TABLE email_sends (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          email TEXT NOT NULL,
+          type TEXT NOT NULL CHECK(type IN ('signup', 'reset', 'verify')),
+          ip TEXT NOT NULL DEFAULT '',
+          created_at INTEGER NOT NULL
+        );
+        INSERT INTO email_sends (id, email, type, ip, created_at)
+          SELECT id, email, type, ip, created_at FROM email_sends_old;
+        DROP TABLE email_sends_old;
+        CREATE INDEX IF NOT EXISTS idx_email_sends_email ON email_sends(email);
+        CREATE INDEX IF NOT EXISTS idx_email_sends_created ON email_sends(created_at);
+        CREATE INDEX IF NOT EXISTS idx_email_sends_ip ON email_sends(ip);
+      `);
+    }
+
+    // blocked_ips is created by the bootstrap SQL; ensure it exists on older DBs.
+    sqlite.exec(`CREATE TABLE IF NOT EXISTS blocked_ips (
+      ip TEXT PRIMARY KEY NOT NULL,
+      blocked_until INTEGER NOT NULL,
+      created_at INTEGER NOT NULL
+    )`);
 
     normalizeAppTimestampStorage(sqlite);
     sqlite.exec('COMMIT');

--- a/apps/api/src/db/login-attempts-migration.test.ts
+++ b/apps/api/src/db/login-attempts-migration.test.ts
@@ -62,6 +62,40 @@ test('legacy login_attempts table is migrated to composite (ip, email) key', () 
   }
 });
 
+test('legacy user table gains password setup flag', () => {
+  const dbFile = join(tmpdir(), `yotara-user-migration-${randomUUID()}.db`);
+  const legacy = new Database(dbFile);
+  legacy.exec(`
+    CREATE TABLE user (
+      id TEXT PRIMARY KEY NOT NULL,
+      name TEXT NOT NULL,
+      email TEXT NOT NULL,
+      emailVerified INTEGER NOT NULL,
+      image TEXT,
+      workspaceMode TEXT,
+      onboardingCompleted INTEGER NOT NULL DEFAULT 0,
+      archiveAutoDelete INTEGER NOT NULL DEFAULT 1,
+      captureBehavior TEXT NOT NULL DEFAULT 'quick',
+      createdAt INTEGER NOT NULL,
+      updatedAt INTEGER NOT NULL
+    )
+  `);
+  legacy.close();
+
+  const { sqlite } = createDbClient(dbFile);
+  try {
+    const columns = sqlite.prepare(`PRAGMA table_info('user')`).all() as Array<{
+      name: string;
+      dflt_value: string | null;
+    }>;
+    const passwordSetupColumn = columns.find((column) => column.name === 'passwordSetupRequired');
+    assert.equal(passwordSetupColumn?.dflt_value, '0');
+  } finally {
+    sqlite.close();
+    rmSync(dbFile, { force: true });
+  }
+});
+
 test('fresh database creates login_attempts with composite key', () => {
   const dbFile = join(tmpdir(), `yotara-login-attempts-fresh-${randomUUID()}.db`);
 
@@ -95,6 +129,14 @@ test('schema bootstrap wraps DDL in a transaction (7b)', () => {
     const tableNames = tables.map((t) => t.name);
 
     assert.ok(tableNames.includes('user'));
+    const userColumns = sqlite.prepare(`PRAGMA table_info('user')`).all() as Array<{
+      name: string;
+      dflt_value: string | null;
+    }>;
+    const passwordSetupColumn = userColumns.find(
+      (column) => column.name === 'passwordSetupRequired',
+    );
+    assert.equal(passwordSetupColumn?.dflt_value, '0');
     assert.ok(tableNames.includes('session'));
     assert.ok(tableNames.includes('account'));
     assert.ok(tableNames.includes('tasks'));

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -22,6 +22,9 @@ export const users = sqliteTable('user', {
   name: text('name').notNull(),
   email: text('email').notNull().unique(),
   emailVerified: integer('emailVerified', { mode: 'boolean' }).notNull(),
+  passwordSetupRequired: integer('passwordSetupRequired', { mode: 'boolean' })
+    .notNull()
+    .default(false),
   image: text('image'),
   workspaceMode: text('workspaceMode', { enum: ['personal', 'team'] }),
   onboardingCompleted: integer('onboardingCompleted', { mode: 'boolean' }).notNull().default(false),

--- a/apps/api/src/docs/openapi.ts
+++ b/apps/api/src/docs/openapi.ts
@@ -255,6 +255,7 @@ const appUserSchema = {
     'name',
     'image',
     'emailVerified',
+    'passwordSetupRequired',
     'workspaceMode',
     'onboardingCompleted',
     'archiveAutoDelete',
@@ -268,6 +269,7 @@ const appUserSchema = {
     name: { type: 'string' },
     image: { anyOf: [{ type: 'string', format: 'uri' }, { type: 'null' }] },
     emailVerified: { type: 'boolean' },
+    passwordSetupRequired: { type: 'boolean' },
     workspaceMode: {
       anyOf: [{ type: 'string', enum: ['personal', 'team'] }, { type: 'null' }],
     },

--- a/apps/api/src/lib/auth-origins.test.ts
+++ b/apps/api/src/lib/auth-origins.test.ts
@@ -4,6 +4,7 @@ import {
   getAppBaseUrl,
   getCorsOrigins,
   getFrontendBaseUrl,
+  getFrontendResetUrl,
   getFrontendVerificationUrl,
   getTrustedOrigins,
 } from './auth-origins.js';
@@ -44,6 +45,15 @@ test('auth origin helpers merge defaults with configured origins', () => {
       getFrontendVerificationUrl('https://api.example.com/verify-email?token=a%2Bb'),
       'https://frontend.example.com/verify-email?token=a%2Bb',
     );
+    // Reset links put the token in the URL path (Better Auth shape) and must
+    // be rewritten to a direct frontend link with the token in the query —
+    // never the API's redirect-based /auth/reset-password/<token> route.
+    assert.equal(
+      getFrontendResetUrl(
+        'https://api.example.com/auth/reset-password/abc123?callbackURL=https%3A%2F%2Ffrontend.example.com%2Freset-password',
+      ),
+      'https://frontend.example.com/reset-password?token=abc123',
+    );
 
     process.env['NODE_ENV'] = 'production';
     delete process.env['FRONTEND_BASE_URL'];
@@ -53,8 +63,16 @@ test('auth origin helpers merge defaults with configured origins', () => {
       getFrontendVerificationUrl('https://example.com/api/verify-email?token=abc'),
       'https://example.com/verify-email?token=abc',
     );
+    assert.equal(
+      getFrontendResetUrl('https://example.com/api/auth/reset-password/xyz?callbackURL='),
+      'https://example.com/reset-password?token=xyz',
+    );
     assert.throws(
       () => getFrontendVerificationUrl('https://example.com/api/verify-email'),
+      /missing its token/,
+    );
+    assert.throws(
+      () => getFrontendResetUrl('https://example.com/api/auth/reset-password?callbackURL=x'),
       /missing its token/,
     );
   } finally {

--- a/apps/api/src/lib/auth-origins.test.ts
+++ b/apps/api/src/lib/auth-origins.test.ts
@@ -1,6 +1,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { getAppBaseUrl, getCorsOrigins, getTrustedOrigins } from './auth-origins.js';
+import {
+  getAppBaseUrl,
+  getCorsOrigins,
+  getFrontendBaseUrl,
+  getFrontendVerificationUrl,
+  getTrustedOrigins,
+} from './auth-origins.js';
 
 test('auth origin helpers merge defaults with configured origins', () => {
   const previous = {
@@ -8,6 +14,7 @@ test('auth origin helpers merge defaults with configured origins', () => {
     APP_BASE_URL: process.env['APP_BASE_URL'],
     TRUSTED_ORIGINS: process.env['TRUSTED_ORIGINS'],
     CORS_ORIGIN: process.env['CORS_ORIGIN'],
+    FRONTEND_BASE_URL: process.env['FRONTEND_BASE_URL'],
   };
 
   try {
@@ -30,6 +37,26 @@ test('auth origin helpers merge defaults with configured origins', () => {
       'https://admin.example.com',
       'https://marketing.example.com',
     ]);
+
+    process.env['FRONTEND_BASE_URL'] = 'https://frontend.example.com/';
+    assert.equal(getFrontendBaseUrl(), 'https://frontend.example.com');
+    assert.equal(
+      getFrontendVerificationUrl('https://api.example.com/verify-email?token=a%2Bb'),
+      'https://frontend.example.com/verify-email?token=a%2Bb',
+    );
+
+    process.env['NODE_ENV'] = 'production';
+    delete process.env['FRONTEND_BASE_URL'];
+    process.env['APP_BASE_URL'] = 'https://example.com/api';
+    assert.equal(getFrontendBaseUrl(), 'https://example.com');
+    assert.equal(
+      getFrontendVerificationUrl('https://example.com/api/verify-email?token=abc'),
+      'https://example.com/verify-email?token=abc',
+    );
+    assert.throws(
+      () => getFrontendVerificationUrl('https://example.com/api/verify-email'),
+      /missing its token/,
+    );
   } finally {
     for (const [key, value] of Object.entries(previous)) {
       if (value === undefined) {

--- a/apps/api/src/lib/auth-origins.test.ts
+++ b/apps/api/src/lib/auth-origins.test.ts
@@ -7,7 +7,31 @@ import {
   getFrontendResetUrl,
   getFrontendVerificationUrl,
   getTrustedOrigins,
+  parseOriginList,
 } from './auth-origins.js';
+
+test('parseOriginList trims, filters empty and whitespace-only entries', () => {
+  assert.deepEqual(parseOriginList(undefined), []);
+  assert.deepEqual(parseOriginList(''), []);
+  assert.deepEqual(parseOriginList('   , , '), []);
+  assert.deepEqual(parseOriginList('https://a.com ,  ,https://b.com\t,'), [
+    'https://a.com',
+    'https://b.com',
+  ]);
+});
+
+test('parseOriginList passes malformed entries through unchanged', () => {
+  // Malformed values never match a real origin, so they are inert — pin that
+  // behavior rather than guessing at validation rules here.
+  assert.deepEqual(parseOriginList('http://[::1'), ['http://[::1']);
+  assert.deepEqual(parseOriginList('not a url'), ['not a url']);
+});
+
+test('parseOriginList refuses wildcard origins', () => {
+  assert.throws(() => parseOriginList('*'), /Wildcard origins are not allowed/);
+  assert.throws(() => parseOriginList('https://*.example.com'), /Wildcard origins are not allowed/);
+  assert.throws(() => parseOriginList('https://a.com, *'), /Wildcard origins are not allowed/);
+});
 
 test('auth origin helpers merge defaults with configured origins', () => {
   const previous = {

--- a/apps/api/src/lib/auth-origins.ts
+++ b/apps/api/src/lib/auth-origins.ts
@@ -1,10 +1,21 @@
-function parseOriginList(value: string | undefined) {
-  return (
+export function parseOriginList(value: string | undefined): string[] {
+  const origins =
     value
       ?.split(',')
       .map((origin) => origin.trim())
-      .filter(Boolean) ?? []
-  );
+      .filter(Boolean) ?? [];
+
+  // A wildcard origin (e.g. "*") makes origin checks match every site —
+  // effectively disabling CSRF/origin protection. Refuse it loudly at boot
+  // (this runs from auth module load) rather than silently weakening checks.
+  if (origins.some((origin) => origin.includes('*'))) {
+    throw new Error(
+      'Wildcard origins are not allowed ("*" would match every site and disable ' +
+        'origin checks). List explicit origins instead.',
+    );
+  }
+
+  return origins;
 }
 
 export function getAppBaseUrl() {

--- a/apps/api/src/lib/auth-origins.ts
+++ b/apps/api/src/lib/auth-origins.ts
@@ -11,6 +11,32 @@ export function getAppBaseUrl() {
   return process.env['APP_BASE_URL'] ?? 'http://localhost:3000';
 }
 
+export function getFrontendBaseUrl() {
+  const configuredUrl = process.env['FRONTEND_BASE_URL']?.trim();
+  if (configuredUrl) {
+    return configuredUrl.replace(/\/+$/, '');
+  }
+
+  if (process.env['NODE_ENV'] !== 'production') {
+    return 'http://localhost:4200';
+  }
+
+  const appUrl = new URL(getAppBaseUrl());
+  const frontendPath = appUrl.pathname.replace(/\/api\/?$/, '') || '/';
+  return `${appUrl.origin}${frontendPath}`.replace(/\/+$/, '');
+}
+
+export function getFrontendVerificationUrl(apiVerificationUrl: string) {
+  const token = new URL(apiVerificationUrl).searchParams.get('token');
+  if (!token) {
+    throw new Error('Better Auth verification URL is missing its token.');
+  }
+
+  const frontendUrl = new URL(`${getFrontendBaseUrl()}/verify-email`);
+  frontendUrl.searchParams.set('token', token);
+  return frontendUrl.toString();
+}
+
 export function getTrustedOrigins() {
   const configuredOrigins = parseOriginList(process.env['TRUSTED_ORIGINS']);
   const isProd = process.env['NODE_ENV'] === 'production';

--- a/apps/api/src/lib/auth-origins.ts
+++ b/apps/api/src/lib/auth-origins.ts
@@ -32,8 +32,36 @@ export function getFrontendVerificationUrl(apiVerificationUrl: string) {
     throw new Error('Better Auth verification URL is missing its token.');
   }
 
-  const frontendUrl = new URL(`${getFrontendBaseUrl()}/verify-email`);
-  frontendUrl.searchParams.set('token', token);
+  return buildFrontendUrl('/verify-email', { token });
+}
+
+/**
+ * Rewrite a Better Auth password-reset URL into a frontend URL the emailed
+ * link can point at directly.
+ *
+ * Better Auth builds reset links as `${baseURL}/reset-password/<token>?callbackURL=...`
+ * (token in the URL path, not the query) and only works when the browser
+ * round-trips through the API's GET callback route — which falls back to the
+ * bare `${baseURL}/error?error=INVALID_TOKEN` page whenever the callbackURL is
+ * empty. The frontend consumes the token from the query string instead, so
+ * rebuild the link as `${frontendBase}/reset-password?token=<token>`.
+ */
+export function getFrontendResetUrl(apiResetUrl: string) {
+  const pathSegments = new URL(apiResetUrl).pathname.split('/').filter(Boolean);
+  const resetIndex = pathSegments.lastIndexOf('reset-password');
+  const token = resetIndex !== -1 ? pathSegments[resetIndex + 1] : undefined;
+  if (!token) {
+    throw new Error('Better Auth reset URL is missing its token.');
+  }
+
+  return buildFrontendUrl('/reset-password', { token });
+}
+
+function buildFrontendUrl(path: string, params: Record<string, string>) {
+  const frontendUrl = new URL(`${getFrontendBaseUrl()}${path}`);
+  for (const [key, value] of Object.entries(params)) {
+    frontendUrl.searchParams.set(key, value);
+  }
   return frontendUrl.toString();
 }
 

--- a/apps/api/src/lib/auth-secret.test.ts
+++ b/apps/api/src/lib/auth-secret.test.ts
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  DEFAULT_AUTH_SECRET,
+  MIN_AUTH_SECRET_BYTES,
+  assertAuthSecretConfigured,
+  validateAuthSecret,
+} from './auth-secret.js';
+
+const HEX_SECRET = '903d44f75ea956577ae15335bbbef8532a867cdeae599cccac72357d40f14214';
+const BASE64_SECRET = 'w81gXgLNgJ/zOSM4bubuGh+CxPtHsCyvzTblRxR/WME=';
+const SEQUENTIAL_HEX_SECRET = '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f';
+const PASSPHRASE_SECRET = 'correct-horse-battery-staple-into-the-woods';
+
+function restoreEnvironment(previous: Record<string, string | undefined>): void {
+  for (const [key, value] of Object.entries(previous)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+test('validateAuthSecret accepts canonical generated secrets', () => {
+  assert.equal(validateAuthSecret(HEX_SECRET), null);
+  assert.equal(validateAuthSecret(BASE64_SECRET), null);
+});
+
+test('validateAuthSecret rejects missing, placeholder, and short secrets', () => {
+  assert.match(validateAuthSecret(undefined)!, /missing/);
+  assert.match(validateAuthSecret('')!, /missing/);
+  assert.match(validateAuthSecret(DEFAULT_AUTH_SECRET)!, /placeholder/);
+  assert.match(validateAuthSecret('short-secret')!, /canonical hex or Base64/);
+  assert.match(validateAuthSecret('00'.repeat(MIN_AUTH_SECRET_BYTES - 1))!, /32 random bytes/);
+});
+
+test('validateAuthSecret rejects malformed encodings and plain-text passphrases', () => {
+  const invalidSecrets = [
+    `${HEX_SECRET}0`,
+    `${BASE64_SECRET}A`,
+    BASE64_SECRET.slice(0, -1),
+    'not a generated secret with whitespace',
+    PASSPHRASE_SECRET,
+    'password-password-password-123456789',
+  ];
+
+  for (const secret of invalidSecrets) {
+    assert.match(
+      validateAuthSecret(secret)!,
+      /canonical hex or Base64|repeated or sequential pattern/,
+    );
+  }
+});
+
+test('validateAuthSecret rejects repeated and sequential generated-looking values', () => {
+  const invalidSecrets = [
+    '00'.repeat(MIN_AUTH_SECRET_BYTES),
+    'ab'.repeat(MIN_AUTH_SECRET_BYTES),
+    '0123456789abcdef'.repeat(4),
+    SEQUENTIAL_HEX_SECRET,
+    'abcdefghijklmnopqrstuvwxyz123456',
+  ];
+
+  for (const secret of invalidSecrets) {
+    assert.match(
+      validateAuthSecret(secret)!,
+      /repeated or sequential pattern|canonical hex or Base64/,
+    );
+  }
+});
+
+test('validateAuthSecret rejects whitespace and control characters', () => {
+  assert.match(validateAuthSecret(` ${HEX_SECRET}`)!, /canonical hex or Base64/);
+  assert.match(validateAuthSecret(`${HEX_SECRET}\n`)!, /canonical hex or Base64/);
+});
+
+test('assertAuthSecretConfigured enforces generated secrets outside development and test', () => {
+  const previous = {
+    NODE_ENV: process.env['NODE_ENV'],
+    BETTER_AUTH_SECRET: process.env['BETTER_AUTH_SECRET'],
+  };
+
+  try {
+    process.env['NODE_ENV'] = 'production';
+
+    delete process.env['BETTER_AUTH_SECRET'];
+    assert.throws(() => assertAuthSecretConfigured(), /missing/);
+
+    process.env['BETTER_AUTH_SECRET'] = DEFAULT_AUTH_SECRET;
+    assert.throws(() => assertAuthSecretConfigured(), /placeholder/);
+
+    process.env['BETTER_AUTH_SECRET'] = PASSPHRASE_SECRET;
+    assert.throws(() => assertAuthSecretConfigured(), /canonical hex or Base64/);
+
+    process.env['BETTER_AUTH_SECRET'] = BASE64_SECRET;
+    assert.doesNotThrow(() => assertAuthSecretConfigured());
+
+    process.env['BETTER_AUTH_SECRET'] = HEX_SECRET;
+    assert.doesNotThrow(() => assertAuthSecretConfigured('staging'));
+  } finally {
+    restoreEnvironment(previous);
+  }
+});
+
+test('assertAuthSecretConfigured exempts development and test', () => {
+  const previous = {
+    NODE_ENV: process.env['NODE_ENV'],
+    BETTER_AUTH_SECRET: process.env['BETTER_AUTH_SECRET'],
+  };
+
+  try {
+    delete process.env['BETTER_AUTH_SECRET'];
+
+    process.env['NODE_ENV'] = 'development';
+    assert.doesNotThrow(() => assertAuthSecretConfigured());
+
+    process.env['NODE_ENV'] = 'test';
+    assert.doesNotThrow(() => assertAuthSecretConfigured());
+  } finally {
+    restoreEnvironment(previous);
+  }
+});

--- a/apps/api/src/lib/auth-secret.ts
+++ b/apps/api/src/lib/auth-secret.ts
@@ -1,0 +1,88 @@
+/**
+ * BETTER_AUTH_SECRET validation shared by auth configuration and server bootstrap.
+ */
+
+export const DEFAULT_AUTH_SECRET = 'local-dev-secret-change-me';
+export const MIN_AUTH_SECRET_BYTES = 32;
+
+const REPEATED_PATTERN = /^(.{1,16})\1+$/;
+
+function decodeHex(secret: string): Uint8Array | null {
+  if (!/^[0-9a-f]+$/i.test(secret) || secret.length % 2 !== 0) {
+    return null;
+  }
+
+  const bytes = new Uint8Array(secret.length / 2);
+  for (let index = 0; index < secret.length; index += 2) {
+    bytes[index / 2] = Number.parseInt(secret.slice(index, index + 2), 16);
+  }
+  return bytes;
+}
+
+function decodeBase64(secret: string): Uint8Array | null {
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(secret) || secret.length % 4 !== 0) {
+    return null;
+  }
+
+  const padding = secret.endsWith('==') ? 2 : secret.endsWith('=') ? 1 : 0;
+  const contentLength = secret.length - padding;
+  const remainder = contentLength % 4;
+  if ((padding === 1 && remainder !== 3) || (padding === 2 && remainder !== 2)) {
+    return null;
+  }
+
+  const decoded = Buffer.from(secret, 'base64');
+  if (decoded.toString('base64') !== secret) {
+    return null;
+  }
+  return decoded;
+}
+
+function hasObviousByteStructure(bytes: Uint8Array): boolean {
+  const first = bytes[0];
+  if (bytes.every((byte) => byte === first)) {
+    return true;
+  }
+
+  return bytes.every((byte, index) => index === 0 || byte === (bytes[index - 1] + 1) % 256);
+}
+
+function decodeSecretCandidates(secret: string): Uint8Array[] {
+  return [decodeHex(secret), decodeBase64(secret)].filter(
+    (bytes): bytes is Uint8Array => bytes !== null,
+  );
+}
+
+/** Returns an error message when the secret is unacceptable, else null. */
+export function validateAuthSecret(secret: string | undefined): string | null {
+  if (!secret) {
+    return 'BETTER_AUTH_SECRET is missing';
+  }
+  if (secret === DEFAULT_AUTH_SECRET) {
+    return 'BETTER_AUTH_SECRET is still set to the default placeholder';
+  }
+
+  const candidates = decodeSecretCandidates(secret).filter(
+    (candidate) => candidate.length >= MIN_AUTH_SECRET_BYTES,
+  );
+  if (candidates.length === 0) {
+    return 'BETTER_AUTH_SECRET must be a canonical hex or Base64 value representing at least 32 random bytes — generate it with `openssl rand -base64 32` or `openssl rand -hex 32`';
+  }
+  if (REPEATED_PATTERN.test(secret) || candidates.some(hasObviousByteStructure)) {
+    return 'BETTER_AUTH_SECRET looks like a repeated or sequential pattern — generate it with `openssl rand -base64 32`';
+  }
+  return null;
+}
+
+/** Throw unless the environment is exempt or the secret is strong. */
+export function assertAuthSecretConfigured(
+  nodeEnv: string = process.env['NODE_ENV'] ?? 'development',
+): void {
+  if (nodeEnv === 'development' || nodeEnv === 'test') {
+    return;
+  }
+  const problem = validateAuthSecret(process.env['BETTER_AUTH_SECRET']);
+  if (problem) {
+    throw new Error(`Refusing to start: ${problem}.`);
+  }
+}

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -2,7 +2,12 @@ import { betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { db } from '../db/client.js';
 import { accounts, sessions, users, verifications } from '../db/schema.js';
-import { getAppBaseUrl, getFrontendVerificationUrl, getTrustedOrigins } from './auth-origins.js';
+import {
+  getAppBaseUrl,
+  getFrontendResetUrl,
+  getFrontendVerificationUrl,
+  getTrustedOrigins,
+} from './auth-origins.js';
 
 const appBaseUrl = getAppBaseUrl();
 const trustedOrigins = getTrustedOrigins();
@@ -91,7 +96,10 @@ export const auth = betterAuth({
     resetPasswordTokenExpiresIn: 3600, // 1 hour (matches email copy)
     sendResetPassword: async ({ user, url }) => {
       const { sendPasswordResetEmail } = await import('./email.js');
-      await sendPasswordResetEmail(user, url);
+      // The email must link straight to the frontend, not the API's
+      // redirect-based callback route (whose empty-callbackURL failure mode
+      // dead-ends on /auth/error?error=INVALID_TOKEN).
+      await sendPasswordResetEmail(user, getFrontendResetUrl(url));
     },
   },
   emailVerification: {

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -8,18 +8,20 @@ import {
   getFrontendVerificationUrl,
   getTrustedOrigins,
 } from './auth-origins.js';
+import { devMode } from './dev-mode.js';
+import { assertAuthSecretConfigured } from './auth-secret.js';
 
 const appBaseUrl = getAppBaseUrl();
 const trustedOrigins = getTrustedOrigins();
 const useSecureCookies =
   process.env['NODE_ENV'] === 'production' || appBaseUrl.startsWith('https://');
 
-const DEFAULT_AUTH_SECRET = 'local-dev-secret-change-me';
-
 /**
  * Whether email verification is required for sign-in.
  *
- * True in production, or in any env when REQUIRE_EMAIL_VERIFICATION=true (the
+ * Always false in dev mode (which flips the require-email flag and prevents
+ * email validation from impeding local/test work). Otherwise true in
+ * production, or in any env when REQUIRE_EMAIL_VERIFICATION=true (the
  * dev/test override so the email-first flow is testable locally). False
  * otherwise — dev/test default keeps registration frictionless.
  *
@@ -27,25 +29,12 @@ const DEFAULT_AUTH_SECRET = 'local-dev-secret-change-me';
  * exposed to the frontend, and the unverified-account cleanup all read it.
  */
 export function emailVerificationRequired(): boolean {
+  if (devMode()) {
+    return false;
+  }
   return (
     process.env['NODE_ENV'] === 'production' || process.env['REQUIRE_EMAIL_VERIFICATION'] === 'true'
   );
-}
-
-function assertAuthSecretConfigured(): void {
-  const secret = process.env['BETTER_AUTH_SECRET'];
-  const nodeEnv = process.env['NODE_ENV'] ?? 'development';
-  if (
-    nodeEnv !== 'development' &&
-    nodeEnv !== 'test' &&
-    (!secret || secret === DEFAULT_AUTH_SECRET)
-  ) {
-    throw new Error(
-      'Refusing to start: BETTER_AUTH_SECRET is missing or still set to the default ' +
-        'placeholder. Generate a strong, unique secret (e.g. `openssl rand -base64 32`) ' +
-        'and set it in production, otherwise session tokens are forgeable.',
-    );
-  }
 }
 
 // Evaluated at module load so the guard runs before the server serves traffic.

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -59,6 +59,30 @@ export const auth = betterAuth({
       verification: verifications,
     },
   }),
+  user: {
+    additionalFields: {
+      passwordSetupRequired: {
+        type: 'boolean',
+        required: false,
+        defaultValue: false,
+        returned: false,
+      },
+    },
+  },
+  databaseHooks: {
+    user: {
+      create: {
+        before: async (user, context) => {
+          if (
+            emailVerificationRequired() &&
+            context?.request?.url.includes('/auth/sign-up/email')
+          ) {
+            return { data: { ...user, passwordSetupRequired: true } };
+          }
+        },
+      },
+    },
+  },
   emailAndPassword: {
     enabled: true,
     requireEmailVerification: emailVerificationRequired(),

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -59,7 +59,7 @@ export const auth = betterAuth({
         type: 'boolean',
         required: false,
         defaultValue: false,
-        returned: false,
+        returned: true,
       },
     },
   },

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -2,7 +2,7 @@ import { betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { db } from '../db/client.js';
 import { accounts, sessions, users, verifications } from '../db/schema.js';
-import { getAppBaseUrl, getTrustedOrigins } from './auth-origins.js';
+import { getAppBaseUrl, getFrontendVerificationUrl, getTrustedOrigins } from './auth-origins.js';
 
 const appBaseUrl = getAppBaseUrl();
 const trustedOrigins = getTrustedOrigins();
@@ -79,7 +79,7 @@ export const auth = betterAuth({
     autoSignInAfterVerification: true,
     sendVerificationEmail: async ({ user, url }) => {
       const { sendVerificationEmail } = await import('./email.js');
-      await sendVerificationEmail(user, url);
+      await sendVerificationEmail(user, getFrontendVerificationUrl(url));
     },
   },
   advanced: {

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -11,6 +11,22 @@ const useSecureCookies =
 
 const DEFAULT_AUTH_SECRET = 'local-dev-secret-change-me';
 
+/**
+ * Whether email verification is required for sign-in.
+ *
+ * True in production, or in any env when REQUIRE_EMAIL_VERIFICATION=true (the
+ * dev/test override so the email-first flow is testable locally). False
+ * otherwise — dev/test default keeps registration frictionless.
+ *
+ * This is the single source of truth for gating: auth config, the runtime flag
+ * exposed to the frontend, and the unverified-account cleanup all read it.
+ */
+export function emailVerificationRequired(): boolean {
+  return (
+    process.env['NODE_ENV'] === 'production' || process.env['REQUIRE_EMAIL_VERIFICATION'] === 'true'
+  );
+}
+
 function assertAuthSecretConfigured(): void {
   const secret = process.env['BETTER_AUTH_SECRET'];
   const nodeEnv = process.env['NODE_ENV'] ?? 'development';
@@ -45,7 +61,7 @@ export const auth = betterAuth({
   }),
   emailAndPassword: {
     enabled: true,
-    requireEmailVerification: false,
+    requireEmailVerification: emailVerificationRequired(),
     minPasswordLength: 8,
     maxPasswordLength: 128,
     resetPasswordTokenExpiresIn: 3600, // 1 hour (matches email copy)
@@ -54,9 +70,13 @@ export const auth = betterAuth({
       await sendPasswordResetEmail(user, url);
     },
   },
-  // Wired up but dormant: requireEmailVerification is false above, so this
-  // callback will only fire when that flag is flipped to true.
   emailVerification: {
+    // 15-minute verification link (matches the email copy).
+    expiresIn: 900,
+    // Auto-create a session once the email link is clicked, so the user can
+    // set a real password immediately (the account starts with a throwaway
+    // placeholder password).
+    autoSignInAfterVerification: true,
     sendVerificationEmail: async ({ user, url }) => {
       const { sendVerificationEmail } = await import('./email.js');
       await sendVerificationEmail(user, url);

--- a/apps/api/src/lib/blocked-ips.ts
+++ b/apps/api/src/lib/blocked-ips.ts
@@ -1,4 +1,5 @@
 import { sqlite } from '../db/client.js';
+import { bypassIpBan } from './dev-mode.js';
 
 /** How long a honeypot-triggered IP stays banned (configurable via env). */
 export function getIpBanWindowMs(): number {
@@ -23,6 +24,12 @@ export function banIp(ip: string): void {
 
 /** Whether the given IP is currently banned (ban window has not elapsed). */
 export function isIpBanned(ip: string): boolean {
+  // Dev mode never enforces bans — a browser autofill tripping the honeypot
+  // must not lock a developer out of auth endpoints for 24h.
+  if (bypassIpBan()) {
+    return false;
+  }
+
   const row = sqlite.prepare(`SELECT blocked_until FROM blocked_ips WHERE ip = ?`).get(ip) as
     | { blocked_until: number }
     | undefined;

--- a/apps/api/src/lib/blocked-ips.ts
+++ b/apps/api/src/lib/blocked-ips.ts
@@ -1,0 +1,38 @@
+import { sqlite } from '../db/client.js';
+
+/** How long a honeypot-triggered IP stays banned (configurable via env). */
+export function getIpBanWindowMs(): number {
+  return Number(process.env['SIGNUP_IP_BAN_MS'] ?? 24 * 60 * 60 * 1000);
+}
+
+/**
+ * Record an IP as banned for the ban window. Called when the signup honeypot
+ * fires — no user is created and no email is sent, but the bot's IP is
+ * remembered so it cannot retry signup/verification endpoints.
+ */
+export function banIp(ip: string): void {
+  const blockedUntil = Date.now() + getIpBanWindowMs();
+  sqlite
+    .prepare(
+      `INSERT INTO blocked_ips (ip, blocked_until, created_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT(ip) DO UPDATE SET blocked_until = excluded.blocked_until`,
+    )
+    .run(ip, blockedUntil, Date.now());
+}
+
+/** Whether the given IP is currently banned (ban window has not elapsed). */
+export function isIpBanned(ip: string): boolean {
+  const row = sqlite.prepare(`SELECT blocked_until FROM blocked_ips WHERE ip = ?`).get(ip) as
+    | { blocked_until: number }
+    | undefined;
+  if (!row) {
+    return false;
+  }
+  if (row.blocked_until <= Date.now()) {
+    // Expired ban — clean it up lazily.
+    sqlite.prepare(`DELETE FROM blocked_ips WHERE ip = ?`).run(ip);
+    return false;
+  }
+  return true;
+}

--- a/apps/api/src/lib/dev-mode.test.ts
+++ b/apps/api/src/lib/dev-mode.test.ts
@@ -1,0 +1,157 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+// Ensure the SQLite singleton uses a shared temp DB before auth.js imports it.
+import '../db/test-db.js';
+
+import {
+  DEFAULT_DEV_MODE_CONFIG,
+  bypassEmailRateLimits,
+  bypassIpBan,
+  bypassLoginLockout,
+  devMode,
+  emailToConsole,
+  parseDevModeConfig,
+} from './dev-mode.js';
+
+test('parseDevModeConfig parses a full config', () => {
+  const config = parseDevModeConfig(
+    JSON.stringify({
+      enabled: true,
+      emailToConsole: false,
+      bypassEmailRateLimits: false,
+      bypassLoginLockout: false,
+      bypassIpBan: false,
+    }),
+  );
+  assert.deepEqual(config, {
+    enabled: true,
+    emailToConsole: false,
+    bypassEmailRateLimits: false,
+    bypassLoginLockout: false,
+    bypassIpBan: false,
+  });
+});
+
+test('parseDevModeConfig fills defaults for missing fields', () => {
+  assert.deepEqual(parseDevModeConfig('{}'), DEFAULT_DEV_MODE_CONFIG);
+  assert.deepEqual(parseDevModeConfig('{"enabled": true}'), {
+    ...DEFAULT_DEV_MODE_CONFIG,
+    enabled: true,
+  });
+});
+
+test('parseDevModeConfig rejects malformed input', () => {
+  assert.throws(() => parseDevModeConfig('not json'), /not valid JSON/);
+  assert.throws(() => parseDevModeConfig('[]'), /expected a JSON object/);
+  assert.throws(() => parseDevModeConfig('{"enabled": "yes"}'), /"enabled" must be a boolean/);
+});
+
+test('dev mode is off by default (committed dev-mode.json has enabled: false)', () => {
+  const previous = process.env['DEV_MODE'];
+  try {
+    delete process.env['DEV_MODE'];
+    assert.equal(devMode(), false);
+    assert.equal(emailToConsole(), false);
+    assert.equal(bypassEmailRateLimits(), false);
+    assert.equal(bypassLoginLockout(), false);
+    assert.equal(bypassIpBan(), false);
+  } finally {
+    if (previous === undefined) {
+      delete process.env['DEV_MODE'];
+    } else {
+      process.env['DEV_MODE'] = previous;
+    }
+  }
+});
+
+test('DEV_MODE env override wins over the file', () => {
+  const previous = process.env['DEV_MODE'];
+  try {
+    process.env['DEV_MODE'] = 'true';
+    assert.equal(devMode(), true);
+    // File options default to true, so all bypasses are active.
+    assert.equal(emailToConsole(), true);
+    assert.equal(bypassEmailRateLimits(), true);
+    assert.equal(bypassLoginLockout(), true);
+    assert.equal(bypassIpBan(), true);
+
+    process.env['DEV_MODE'] = 'false';
+    assert.equal(devMode(), false);
+    assert.equal(bypassEmailRateLimits(), false);
+  } finally {
+    if (previous === undefined) {
+      delete process.env['DEV_MODE'];
+    } else {
+      process.env['DEV_MODE'] = previous;
+    }
+  }
+});
+
+test('dev mode is refused in production without the explicit opt-in', () => {
+  const previous = {
+    NODE_ENV: process.env['NODE_ENV'],
+    DEV_MODE: process.env['DEV_MODE'],
+    ALLOW_DEV_MODE_IN_PRODUCTION: process.env['ALLOW_DEV_MODE_IN_PRODUCTION'],
+  };
+
+  try {
+    process.env['NODE_ENV'] = 'production';
+    process.env['DEV_MODE'] = 'true';
+
+    // Enabled dev mode in production without the override → refuse to start.
+    delete process.env['ALLOW_DEV_MODE_IN_PRODUCTION'];
+    assert.throws(() => devMode(), /ALLOW_DEV_MODE_IN_PRODUCTION/);
+
+    // With the explicit opt-in, dev mode is allowed (test instance).
+    process.env['ALLOW_DEV_MODE_IN_PRODUCTION'] = 'true';
+    assert.equal(devMode(), true);
+    assert.equal(bypassEmailRateLimits(), true);
+
+    // Explicitly disabled dev mode never throws, even in production.
+    process.env['DEV_MODE'] = 'false';
+    assert.equal(devMode(), false);
+
+    // Unset (file disabled by default) also never throws.
+    delete process.env['DEV_MODE'];
+    assert.equal(devMode(), false);
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+});
+
+test('dev mode forces email verification off even when REQUIRE_EMAIL_VERIFICATION is set', async () => {
+  const previous = {
+    NODE_ENV: process.env['NODE_ENV'],
+    DEV_MODE: process.env['DEV_MODE'],
+    REQUIRE_EMAIL_VERIFICATION: process.env['REQUIRE_EMAIL_VERIFICATION'],
+  };
+
+  try {
+    process.env['NODE_ENV'] = 'test';
+    process.env['REQUIRE_EMAIL_VERIFICATION'] = 'true';
+
+    // Without dev mode, the flag applies.
+    process.env['DEV_MODE'] = 'false';
+    const { emailVerificationRequired } = await import('./auth.js');
+    assert.equal(emailVerificationRequired(), true);
+
+    // With dev mode, verification is forced off.
+    process.env['DEV_MODE'] = 'true';
+    assert.equal(emailVerificationRequired(), false);
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+});

--- a/apps/api/src/lib/dev-mode.ts
+++ b/apps/api/src/lib/dev-mode.ts
@@ -1,0 +1,130 @@
+import { readFileSync } from 'node:fs';
+
+/**
+ * Dev mode — the single switch for frictionless local/test development.
+ *
+ * When enabled (via the `dev-mode.json` file and/or the `DEV_MODE` env var),
+ * email verification is forced off, emails go to the console instead of
+ * Resend, and the anti-abuse guards (email rate limits, login lockout, IP
+ * ban) are bypassed — so signup/login never impede local work.
+ *
+ * Precedence: the `DEV_MODE` env var (true/false) overrides the file's
+ * `enabled` field; the per-feature options always come from the file. The
+ * file is resolved relative to this module so it works in dev (`apps/api/`)
+ * and in the docker image (`/app/apps/api/`).
+ *
+ * Production safety: enabling dev mode under NODE_ENV=production requires the
+ * explicit `ALLOW_DEV_MODE_IN_PRODUCTION=true` opt-in; otherwise the server
+ * refuses to start (dev mode disables auth protections).
+ */
+
+export interface DevModeConfig {
+  /** Master switch: dev mode on/off. */
+  enabled: boolean;
+  /** Never send real email — log messages (with links) to the console. */
+  emailToConsole: boolean;
+  /** Skip the email send rate limits (per-type, hourly, per-IP caps). */
+  bypassEmailRateLimits: boolean;
+  /** Never lock an account after repeated failed sign-in attempts. */
+  bypassLoginLockout: boolean;
+  /** Do not enforce honeypot-triggered IP bans. */
+  bypassIpBan: boolean;
+}
+
+export const DEFAULT_DEV_MODE_CONFIG: DevModeConfig = {
+  enabled: false,
+  emailToConsole: true,
+  bypassEmailRateLimits: true,
+  bypassLoginLockout: true,
+  bypassIpBan: true,
+};
+
+/** Parse and validate the dev-mode config file. Throws on malformed input. */
+export function parseDevModeConfig(raw: string): DevModeConfig {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error('Invalid dev-mode.json: not valid JSON.');
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('Invalid dev-mode.json: expected a JSON object.');
+  }
+
+  const input = parsed as Record<string, unknown>;
+  const result: DevModeConfig = { ...DEFAULT_DEV_MODE_CONFIG };
+  for (const key of Object.keys(DEFAULT_DEV_MODE_CONFIG) as Array<keyof DevModeConfig>) {
+    const value = input[key];
+    if (value === undefined) {
+      continue;
+    }
+    if (typeof value !== 'boolean') {
+      throw new Error(`Invalid dev-mode.json: "${key}" must be a boolean.`);
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
+let cachedFileConfig: DevModeConfig | null = null;
+
+function fileConfig(): DevModeConfig {
+  if (cachedFileConfig) {
+    return cachedFileConfig;
+  }
+  try {
+    const file = new URL('../../dev-mode.json', import.meta.url);
+    cachedFileConfig = parseDevModeConfig(readFileSync(file, 'utf8'));
+  } catch {
+    // Missing or unreadable file → safe defaults (dev mode off).
+    cachedFileConfig = { ...DEFAULT_DEV_MODE_CONFIG };
+  }
+  return cachedFileConfig;
+}
+
+/** Whether dev mode is on: `DEV_MODE` env override, else the file's `enabled`. */
+export function devMode(): boolean {
+  const env = process.env['DEV_MODE'];
+  const enabled = env === 'true' ? true : env === 'false' ? false : fileConfig().enabled;
+  if (!enabled) {
+    return false;
+  }
+
+  // Dev mode disables production auth protections (verification, email
+  // sending, anti-abuse). In production it therefore requires an explicit,
+  // deliberate second opt-in so a misconfigured public instance fails loudly
+  // at boot instead of silently running unprotected.
+  if (
+    process.env['NODE_ENV'] === 'production' &&
+    process.env['ALLOW_DEV_MODE_IN_PRODUCTION'] !== 'true'
+  ) {
+    throw new Error(
+      'Refusing to start: dev mode is enabled but NODE_ENV=production. ' +
+        'Dev mode disables email verification, real email sending, and anti-abuse ' +
+        'guards. Set ALLOW_DEV_MODE_IN_PRODUCTION=true to confirm this is a test ' +
+        'instance, or disable dev mode.',
+    );
+  }
+
+  return true;
+}
+
+/** Emails must be logged to console (never sent via Resend) in dev mode. */
+export function emailToConsole(): boolean {
+  return devMode() && fileConfig().emailToConsole;
+}
+
+/** Email send rate limits are bypassed in dev mode. */
+export function bypassEmailRateLimits(): boolean {
+  return devMode() && fileConfig().bypassEmailRateLimits;
+}
+
+/** Login lockout is bypassed in dev mode. */
+export function bypassLoginLockout(): boolean {
+  return devMode() && fileConfig().bypassLoginLockout;
+}
+
+/** Honeypot IP bans are not enforced in dev mode. */
+export function bypassIpBan(): boolean {
+  return devMode() && fileConfig().bypassIpBan;
+}

--- a/apps/api/src/lib/email-cleanup.test.ts
+++ b/apps/api/src/lib/email-cleanup.test.ts
@@ -16,11 +16,11 @@ test('unverified account cleanup', async () => {
   try {
     const { sqlite } = await import('../db/client.js');
 
-    // Create users directly: one verified, one unverified old, one unverified new.
+    // Create users directly: one verified, one legacy unverified, one email-first pending, one email-first new.
     const now = Date.now();
     const insert = sqlite.prepare(
-      `INSERT INTO user (id, name, email, emailVerified, createdAt, updatedAt)
-       VALUES (?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO user (id, name, email, emailVerified, passwordSetupRequired, createdAt, updatedAt)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
     );
 
     insert.run(
@@ -28,21 +28,24 @@ test('unverified account cleanup', async () => {
       'Verified',
       `v-${randomUUID()}@test.com`,
       1,
-      now - 48 * 3600_000,
-      now,
-    );
-    insert.run(
-      `unverified-old-${randomUUID()}`,
-      'Old Unverified',
-      `o-${randomUUID()}@test.com`,
       0,
       now - 48 * 3600_000,
       now,
     );
-    // Track the old unverified user id + email to assert orphan cleanup.
+    // Legacy unverified user: passwordSetupRequired = 0 → must survive cleanup.
+    insert.run(
+      `legacy-unverified-${randomUUID()}`,
+      'Legacy Unverified',
+      `l-${randomUUID()}@test.com`,
+      0,
+      0,
+      now - 48 * 3600_000,
+      now,
+    );
+    // Email-first pending: passwordSetupRequired = 1, old → must be deleted.
     const staleId = `stale-${randomUUID()}`;
     const staleEmail = `stale-${randomUUID()}@test.com`;
-    insert.run(staleId, 'Stale', staleEmail, 0, now - 48 * 3600_000, now);
+    insert.run(staleId, 'Stale', staleEmail, 0, 1, now - 48 * 3600_000, now);
     // Orphan-prone related rows (NO ACTION FKs).
     sqlite
       .prepare(
@@ -68,11 +71,13 @@ test('unverified account cleanup', async () => {
         new Date(now).toISOString(),
         new Date(now).toISOString(),
       );
+    // New email-first pending: passwordSetupRequired = 1, recent → must survive.
     insert.run(
-      `unverified-new-${randomUUID()}`,
-      'New Unverified',
+      `new-pending-${randomUUID()}`,
+      'New Pending',
       `n-${randomUUID()}@test.com`,
       0,
+      1,
       now - 1 * 3600_000,
       now,
     );
@@ -94,11 +99,12 @@ test('unverified account cleanup', async () => {
       ).c;
     assert.equal(countUnverified(), 3, 'no users deleted when verification not required');
 
-    // With the override flag: only the old unverified accounts (2) are deleted.
+    // With the override flag: only the email-first pending account older than 24h is deleted.
+    // Legacy unverified (passwordSetupRequired = 0) and recent pending survive.
     process.env['REQUIRE_EMAIL_VERIFICATION'] = 'true';
     const deleted = cleanupUnverifiedAccounts();
-    assert.equal(deleted, 2, 'exactly two unverified accounts older than 24h deleted');
-    assert.equal(countUnverified(), 1, 'new unverified account survives');
+    assert.equal(deleted, 1, 'only the old email-first pending account is deleted');
+    assert.equal(countUnverified(), 2, 'legacy and recent pending accounts survive');
     assert.equal(countVerified(), 1, 'verified account survives');
 
     // Related rows (NO ACTION FKs) must be cleaned up, not orphaned.

--- a/apps/api/src/lib/email-cleanup.test.ts
+++ b/apps/api/src/lib/email-cleanup.test.ts
@@ -113,6 +113,13 @@ test('unverified account cleanup', async () => {
     assert.equal(count('projects', `owner_id = '${staleId}'`), 0, 'projects removed');
     assert.equal(count('verification', `identifier = '${staleEmail}'`), 0, 'verifications removed');
     assert.equal(count('user', `id = '${staleId}'`), 0, 'user removed');
+
+    // Job lifecycle: start runs once on boot, then on an interval; stop clears it.
+    const { startUnverifiedCleanupJob, stopUnverifiedCleanupJob } =
+      await import('./email-cleanup.js');
+    startUnverifiedCleanupJob(10_000); // long interval; boot run happens synchronously
+    startUnverifiedCleanupJob(10_000); // idempotent — no second timer
+    stopUnverifiedCleanupJob();
   } finally {
     delete process.env['DATABASE_URL'];
     if (previousEnv === undefined) {

--- a/apps/api/src/lib/email-cleanup.test.ts
+++ b/apps/api/src/lib/email-cleanup.test.ts
@@ -51,26 +51,26 @@ test('unverified account cleanup', async () => {
     // Default (no flag): verification not required → cleanup is a no-op.
     const { cleanupUnverifiedAccounts } = await import('./email-cleanup.js');
     assert.equal(cleanupUnverifiedAccounts(), 0);
-    assert.equal(
-      sqlite.prepare(`SELECT COUNT(*) AS c FROM user WHERE emailVerified = 0`).get()?.c,
-      2,
-      'no users deleted when verification not required',
-    );
+    const countUnverified = () =>
+      (
+        sqlite.prepare(`SELECT COUNT(*) AS c FROM user WHERE emailVerified = 0`).get() as {
+          c: number;
+        }
+      ).c;
+    const countVerified = () =>
+      (
+        sqlite.prepare(`SELECT COUNT(*) AS c FROM user WHERE emailVerified = 1`).get() as {
+          c: number;
+        }
+      ).c;
+    assert.equal(countUnverified(), 2, 'no users deleted when verification not required');
 
     // With the override flag: only the old unverified account is deleted.
     process.env['REQUIRE_EMAIL_VERIFICATION'] = 'true';
     const deleted = cleanupUnverifiedAccounts();
     assert.equal(deleted, 1, 'exactly one unverified account older than 24h deleted');
-    assert.equal(
-      sqlite.prepare(`SELECT COUNT(*) AS c FROM user WHERE emailVerified = 0`).get()?.c,
-      1,
-      'new unverified account survives',
-    );
-    assert.equal(
-      sqlite.prepare(`SELECT COUNT(*) AS c FROM user WHERE emailVerified = 1`).get()?.c,
-      1,
-      'verified account survives',
-    );
+    assert.equal(countUnverified(), 1, 'new unverified account survives');
+    assert.equal(countVerified(), 1, 'verified account survives');
   } finally {
     delete process.env['DATABASE_URL'];
     if (previousEnv === undefined) {

--- a/apps/api/src/lib/email-cleanup.test.ts
+++ b/apps/api/src/lib/email-cleanup.test.ts
@@ -1,0 +1,88 @@
+import { randomUUID } from 'node:crypto';
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+test('unverified account cleanup', async () => {
+  const dbFile = join(tmpdir(), `yotara-cleanup-test-${randomUUID()}.db`);
+  process.env['DATABASE_URL'] = dbFile;
+  const previousEnv = process.env['NODE_ENV'];
+  const previousFlag = process.env['REQUIRE_EMAIL_VERIFICATION'];
+  process.env['NODE_ENV'] = 'test';
+  delete process.env['REQUIRE_EMAIL_VERIFICATION'];
+
+  try {
+    const { sqlite } = await import('../db/client.js');
+
+    // Create users directly: one verified, one unverified old, one unverified new.
+    const now = Date.now();
+    const insert = sqlite.prepare(
+      `INSERT INTO user (id, name, email, emailVerified, createdAt, updatedAt)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    );
+
+    insert.run(
+      `verified-${randomUUID()}`,
+      'Verified',
+      `v-${randomUUID()}@test.com`,
+      1,
+      now - 48 * 3600_000,
+      now,
+    );
+    insert.run(
+      `unverified-old-${randomUUID()}`,
+      'Old Unverified',
+      `o-${randomUUID()}@test.com`,
+      0,
+      now - 48 * 3600_000,
+      now,
+    );
+    insert.run(
+      `unverified-new-${randomUUID()}`,
+      'New Unverified',
+      `n-${randomUUID()}@test.com`,
+      0,
+      now - 1 * 3600_000,
+      now,
+    );
+
+    // Default (no flag): verification not required → cleanup is a no-op.
+    const { cleanupUnverifiedAccounts } = await import('./email-cleanup.js');
+    assert.equal(cleanupUnverifiedAccounts(), 0);
+    assert.equal(
+      sqlite.prepare(`SELECT COUNT(*) AS c FROM user WHERE emailVerified = 0`).get()?.c,
+      2,
+      'no users deleted when verification not required',
+    );
+
+    // With the override flag: only the old unverified account is deleted.
+    process.env['REQUIRE_EMAIL_VERIFICATION'] = 'true';
+    const deleted = cleanupUnverifiedAccounts();
+    assert.equal(deleted, 1, 'exactly one unverified account older than 24h deleted');
+    assert.equal(
+      sqlite.prepare(`SELECT COUNT(*) AS c FROM user WHERE emailVerified = 0`).get()?.c,
+      1,
+      'new unverified account survives',
+    );
+    assert.equal(
+      sqlite.prepare(`SELECT COUNT(*) AS c FROM user WHERE emailVerified = 1`).get()?.c,
+      1,
+      'verified account survives',
+    );
+  } finally {
+    delete process.env['DATABASE_URL'];
+    if (previousEnv === undefined) {
+      delete process.env['NODE_ENV'];
+    } else {
+      process.env['NODE_ENV'] = previousEnv;
+    }
+    if (previousFlag === undefined) {
+      delete process.env['REQUIRE_EMAIL_VERIFICATION'];
+    } else {
+      process.env['REQUIRE_EMAIL_VERIFICATION'] = previousFlag;
+    }
+    rmSync(dbFile, { force: true });
+  }
+});

--- a/apps/api/src/lib/email-cleanup.test.ts
+++ b/apps/api/src/lib/email-cleanup.test.ts
@@ -39,6 +39,35 @@ test('unverified account cleanup', async () => {
       now - 48 * 3600_000,
       now,
     );
+    // Track the old unverified user id + email to assert orphan cleanup.
+    const staleId = `stale-${randomUUID()}`;
+    const staleEmail = `stale-${randomUUID()}@test.com`;
+    insert.run(staleId, 'Stale', staleEmail, 0, now - 48 * 3600_000, now);
+    // Orphan-prone related rows (NO ACTION FKs).
+    sqlite
+      .prepare(
+        `INSERT INTO session (id, userId, token, expiresAt, createdAt, updatedAt)
+                VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(`sess-${randomUUID()}`, staleId, 'tok', now + 3600_000, now, now);
+    sqlite
+      .prepare(
+        `INSERT INTO account (id, userId, accountId, providerId, createdAt, updatedAt)
+                VALUES (?, ?, ?, 'credential', ?, ?)`,
+      )
+      .run(`acct-${randomUUID()}`, staleId, staleId, now, now);
+    sqlite
+      .prepare(
+        `INSERT INTO projects (id, owner_id, name, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run(
+        `proj-${randomUUID()}`,
+        staleId,
+        'P',
+        new Date(now).toISOString(),
+        new Date(now).toISOString(),
+      );
     insert.run(
       `unverified-new-${randomUUID()}`,
       'New Unverified',
@@ -63,14 +92,27 @@ test('unverified account cleanup', async () => {
           c: number;
         }
       ).c;
-    assert.equal(countUnverified(), 2, 'no users deleted when verification not required');
+    assert.equal(countUnverified(), 3, 'no users deleted when verification not required');
 
-    // With the override flag: only the old unverified account is deleted.
+    // With the override flag: only the old unverified accounts (2) are deleted.
     process.env['REQUIRE_EMAIL_VERIFICATION'] = 'true';
     const deleted = cleanupUnverifiedAccounts();
-    assert.equal(deleted, 1, 'exactly one unverified account older than 24h deleted');
+    assert.equal(deleted, 2, 'exactly two unverified accounts older than 24h deleted');
     assert.equal(countUnverified(), 1, 'new unverified account survives');
     assert.equal(countVerified(), 1, 'verified account survives');
+
+    // Related rows (NO ACTION FKs) must be cleaned up, not orphaned.
+    const count = (table: string, where: string) =>
+      (
+        sqlite.prepare(`SELECT COUNT(*) AS c FROM ${table} WHERE ${where}`).get() as {
+          c: number;
+        }
+      ).c;
+    assert.equal(count('session', `userId = '${staleId}'`), 0, 'sessions removed');
+    assert.equal(count('account', `userId = '${staleId}'`), 0, 'accounts removed');
+    assert.equal(count('projects', `owner_id = '${staleId}'`), 0, 'projects removed');
+    assert.equal(count('verification', `identifier = '${staleEmail}'`), 0, 'verifications removed');
+    assert.equal(count('user', `id = '${staleId}'`), 0, 'user removed');
   } finally {
     delete process.env['DATABASE_URL'];
     if (previousEnv === undefined) {

--- a/apps/api/src/lib/email-cleanup.ts
+++ b/apps/api/src/lib/email-cleanup.ts
@@ -7,10 +7,13 @@ const UNVERIFIED_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 let cleanupTimer: ReturnType<typeof setInterval> | null = null;
 
 /**
- * Delete accounts that were created but never verified, once they are older
- * than 24h. Only runs when email verification is required (production, or the
- * REQUIRE_EMAIL_VERIFICATION dev/test override) — otherwise dev/test users who
- * registered without verification would be deleted.
+ * Delete email-first pending accounts that were created but never verified,
+ * once they are older than 24h. Only runs when email verification is required
+ * (production, or the REQUIRE_EMAIL_VERIFICATION dev/test override).
+ *
+ * The query targets only accounts marked by the email-first signup flow
+ * (passwordSetupRequired = 1). Legacy unverified accounts from before this
+ * flow are preserved to avoid data loss.
  *
  * The user row is deleted alongside its related rows. session/account/projects
  * use ON DELETE NO ACTION (see db/client.ts bootstrap), so they must be deleted
@@ -25,7 +28,9 @@ export function cleanupUnverifiedAccounts(): number {
 
   const cutoff = Date.now() - UNVERIFIED_TTL_MS;
   const staleUsers = sqlite
-    .prepare(`SELECT id, email FROM user WHERE emailVerified = 0 AND createdAt < ?`)
+    .prepare(
+      `SELECT id, email FROM user WHERE emailVerified = 0 AND passwordSetupRequired = 1 AND createdAt < ?`,
+    )
     .all(cutoff) as Array<{ id: string; email: string }>;
 
   if (staleUsers.length === 0) {

--- a/apps/api/src/lib/email-cleanup.ts
+++ b/apps/api/src/lib/email-cleanup.ts
@@ -1,0 +1,67 @@
+import { sqlite } from '../db/client.js';
+import { emailVerificationRequired } from './auth.js';
+
+const DEFAULT_CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // hourly
+const UNVERIFIED_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+let cleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Delete accounts that were created but never verified, once they are older
+ * than 24h. Only runs when email verification is required (production, or the
+ * REQUIRE_EMAIL_VERIFICATION dev/test override) — otherwise dev/test users who
+ * registered without verification would be deleted.
+ *
+ * Returns the number of accounts deleted (useful for tests).
+ */
+export function cleanupUnverifiedAccounts(): number {
+  if (!emailVerificationRequired()) {
+    return 0;
+  }
+
+  const cutoff = Date.now() - UNVERIFIED_TTL_MS;
+  const result = sqlite
+    .prepare(`DELETE FROM user WHERE emailVerified = 0 AND createdAt < ?`)
+    .run(cutoff);
+
+  // Related rows cascade via FK where configured; be explicit about the
+  // Better Auth tables that use NO ACTION, to avoid orphaned rows.
+  return result.changes;
+}
+
+/**
+ * Start the periodic cleanup job. Runs once on boot, then on the interval.
+ * No-op when verification is not required (dev/test default).
+ */
+export function startUnverifiedCleanupJob(intervalMs = DEFAULT_CLEANUP_INTERVAL_MS): void {
+  if (!emailVerificationRequired()) {
+    return;
+  }
+  if (cleanupTimer) {
+    return;
+  }
+
+  try {
+    cleanupUnverifiedAccounts();
+  } catch (error) {
+    console.error('[cleanup] Unverified account cleanup failed on boot:', error);
+  }
+
+  cleanupTimer = setInterval(() => {
+    try {
+      cleanupUnverifiedAccounts();
+    } catch (error) {
+      console.error('[cleanup] Unverified account cleanup failed:', error);
+    }
+  }, intervalMs);
+
+  // Don't keep the process alive just for the cleanup interval.
+  cleanupTimer.unref?.();
+}
+
+export function stopUnverifiedCleanupJob(): void {
+  if (cleanupTimer) {
+    clearInterval(cleanupTimer);
+    cleanupTimer = null;
+  }
+}

--- a/apps/api/src/lib/email-cleanup.ts
+++ b/apps/api/src/lib/email-cleanup.ts
@@ -12,6 +12,10 @@ let cleanupTimer: ReturnType<typeof setInterval> | null = null;
  * REQUIRE_EMAIL_VERIFICATION dev/test override) — otherwise dev/test users who
  * registered without verification would be deleted.
  *
+ * The user row is deleted alongside its related rows. session/account/projects
+ * use ON DELETE NO ACTION (see db/client.ts bootstrap), so they must be deleted
+ * explicitly to avoid orphaned rows.
+ *
  * Returns the number of accounts deleted (useful for tests).
  */
 export function cleanupUnverifiedAccounts(): number {
@@ -20,13 +24,40 @@ export function cleanupUnverifiedAccounts(): number {
   }
 
   const cutoff = Date.now() - UNVERIFIED_TTL_MS;
-  const result = sqlite
-    .prepare(`DELETE FROM user WHERE emailVerified = 0 AND createdAt < ?`)
-    .run(cutoff);
+  const staleUsers = sqlite
+    .prepare(`SELECT id, email FROM user WHERE emailVerified = 0 AND createdAt < ?`)
+    .all(cutoff) as Array<{ id: string; email: string }>;
 
-  // Related rows cascade via FK where configured; be explicit about the
-  // Better Auth tables that use NO ACTION, to avoid orphaned rows.
-  return result.changes;
+  if (staleUsers.length === 0) {
+    return 0;
+  }
+
+  const deleteSessions = sqlite.prepare(`DELETE FROM session WHERE userId = ?`);
+  const deleteAccounts = sqlite.prepare(`DELETE FROM account WHERE userId = ?`);
+  const deleteProjects = sqlite.prepare(`DELETE FROM projects WHERE owner_id = ?`);
+  const deleteVerifications = sqlite.prepare(`DELETE FROM verification WHERE identifier = ?`);
+  const deleteLoginAttempts = sqlite.prepare(`DELETE FROM login_attempts WHERE email = ?`);
+  const deleteEmailSends = sqlite.prepare(`DELETE FROM email_sends WHERE email = ?`);
+  const deleteUser = sqlite.prepare(`DELETE FROM user WHERE id = ?`);
+
+  sqlite.exec('BEGIN IMMEDIATE');
+  try {
+    for (const user of staleUsers) {
+      deleteSessions.run(user.id);
+      deleteAccounts.run(user.id);
+      deleteProjects.run(user.id);
+      deleteVerifications.run(user.email);
+      deleteLoginAttempts.run(user.email);
+      deleteEmailSends.run(user.email);
+      deleteUser.run(user.id);
+    }
+    sqlite.exec('COMMIT');
+  } catch (err) {
+    sqlite.exec('ROLLBACK');
+    throw err;
+  }
+
+  return staleUsers.length;
 }
 
 /**

--- a/apps/api/src/lib/email-rate-limit.ts
+++ b/apps/api/src/lib/email-rate-limit.ts
@@ -1,4 +1,5 @@
 import { sqlite } from '../db/client.js';
+import { bypassEmailRateLimits } from './dev-mode.js';
 
 export type EmailType = 'signup' | 'reset' | 'verify';
 
@@ -36,6 +37,12 @@ export function checkEmailRateLimit(
   type: EmailType,
   clientIp?: string,
 ): RateLimitResult {
+  // Dev mode bypasses rate limiting entirely so rapid local testing never
+  // hits 429s.
+  if (bypassEmailRateLimits()) {
+    return { allowed: true, retryAfterSeconds: null };
+  }
+
   // Scoped cleanup — only delete stale rows for this email to avoid
   // paying a full-table scan cost on every check.
   const cutoff = Date.now() - TOTAL_WINDOW_MS;
@@ -113,6 +120,9 @@ export function checkEmailRateLimit(
 
 /** Record a successful email send. */
 export function recordEmailSend(email: string, type: EmailType, clientIp?: string): void {
+  if (bypassEmailRateLimits()) {
+    return;
+  }
   sqlite
     .prepare(
       `INSERT INTO email_sends (email, type, ip, created_at)

--- a/apps/api/src/lib/email-rate-limit.ts
+++ b/apps/api/src/lib/email-rate-limit.ts
@@ -1,9 +1,14 @@
 import { sqlite } from '../db/client.js';
 
-export type EmailType = 'signup' | 'reset';
+export type EmailType = 'signup' | 'reset' | 'verify';
 
-/** Cooldown per type: 1 email of the same type per 5 minutes */
-const PER_TYPE_WINDOW_MS = 5 * 60 * 1000;
+/** Cooldown per type. 'verify' (verification email resends) is 30 min; the
+ *  signup and reset emails keep the original 5-minute window. */
+const PER_TYPE_WINDOW_MS: Record<EmailType, number> = {
+  signup: 5 * 60 * 1000,
+  reset: 5 * 60 * 1000,
+  verify: 30 * 60 * 1000,
+};
 
 /** Total cap: 3 emails of any type per 1 hour */
 const TOTAL_WINDOW_MS = 60 * 60 * 1000;
@@ -37,9 +42,11 @@ export function checkEmailRateLimit(
   sqlite.prepare('DELETE FROM email_sends WHERE email = ? AND created_at < ?').run(email, cutoff);
 
   const now = Date.now();
-  const perTypeCutoff = now - PER_TYPE_WINDOW_MS;
+  const perTypeWindow = PER_TYPE_WINDOW_MS[type];
+  const perTypeCutoff = now - perTypeWindow;
 
-  // Check 1: same type in last 5 minutes
+  // Check 1: same type in the per-type window (5 min for signup/reset, 30 min
+  // for verify resends)
   const sameTypeRow = sqlite
     .prepare(
       `SELECT COUNT(*) AS cnt FROM email_sends
@@ -57,8 +64,8 @@ export function checkEmailRateLimit(
       .get(email, type) as { last_ts: number | null };
 
     const retryAfter = lastSend.last_ts
-      ? Math.ceil((lastSend.last_ts + PER_TYPE_WINDOW_MS - now) / 1000)
-      : PER_TYPE_WINDOW_MS / 1000;
+      ? Math.ceil((lastSend.last_ts + perTypeWindow - now) / 1000)
+      : perTypeWindow / 1000;
 
     return { allowed: false, retryAfterSeconds: Math.max(1, retryAfter) };
   }

--- a/apps/api/src/lib/email.test.ts
+++ b/apps/api/src/lib/email.test.ts
@@ -118,6 +118,25 @@ test('email module', async (t) => {
       assert.doesNotThrow(() => checkRateLimitOrThrow(freshEmail, 'reset'));
     });
 
+    await t.test('verify resend type enforces a 30-minute cooldown', async () => {
+      const { checkRateLimitOrThrow } = await import('./email.js');
+      const { recordEmailSend } = await import('./email-rate-limit.js');
+
+      const verifyEmail = `verify-${randomUUID()}@test.com`;
+      recordEmailSend(verifyEmail, 'verify');
+
+      assert.throws(
+        () => checkRateLimitOrThrow(verifyEmail, 'verify'),
+        (err: Error & { statusCode?: number; retryAfterSeconds?: number }) => {
+          assert.equal(err.statusCode, 429);
+          assert.equal(err.message.includes('Too many verify requests'), true);
+          // 30-minute window: retry after should be > 25 minutes (1500s).
+          assert.ok(err.retryAfterSeconds! > 1500, 'verify cooldown should be ~30 min');
+          return true;
+        },
+      );
+    });
+
     await t.test('checkRateLimitOrThrow includes retry minutes in message', async () => {
       const { checkRateLimitOrThrow } = await import('./email.js');
       const { recordEmailSend } = await import('./email-rate-limit.js');

--- a/apps/api/src/lib/email.test.ts
+++ b/apps/api/src/lib/email.test.ts
@@ -190,6 +190,95 @@ test('email module', async (t) => {
         }
       }
     });
+    await t.test('production with dev mode enabled does not fail loud', async () => {
+      const previousNodeEnv = process.env['NODE_ENV'];
+      const previousApiKey = process.env['RESEND_API_KEY'];
+      const previousDevMode = process.env['DEV_MODE'];
+      const previousAllow = process.env['ALLOW_DEV_MODE_IN_PRODUCTION'];
+
+      process.env['NODE_ENV'] = 'production';
+      process.env['DEV_MODE'] = 'true';
+      delete process.env['RESEND_API_KEY'];
+
+      try {
+        // Without the explicit production opt-in, dev mode refuses to start.
+        delete process.env['ALLOW_DEV_MODE_IN_PRODUCTION'];
+        await assert.rejects(
+          () => import(`./email.js?prod-refuse=${Date.now()}`),
+          /ALLOW_DEV_MODE_IN_PRODUCTION/,
+        );
+
+        // With the opt-in (a test instance), the console fallback is allowed
+        // at module load — no startup failure.
+        process.env['ALLOW_DEV_MODE_IN_PRODUCTION'] = 'true';
+        const mod = await import(`./email.js?devmode=${Date.now()}`);
+        assert.equal(typeof mod.sendPasswordResetEmail, 'function');
+      } finally {
+        if (previousNodeEnv === undefined) {
+          delete process.env['NODE_ENV'];
+        } else {
+          process.env['NODE_ENV'] = previousNodeEnv;
+        }
+        if (previousApiKey === undefined) {
+          delete process.env['RESEND_API_KEY'];
+        } else {
+          process.env['RESEND_API_KEY'] = previousApiKey;
+        }
+        if (previousDevMode === undefined) {
+          delete process.env['DEV_MODE'];
+        } else {
+          process.env['DEV_MODE'] = previousDevMode;
+        }
+        if (previousAllow === undefined) {
+          delete process.env['ALLOW_DEV_MODE_IN_PRODUCTION'];
+        } else {
+          process.env['ALLOW_DEV_MODE_IN_PRODUCTION'] = previousAllow;
+        }
+      }
+    });
+    await t.test('dev mode logs emails to console even with RESEND_API_KEY set', async () => {
+      const previousDevMode = process.env['DEV_MODE'];
+      const previousApiKey = process.env['RESEND_API_KEY'];
+      const logs: string[] = [];
+      mock.method(console, 'log', (msg: string) => {
+        if (typeof msg === 'string' && msg.startsWith('[email]')) logs.push(msg);
+      });
+
+      try {
+        process.env['DEV_MODE'] = 'true';
+        process.env['RESEND_API_KEY'] = 're_test_key';
+
+        const { getResend, sendPasswordResetEmail } = await import('./email.js');
+        // Dev mode forces console emailing — Resend is never used, so a
+        // configured key cannot spam real inboxes during local testing.
+        assert.equal(getResend(), null);
+
+        await sendPasswordResetEmail(
+          { email: `devmode-${randomUUID()}@test.com`, name: 'Dev User' },
+          'https://example.com/reset?token=devmode',
+        );
+        assert.ok(
+          logs.some((l) => l.includes('reset?token=devmode')),
+          'email body is logged to console in dev mode',
+        );
+
+        // With dev mode off, the configured key is honored again.
+        delete process.env['DEV_MODE'];
+        assert.notEqual(getResend(), null, 'RESEND_API_KEY is honored outside dev mode');
+      } finally {
+        if (previousDevMode === undefined) {
+          delete process.env['DEV_MODE'];
+        } else {
+          process.env['DEV_MODE'] = previousDevMode;
+        }
+        if (previousApiKey === undefined) {
+          delete process.env['RESEND_API_KEY'];
+        } else {
+          process.env['RESEND_API_KEY'] = previousApiKey;
+        }
+        mock.restoreAll();
+      }
+    });
   } finally {
     delete process.env['DATABASE_URL'];
     mock.restoreAll();

--- a/apps/api/src/lib/email.test.ts
+++ b/apps/api/src/lib/email.test.ts
@@ -133,6 +133,44 @@ test('email module', async (t) => {
         },
       );
     });
+    await t.test('escapeHtml and escapeAttribute neutralize injection', async () => {
+      const { escapeHtml, escapeAttribute } = await import('./email.js');
+      const name = '<script>alert("x")</script>';
+      assert.equal(escapeHtml(name), '&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;');
+      const url = 'https://example.com/verify?token=abc&x=" onmouseover="alert(1)';
+      assert.equal(
+        escapeAttribute(url),
+        'https://example.com/verify?token=abc&amp;x=&quot; onmouseover=&quot;alert(1)',
+      );
+    });
+
+    await t.test('production with no RESEND_API_KEY fails loudly', async () => {
+      const previousNodeEnv = process.env['NODE_ENV'];
+      const previousApiKey = process.env['RESEND_API_KEY'];
+
+      process.env['NODE_ENV'] = 'production';
+      delete process.env['RESEND_API_KEY'];
+
+      try {
+        // Module-level assertEmailConfigured runs on import; use dynamic import
+        // after clearing any cached instance via a fresh query string.
+        await assert.rejects(
+          () => import(`./email.js?fail=${Date.now()}`),
+          /RESEND_API_KEY must be set in production/,
+        );
+      } finally {
+        if (previousNodeEnv === undefined) {
+          delete process.env['NODE_ENV'];
+        } else {
+          process.env['NODE_ENV'] = previousNodeEnv;
+        }
+        if (previousApiKey === undefined) {
+          delete process.env['RESEND_API_KEY'];
+        } else {
+          process.env['RESEND_API_KEY'] = previousApiKey;
+        }
+      }
+    });
   } finally {
     delete process.env['DATABASE_URL'];
     mock.restoreAll();

--- a/apps/api/src/lib/email.ts
+++ b/apps/api/src/lib/email.ts
@@ -2,11 +2,48 @@ import { Resend } from 'resend';
 import { checkEmailRateLimit, type EmailType } from './email-rate-limit.js';
 
 const RESEND_API_KEY = process.env['RESEND_API_KEY'] ?? '';
-const EMAIL_FROM = process.env['EMAIL_FROM'] ?? 'noreply@yotara.app';
+const EMAIL_FROM = process.env['EMAIL_FROM'] ?? 'noreply@email.yotara.website';
 const APP_NAME = 'Yotara';
+const NODE_ENV = process.env['NODE_ENV'] ?? 'development';
 
-if (!RESEND_API_KEY) {
-  console.log('[email] No RESEND_API_KEY set — emails will be logged to console');
+/**
+ * Console fallback (logging the email body, which contains the verification or
+ * reset link) is only permitted in development or test. In production, sending
+ * an email with no provider configured must fail loudly — never silently leak
+ * a reset/verification link into the container logs.
+ */
+const consoleFallbackAllowed = NODE_ENV === 'development' || NODE_ENV === 'test';
+
+function assertEmailConfigured(): void {
+  if (!RESEND_API_KEY && !consoleFallbackAllowed) {
+    throw new Error(
+      'RESEND_API_KEY must be set in production: email verification and password ' +
+        'reset depend on it, and emails must never be logged to the console outside ' +
+        'development/test.',
+    );
+  }
+}
+
+// Evaluated at module load so a misconfigured production deployment fails fast.
+assertEmailConfigured();
+
+export function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+/** Attribute-escape a URL for use inside an href value. */
+export function escapeAttribute(value: string): string {
+  // HTML attribute context: escape quotes, angle brackets, and ampersands.
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll("'", '&#39;');
 }
 
 export function getResend(): Resend | null {
@@ -23,7 +60,8 @@ async function sendEmail(payload: {
   const resend = getResend();
 
   if (!resend) {
-    // Dev mode fallback — log instead of sending
+    // Dev/test only fallback — log instead of sending. Production is blocked
+    // by assertEmailConfigured() above.
     console.log(`[email] To: ${payload.to}`);
     console.log(`[email] Subject: ${payload.subject}`);
     console.log(`[email] Body:\n${payload.text}`);
@@ -61,35 +99,41 @@ export function checkRateLimitOrThrow(email: string, type: EmailType, clientIp?:
 }
 
 export async function sendVerificationEmail(user: { email: string; name: string }, url: string) {
+  const displayName = user.name || 'there';
+  const safeName = escapeHtml(displayName);
+  const safeUrl = escapeAttribute(url);
   await sendEmail({
     to: user.email,
     subject: `Verify your ${APP_NAME} account`,
-    text: `Hi ${user.name || 'there'},
+    text: `Hi ${displayName},
 
 Thanks for signing up for ${APP_NAME}!
 
 Click the link below to verify your email address:
 ${url}
 
-This link will expire in 1 hour.
+This link will expire in 15 minutes.
 
 If you didn't create an account, you can safely ignore this email.
 
 — The ${APP_NAME} Team`,
-    html: `<p>Hi ${user.name || 'there'},</p>
+    html: `<p>Hi ${safeName},</p>
 <p>Thanks for signing up for <strong>${APP_NAME}</strong>!</p>
-<p><a href="${url}">Click here to verify your email address</a></p>
-<p>This link will expire in 1 hour.</p>
+<p><a href="${safeUrl}">Click here to verify your email address</a></p>
+<p>This link will expire in 15 minutes.</p>
 <p>If you didn't create an account, you can safely ignore this email.</p>
 <p>— The ${APP_NAME} Team</p>`,
   });
 }
 
 export async function sendPasswordResetEmail(user: { email: string; name: string }, url: string) {
+  const displayName = user.name || 'there';
+  const safeName = escapeHtml(displayName);
+  const safeUrl = escapeAttribute(url);
   await sendEmail({
     to: user.email,
     subject: `Reset your ${APP_NAME} password`,
-    text: `Hi ${user.name || 'there'},
+    text: `Hi ${displayName},
 
 You requested a password reset for your ${APP_NAME} account.
 
@@ -101,9 +145,9 @@ This link will expire in 1 hour.
 If you didn't request this, you can safely ignore this email.
 
 — The ${APP_NAME} Team`,
-    html: `<p>Hi ${user.name || 'there'},</p>
+    html: `<p>Hi ${safeName},</p>
 <p>You requested a password reset for your <strong>${APP_NAME}</strong> account.</p>
-<p><a href="${url}">Click here to reset your password</a></p>
+<p><a href="${safeUrl}">Click here to reset your password</a></p>
 <p>This link will expire in 1 hour.</p>
 <p>If you didn't request this, you can safely ignore this email.</p>
 <p>— The ${APP_NAME} Team</p>`,

--- a/apps/api/src/lib/email.ts
+++ b/apps/api/src/lib/email.ts
@@ -1,5 +1,6 @@
 import { Resend } from 'resend';
 import { checkEmailRateLimit, type EmailType } from './email-rate-limit.js';
+import { emailToConsole } from './dev-mode.js';
 
 const RESEND_API_KEY = process.env['RESEND_API_KEY'] ?? '';
 const EMAIL_FROM = process.env['EMAIL_FROM'] ?? 'noreply@email.yotara.website';
@@ -8,11 +9,13 @@ const NODE_ENV = process.env['NODE_ENV'] ?? 'development';
 
 /**
  * Console fallback (logging the email body, which contains the verification or
- * reset link) is only permitted in development or test. In production, sending
- * an email with no provider configured must fail loudly — never silently leak
- * a reset/verification link into the container logs.
+ * reset link) is permitted in development/test, or whenever dev mode asks for
+ * console emailing. In production, sending an email with no provider
+ * configured must fail loudly — never silently leak a reset/verification link
+ * into the container logs.
  */
-const consoleFallbackAllowed = NODE_ENV === 'development' || NODE_ENV === 'test';
+const consoleFallbackAllowed =
+  NODE_ENV === 'development' || NODE_ENV === 'test' || emailToConsole();
 
 function assertEmailConfigured(): void {
   if (!RESEND_API_KEY && !consoleFallbackAllowed) {
@@ -47,8 +50,17 @@ export function escapeAttribute(value: string): string {
 }
 
 export function getResend(): Resend | null {
-  if (!RESEND_API_KEY) return null;
-  return new Resend(RESEND_API_KEY);
+  // Dev mode with emailToConsole never sends real email — a configured
+  // RESEND_API_KEY is deliberately ignored so local/test runs can't spam
+  // real inboxes (the links are logged to the console instead).
+  if (emailToConsole()) {
+    return null;
+  }
+  const key = process.env['RESEND_API_KEY'] ?? '';
+  if (!key) {
+    return null;
+  }
+  return new Resend(key);
 }
 
 async function sendEmail(payload: {

--- a/apps/api/src/lib/login-lockout.ts
+++ b/apps/api/src/lib/login-lockout.ts
@@ -1,4 +1,5 @@
 import { sqlite } from '../db/client.js';
+import { bypassLoginLockout } from './dev-mode.js';
 
 interface LockoutConfig {
   attempts?: number;
@@ -20,6 +21,11 @@ export function getLockoutMinutes(): number {
 }
 
 export function getRemainingLockoutSeconds(ip: string, email: string): number {
+  // Dev mode never locks accounts — failed sign-ins must not impede local work.
+  if (bypassLoginLockout()) {
+    return 0;
+  }
+
   // Clean up any expired lockouts before checking
   cleanExpiredLockouts();
 
@@ -53,6 +59,12 @@ export function recordFailedAttempt(
   remainingLockoutSeconds: number;
   remainingAttempts: number;
 } {
+  // Dev mode: never record attempts or lock — the bridge also returns a
+  // plain 401, so no lockout messaging leaks into the UI.
+  if (bypassLoginLockout()) {
+    return { locked: false, remainingLockoutSeconds: 0, remainingAttempts: 0 };
+  }
+
   // Don't extend an active lockout — return immediately if already locked
   const alreadyLockedSeconds = getRemainingLockoutSeconds(ip, email);
   if (alreadyLockedSeconds > 0) {

--- a/apps/api/src/lib/public-user.ts
+++ b/apps/api/src/lib/public-user.ts
@@ -7,6 +7,7 @@ export type PublicUser = {
   name: string;
   image: string | null;
   emailVerified: boolean;
+  passwordSetupRequired: boolean;
   workspaceMode: 'personal' | 'team' | null;
   onboardingCompleted: boolean;
   archiveAutoDelete: boolean;
@@ -22,6 +23,7 @@ export function toPublicUser(user: typeof users.$inferSelect): PublicUser {
     name: user.name,
     image: user.image,
     emailVerified: user.emailVerified,
+    passwordSetupRequired: user.passwordSetupRequired,
     workspaceMode: user.workspaceMode,
     onboardingCompleted: user.onboardingCompleted,
     archiveAutoDelete: user.archiveAutoDelete,

--- a/apps/api/src/lib/security-audit.test.ts
+++ b/apps/api/src/lib/security-audit.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { spawn } from 'node:child_process';
+import { createServer } from 'node:net';
 import { rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -37,10 +38,17 @@ async function createTestApp() {
 // Spawn the real server entry point and assert it refuses to start with a
 // default/placeholder BETTER_AUTH_SECRET in production. Runs out-of-process so
 // the auth module cache is isolated from the other tests.
+type BootResult = {
+  code: number | null;
+  stderr: string;
+  timedOut: boolean;
+};
+
 function bootServer(
   execArgv: string[],
   env: NodeJS.ProcessEnv,
-): Promise<{ code: number | null; stderr: string }> {
+  timeoutMs = 15_000,
+): Promise<BootResult> {
   return new Promise((resolve) => {
     const child = spawn('pnpm', ['exec', 'tsx', ...execArgv], {
       cwd: join(import.meta.dirname, '..', '..'),
@@ -48,38 +56,138 @@ function bootServer(
       stdio: ['ignore', 'ignore', 'pipe'],
     });
     let stderr = '';
+    let timedOut = false;
     child.stderr.on('data', (chunk) => {
       stderr += chunk.toString();
     });
-    const timer = setTimeout(() => child.kill(), 15_000);
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill();
+    }, timeoutMs);
     child.on('close', (code) => {
       clearTimeout(timer);
-      resolve({ code, stderr });
+      resolve({ code, stderr, timedOut });
     });
   });
 }
 
-test('production boot refuses a default/placeholder BETTER_AUTH_SECRET', async () => {
+async function getFreePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const address = server.address();
+  assert.ok(address && typeof address !== 'string');
+  const port = address.port;
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+  return port;
+}
+
+async function waitForHealth(port: number, child: ReturnType<typeof spawn>): Promise<void> {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`server exited before becoming healthy with code ${child.exitCode}`);
+    }
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/health`);
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // The server may still be starting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error('server did not become healthy before the timeout');
+}
+
+function waitForChildClose(child: ReturnType<typeof spawn>): Promise<void> {
+  if (child.exitCode !== null) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => child.once('close', () => resolve()));
+}
+
+async function assertProductionBootRejects(secret: string, expectedMessage: RegExp): Promise<void> {
   const dbFile = join(tmpdir(), `yotara-boot-${randomUUID()}.db`);
-  const { code, stderr } = await bootServer(
-    [join(import.meta.dirname, '..', '..', 'src', 'server.ts')],
-    {
+  try {
+    const result = await bootServer([join(import.meta.dirname, '..', '..', 'src', 'server.ts')], {
       ...process.env,
       NODE_ENV: 'production',
-      BETTER_AUTH_SECRET: 'local-dev-secret-change-me',
+      BETTER_AUTH_SECRET: secret,
+      RESEND_API_KEY: 're_test_bootstrap_key',
       DATABASE_URL: dbFile,
       APP_BASE_URL: 'http://localhost:3000',
+      HOST: '127.0.0.1',
+    });
+
+    assert.equal(result.timedOut, false, 'invalid secret must fail instead of hanging');
+    assert.notEqual(result.code, 0, 'server must exit non-zero for an invalid secret');
+    assert.match(result.stderr, expectedMessage);
+  } finally {
+    rmSync(dbFile, { force: true });
+  }
+}
+
+test('production boot refuses predictable or malformed BETTER_AUTH_SECRET values', async () => {
+  const cases: Array<[string, RegExp]> = [
+    ['local-dev-secret-change-me', /placeholder/],
+    ['0'.repeat(64), /repeated or sequential pattern/],
+    ['0123456789abcdef'.repeat(4), /repeated or sequential pattern/],
+    [
+      '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f',
+      /repeated or sequential pattern/,
+    ],
+    ['correct-horse-battery-staple-into-the-woods', /canonical hex or Base64/],
+    ['ABEiM0RVZneImaq7zN3u/xAhMkNUZXaHmKm6y9zt/g8', /canonical hex or Base64/],
+    ['00'.repeat(31), /canonical hex or Base64/],
+  ];
+
+  for (const [secret, expectedMessage] of cases) {
+    await assertProductionBootRejects(secret, expectedMessage);
+  }
+});
+
+test('production boot reaches health with a canonical generated secret', async () => {
+  const dbFile = join(tmpdir(), `yotara-boot-${randomUUID()}.db`);
+  const port = await getFreePort();
+  const child = spawn(
+    'pnpm',
+    ['exec', 'tsx', join(import.meta.dirname, '..', '..', 'src', 'server.ts')],
+    {
+      cwd: join(import.meta.dirname, '..', '..'),
+      env: {
+        ...process.env,
+        NODE_ENV: 'production',
+        BETTER_AUTH_SECRET: '903d44f75ea956577ae15335bbbef8532a867cdeae599cccac72357d40f14214',
+        RESEND_API_KEY: 're_test_bootstrap_key',
+        DATABASE_URL: dbFile,
+        APP_BASE_URL: `http://127.0.0.1:${port}`,
+        HOST: '127.0.0.1',
+        PORT: String(port),
+      },
+      stdio: ['ignore', 'ignore', 'pipe'],
     },
   );
+  let stderr = '';
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk.toString();
+  });
 
-  assert.notEqual(
-    code,
-    0,
-    'server must exit non-zero when the default secret is used in production',
-  );
-  assert.match(stderr, /BETTER_AUTH_SECRET/i, 'failure must mention the missing/insecure secret');
-
-  rmSync(dbFile, { force: true });
+  try {
+    await waitForHealth(port, child);
+    assert.equal(stderr, '', 'a valid secret must not produce a bootstrap error');
+  } finally {
+    if (child.exitCode === null) {
+      child.kill();
+    }
+    await waitForChildClose(child);
+    rmSync(dbFile, { force: true });
+  }
 });
 
 test('lockout is scoped to (ip, email) — a victim can still log in from their own IP', async () => {

--- a/apps/api/src/lib/security-audit.test.ts
+++ b/apps/api/src/lib/security-audit.test.ts
@@ -212,7 +212,8 @@ test('lockout is scoped to (ip, email) — a victim can still log in from their 
       const fail = await ctx.app.inject({
         method: 'POST',
         url: '/auth/sign-in/email',
-        headers: { origin: TEST_ORIGIN, 'x-forwarded-for': attackerIp },
+        remoteAddress: attackerIp,
+        headers: { origin: TEST_ORIGIN },
         payload: { email, password: `WrongPassword${i}!` },
       });
       if (i < 2) {
@@ -227,7 +228,8 @@ test('lockout is scoped to (ip, email) — a victim can still log in from their 
     const victimLogin = await ctx.app.inject({
       method: 'POST',
       url: '/auth/sign-in/email',
-      headers: { origin: TEST_ORIGIN, 'x-forwarded-for': victimIp },
+      remoteAddress: victimIp,
+      headers: { origin: TEST_ORIGIN },
       payload: { email, password: TEST_PASSWORD },
     });
     assert.equal(victimLogin.statusCode, 200, 'victim must still be able to log in from their IP');
@@ -237,7 +239,8 @@ test('lockout is scoped to (ip, email) — a victim can still log in from their 
     const attackerRetry = await ctx.app.inject({
       method: 'POST',
       url: '/auth/sign-in/email',
-      headers: { origin: TEST_ORIGIN, 'x-forwarded-for': attackerIp },
+      remoteAddress: attackerIp,
+      headers: { origin: TEST_ORIGIN },
       payload: { email, password: TEST_PASSWORD },
     });
     assert.equal(attackerRetry.statusCode, 429, 'attacker IP stays locked');

--- a/apps/api/src/lib/trusted-proxy.test.ts
+++ b/apps/api/src/lib/trusted-proxy.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getTrustedProxy } from './trusted-proxy.js';
+
+test('trusted proxy defaults to no proxy trust', () => {
+  const previous = process.env['TRUST_PROXY'];
+  delete process.env['TRUST_PROXY'];
+
+  try {
+    assert.equal(getTrustedProxy(), false);
+  } finally {
+    if (previous === undefined) {
+      delete process.env['TRUST_PROXY'];
+    } else {
+      process.env['TRUST_PROXY'] = previous;
+    }
+  }
+});
+
+test('trusted proxy parses configured addresses and CIDRs', () => {
+  const previous = process.env['TRUST_PROXY'];
+  process.env['TRUST_PROXY'] = ' 172.16.0.0/12, 10.0.0.5 ';
+
+  try {
+    assert.deepEqual(getTrustedProxy(), ['172.16.0.0/12', '10.0.0.5']);
+  } finally {
+    if (previous === undefined) {
+      delete process.env['TRUST_PROXY'];
+    } else {
+      process.env['TRUST_PROXY'] = previous;
+    }
+  }
+});

--- a/apps/api/src/lib/trusted-proxy.ts
+++ b/apps/api/src/lib/trusted-proxy.ts
@@ -1,0 +1,8 @@
+export function getTrustedProxy(): false | string[] {
+  const configured = process.env['TRUST_PROXY']
+    ?.split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  return configured && configured.length > 0 ? configured : false;
+}

--- a/apps/api/src/plugins/auth-bridge.ts
+++ b/apps/api/src/plugins/auth-bridge.ts
@@ -250,6 +250,8 @@ export default async function authBridgePlugin(app: FastifyInstance) {
           if (respJson?.code === 'EMAIL_NOT_VERIFIED') {
             return reply.code(401).send({ message: 'Invalid email or password.' });
           }
+          // Any other 403 code — still normalize to avoid leaking info.
+          return reply.code(401).send({ message: 'Invalid email or password.' });
         }
       }
 

--- a/apps/api/src/plugins/auth-bridge.ts
+++ b/apps/api/src/plugins/auth-bridge.ts
@@ -238,28 +238,17 @@ export default async function authBridgePlugin(app: FastifyInstance) {
             });
           }
 
-          const message =
-            result.remainingAttempts <= 1
-              ? `Invalid email or password. ${result.remainingAttempts} attempt remaining.`
-              : `Invalid email or password. ${result.remainingAttempts} attempts remaining.`;
-
-          return reply.code(401).send({
-            message,
-            remainingAttempts: result.remainingAttempts,
-          });
+          return reply.code(401).send({ message: 'Invalid email or password.' });
         } else if (response.status === 403) {
-          // Better Auth returns 403 EMAIL_NOT_VERIFIED when the account exists
-          // but the email was never verified. This is not a bad password — it
-          // must not burn a lockout attempt or show "invalid credentials".
+          // Do not reveal whether an account exists but remains unverified.
+          // Normalize Better Auth's response to the generic sign-in failure
+          // without recording a failed password attempt.
           const respJson = (await response
             .clone()
             .json()
-            .catch(() => null)) as { code?: string; message?: string } | null;
+            .catch(() => null)) as { code?: string } | null;
           if (respJson?.code === 'EMAIL_NOT_VERIFIED') {
-            return reply.code(403).send({
-              code: 'EMAIL_NOT_VERIFIED',
-              message: 'Please verify your email before signing in.',
-            });
+            return reply.code(401).send({ message: 'Invalid email or password.' });
           }
         }
       }

--- a/apps/api/src/plugins/auth-bridge.ts
+++ b/apps/api/src/plugins/auth-bridge.ts
@@ -111,9 +111,9 @@ export default async function authBridgePlugin(app: FastifyInstance) {
       const isSendVerificationEmail =
         request.method === 'POST' && url.pathname === '/auth/send-verification-email';
 
-      // Real client IP (resolves via trustProxy: 1 + nginx X-Forwarded-For) used
-      // to scope the lockout tuple so an attacker can't lock a victim's account
-      // from a different IP.
+      // Client IP is socket-derived unless the connection comes from an
+      // explicitly trusted proxy, preventing spoofed forwarding headers from
+      // selecting lockout or honeypot-ban keys.
       const clientIp = request.ip ?? 'unknown';
 
       // Honeypot-triggered IPs are banned from auth endpoints for 24h.

--- a/apps/api/src/plugins/auth-bridge.ts
+++ b/apps/api/src/plugins/auth-bridge.ts
@@ -9,6 +9,7 @@ import {
 import { checkRateLimitOrThrow } from '../lib/email.js';
 import { recordEmailSend } from '../lib/email-rate-limit.js';
 import { banIp, isIpBanned } from '../lib/blocked-ips.js';
+import { bypassLoginLockout } from '../lib/dev-mode.js';
 import { scanDueNotifications } from '../services/notification-service.js';
 
 function toHeaders(source: Record<string, string | string[] | undefined>) {
@@ -203,6 +204,12 @@ export default async function authBridgePlugin(app: FastifyInstance) {
             }
           }
         } else if (response.status === 401) {
+          if (bypassLoginLockout()) {
+            // Dev mode: plain invalid-credentials response — no attempt
+            // counting, no lockout messaging.
+            return reply.code(401).send({ message: 'Invalid email or password.' });
+          }
+
           const result = recordFailedAttempt(clientIp, loginEmail);
           if (result.locked) {
             reply.header('Retry-After', String(result.remainingLockoutSeconds));

--- a/apps/api/src/plugins/auth-bridge.ts
+++ b/apps/api/src/plugins/auth-bridge.ts
@@ -104,6 +104,8 @@ export default async function authBridgePlugin(app: FastifyInstance) {
       const isSignUp = request.method === 'POST' && url.pathname.startsWith('/auth/sign-up/email');
       const isForgetPassword =
         request.method === 'POST' && url.pathname.startsWith('/auth/request-password-reset');
+      const isSendVerificationEmail =
+        request.method === 'POST' && url.pathname === '/auth/send-verification-email';
 
       // Real client IP (resolves via trustProxy: 1 + nginx X-Forwarded-For) used
       // to scope the lockout tuple so an attacker can't lock a victim's account
@@ -135,9 +137,16 @@ export default async function authBridgePlugin(app: FastifyInstance) {
       const loginEmail =
         isSignIn && parsedBody && typeof parsedBody.email === 'string' ? parsedBody.email : null;
       const actionEmail =
-        (isSignUp || isForgetPassword) && parsedBody && typeof parsedBody.email === 'string'
+        (isSignUp || isForgetPassword || isSendVerificationEmail) &&
+        parsedBody &&
+        typeof parsedBody.email === 'string'
           ? parsedBody.email
           : null;
+      const actionType = isSignUp
+        ? ('signup' as const)
+        : isForgetPassword
+          ? ('reset' as const)
+          : ('verify' as const);
 
       if (isSignIn && loginEmail) {
         const remaining = getRemainingLockoutSeconds(clientIp, loginEmail);
@@ -152,7 +161,6 @@ export default async function authBridgePlugin(app: FastifyInstance) {
       }
 
       if (actionEmail) {
-        const actionType = isSignUp ? ('signup' as const) : ('reset' as const);
         try {
           checkRateLimitOrThrow(actionEmail, actionType, clientIp);
         } catch (err) {

--- a/apps/api/src/plugins/auth-bridge.ts
+++ b/apps/api/src/plugins/auth-bridge.ts
@@ -8,6 +8,7 @@ import {
 } from '../lib/login-lockout.js';
 import { checkRateLimitOrThrow } from '../lib/email.js';
 import { recordEmailSend } from '../lib/email-rate-limit.js';
+import { banIp, isIpBanned } from '../lib/blocked-ips.js';
 import { scanDueNotifications } from '../services/notification-service.js';
 
 function toHeaders(source: Record<string, string | string[] | undefined>) {
@@ -104,10 +105,31 @@ export default async function authBridgePlugin(app: FastifyInstance) {
       const isForgetPassword =
         request.method === 'POST' && url.pathname.startsWith('/auth/request-password-reset');
 
+      // Real client IP (resolves via trustProxy: 1 + nginx X-Forwarded-For) used
+      // to scope the lockout tuple so an attacker can't lock a victim's account
+      // from a different IP.
+      const clientIp = request.ip ?? 'unknown';
+
+      // Honeypot-triggered IPs are banned from auth endpoints for 24h.
+      if (isIpBanned(clientIp)) {
+        return reply.code(403).send({ message: 'Forbidden' });
+      }
+
       // Parse body once for all branches
       const parsedBody = parseRequestBody(request.body);
       if (request.method === 'POST' && parsedBody === null) {
         return reply.code(400).send({ message: 'Invalid JSON body' });
+      }
+
+      // Honeypot: hidden "website" field on the signup form. Bots fill it;
+      // humans never see it. On trigger: ban the IP, return a fake success so
+      // the bot can't tell it was caught, and create no user / send no email.
+      if (isSignUp) {
+        const website = parsedBody?.['website'];
+        if (typeof website === 'string' && website.trim() !== '') {
+          banIp(clientIp);
+          return reply.code(200).send({ user: null, token: null });
+        }
       }
 
       const loginEmail =
@@ -116,11 +138,6 @@ export default async function authBridgePlugin(app: FastifyInstance) {
         (isSignUp || isForgetPassword) && parsedBody && typeof parsedBody.email === 'string'
           ? parsedBody.email
           : null;
-
-      // Real client IP (resolves via trustProxy: 1 + nginx X-Forwarded-For) used
-      // to scope the lockout tuple so an attacker can't lock a victim's account
-      // from a different IP.
-      const clientIp = request.ip ?? 'unknown';
 
       if (isSignIn && loginEmail) {
         const remaining = getRemainingLockoutSeconds(clientIp, loginEmail);
@@ -197,6 +214,20 @@ export default async function authBridgePlugin(app: FastifyInstance) {
             message,
             remainingAttempts: result.remainingAttempts,
           });
+        } else if (response.status === 403) {
+          // Better Auth returns 403 EMAIL_NOT_VERIFIED when the account exists
+          // but the email was never verified. This is not a bad password — it
+          // must not burn a lockout attempt or show "invalid credentials".
+          const respJson = (await response
+            .clone()
+            .json()
+            .catch(() => null)) as { code?: string; message?: string } | null;
+          if (respJson?.code === 'EMAIL_NOT_VERIFIED') {
+            return reply.code(403).send({
+              code: 'EMAIL_NOT_VERIFIED',
+              message: 'Please verify your email before signing in.',
+            });
+          }
         }
       }
 

--- a/apps/api/src/plugins/auth-bridge.ts
+++ b/apps/api/src/plugins/auth-bridge.ts
@@ -1,5 +1,8 @@
 import type { FastifyInstance, FastifyReply } from 'fastify';
+import { eq } from 'drizzle-orm';
 import { auth } from '../lib/auth.js';
+import { db } from '../db/client.js';
+import { users } from '../db/schema.js';
 import { getCorsOrigins } from '../lib/auth-origins.js';
 import {
   getRemainingLockoutSeconds,
@@ -176,6 +179,21 @@ export default async function authBridgePlugin(app: FastifyInstance) {
         // 3h: Record email send on every attempt (regardless of response status)
         // so the rate limit applies to both new and existing email addresses.
         recordEmailSend(actionEmail, actionType, clientIp);
+      }
+
+      if (isSignIn && loginEmail) {
+        const [user] = await db
+          .select({
+            emailVerified: users.emailVerified,
+            passwordSetupRequired: users.passwordSetupRequired,
+          })
+          .from(users)
+          .where(eq(users.email, loginEmail))
+          .limit(1);
+
+        if (user?.emailVerified && user.passwordSetupRequired) {
+          return reply.code(401).send({ message: 'Invalid email or password.' });
+        }
       }
 
       const headers = toHeaders(request.headers);

--- a/apps/api/src/plugins/rate-limit.test.ts
+++ b/apps/api/src/plugins/rate-limit.test.ts
@@ -3,8 +3,79 @@ import test from 'node:test';
 import Fastify from 'fastify';
 import rateLimit from '@fastify/rate-limit';
 
-test('rate-limit plugin returns 429 when limit is exceeded and respects X-Forwarded-For', async () => {
-  const app = Fastify({ trustProxy: 1 });
+test('rate-limit plugin ignores forwarded IPs from direct clients', async () => {
+  const app = Fastify({ trustProxy: false });
+  const keys: string[] = [];
+  await app.register(rateLimit, {
+    max: 3,
+    timeWindow: 60000,
+    keyGenerator: (request) => {
+      const key = request.ip;
+      keys.push(key);
+      return key;
+    },
+  });
+
+  app.get('/test', async () => ({ ok: true }));
+
+  await app.ready();
+
+  try {
+    for (let i = 0; i < 3; i++) {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/test',
+        remoteAddress: '203.0.113.10',
+        headers: { 'x-forwarded-for': '10.0.0.99' },
+      });
+      assert.equal(response.statusCode, 200);
+    }
+
+    const blocked = await app.inject({
+      method: 'GET',
+      url: '/test',
+      remoteAddress: '203.0.113.10',
+      headers: { 'x-forwarded-for': '10.0.0.99' },
+    });
+    assert.equal(blocked.statusCode, 429);
+    assert.deepEqual(new Set(keys), new Set(['203.0.113.10']));
+  } finally {
+    await app.close();
+  }
+});
+
+test('rate-limit plugin honors forwarded IPs only from a trusted proxy', async () => {
+  const app = Fastify({ trustProxy: ['172.16.0.0/12'] });
+  const keys: string[] = [];
+  await app.register(rateLimit, {
+    max: 3,
+    timeWindow: 60000,
+    keyGenerator: (request) => {
+      const key = request.ip;
+      keys.push(key);
+      return key;
+    },
+  });
+
+  app.get('/test', async () => ({ ok: true }));
+  await app.ready();
+
+  try {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/test',
+      remoteAddress: '172.16.0.5',
+      headers: { 'x-forwarded-for': '203.0.113.10' },
+    });
+    assert.equal(response.statusCode, 200);
+    assert.equal(keys[0], '203.0.113.10');
+  } finally {
+    await app.close();
+  }
+});
+
+test('rate-limit plugin returns 429 when the trusted client IP exceeds the limit', async () => {
+  const app = Fastify({ trustProxy: ['172.16.0.0/12'] });
   await app.register(rateLimit, {
     max: 3,
     timeWindow: 60000,
@@ -16,58 +87,39 @@ test('rate-limit plugin returns 429 when limit is exceeded and respects X-Forwar
   await app.ready();
 
   try {
-    // First 3 requests should succeed
     for (let i = 0; i < 3; i++) {
-      const response = await app.inject({ method: 'GET', url: '/test' });
-      assert.equal(response.statusCode, 200, `default ip request ${i + 1} should succeed`);
+      const response = await app.inject({
+        method: 'GET',
+        url: '/test',
+        remoteAddress: '172.16.0.5',
+        headers: { 'x-forwarded-for': '203.0.113.10' },
+      });
+      assert.equal(response.statusCode, 200, `trusted request ${i + 1} should succeed`);
     }
 
-    // 4th request from default IP should be rate-limited
-    const blocked = await app.inject({ method: 'GET', url: '/test' });
-    assert.equal(blocked.statusCode, 429, '4th request from default IP should be rate-limited');
-    const body = blocked.json();
-    assert.match(body.message, /Rate limit exceeded/i);
-
-    // A different IP via X-Forwarded-For should still succeed
-    const r1 = await app.inject({
+    const blocked = await app.inject({
       method: 'GET',
       url: '/test',
-      headers: { 'x-forwarded-for': '10.0.0.99' },
+      remoteAddress: '172.16.0.5',
+      headers: { 'x-forwarded-for': '203.0.113.10' },
     });
-    assert.equal(r1.statusCode, 200, 'different IP should succeed on first request');
+    assert.equal(blocked.statusCode, 429);
+    assert.match(blocked.json().message, /Rate limit exceeded/i);
 
-    // Second request from different IP should also succeed
-    const r2 = await app.inject({
+    const otherClient = await app.inject({
       method: 'GET',
       url: '/test',
-      headers: { 'x-forwarded-for': '10.0.0.99' },
+      remoteAddress: '172.16.0.5',
+      headers: { 'x-forwarded-for': '203.0.113.11' },
     });
-    assert.equal(r2.statusCode, 200, 'different IP should succeed on second request');
-
-    // Third request from different IP should also succeed
-    const r3 = await app.inject({
-      method: 'GET',
-      url: '/test',
-      headers: { 'x-forwarded-for': '10.0.0.99' },
-    });
-    assert.equal(r3.statusCode, 200, 'different IP should succeed on third request');
-
-    // Fourth request from different IP should be rate-limited
-    const blockedDiff = await app.inject({
-      method: 'GET',
-      url: '/test',
-      headers: { 'x-forwarded-for': '10.0.0.99' },
-    });
-    assert.equal(blockedDiff.statusCode, 429, 'different IP should be rate-limited on 4th request');
+    assert.equal(otherClient.statusCode, 200);
   } finally {
     await app.close();
   }
 });
 
-test('rate-limit key uses last entry in X-Forwarded-For when trustProxy is enabled', async () => {
-  // Simulate nginx's $proxy_add_x_forwarded_for: the real client IP is the
-  // last entry in the chain; a spoofed first entry must be ignored.
-  const app = Fastify({ trustProxy: 1 });
+test('rate-limit key uses the sanitized client address from a trusted proxy', async () => {
+  const app = Fastify({ trustProxy: ['172.16.0.0/12'] });
 
   const keys: string[] = [];
   await app.register(rateLimit, {
@@ -84,15 +136,14 @@ test('rate-limit key uses last entry in X-Forwarded-For when trustProxy is enabl
   await app.ready();
 
   try {
-    // Send X-Forwarded-For with a spoofed first entry and the real IP last,
-    // matching nginx's $proxy_add_x_forwarded_for behaviour.
     const r = await app.inject({
       method: 'GET',
       url: '/test',
-      headers: { 'x-forwarded-for': 'spoofed-ip, 10.0.0.1' },
+      remoteAddress: '172.16.0.5',
+      headers: { 'x-forwarded-for': '203.0.113.10' },
     });
     assert.equal(r.statusCode, 200);
-    assert.equal(keys[0], '10.0.0.1', 'key must be the last X-Forwarded-For entry, not the first');
+    assert.equal(keys[0], '203.0.113.10');
   } finally {
     await app.close();
   }

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -158,6 +158,85 @@ test('honeypot signup triggers IP ban and creates no user', async () => {
   }
 });
 
+test('dev mode flips the require-email flag and bypasses rate limit, lockout, and IP ban', async () => {
+  const ctx = await createTestApp();
+  const previousDevMode = process.env['DEV_MODE'];
+
+  try {
+    process.env['DEV_MODE'] = 'true';
+
+    // The runtime flag is flipped off even if REQUIRE_EMAIL_VERIFICATION
+    // would otherwise force it on (it is unset here; the unit-level flip is
+    // covered in dev-mode.test.ts).
+    const configResponse = await ctx.app.inject({ method: 'GET', url: '/config' });
+    assert.equal(configResponse.statusCode, 200);
+    assert.equal(configResponse.json().requireEmailVerification, false);
+    assert.equal(configResponse.json().devMode, true);
+
+    // Email rate limit bypassed: two verification resends for the same email
+    // both succeed (normally the second is a 429 from the 30-min cooldown).
+    const resendEmail = `devmode-resend-${randomUUID()}@example.com`;
+    const firstResend = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/send-verification-email',
+      headers: { origin: TEST_ORIGIN },
+      payload: { email: resendEmail },
+    });
+    const secondResend = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/send-verification-email',
+      headers: { origin: TEST_ORIGIN },
+      payload: { email: resendEmail },
+    });
+    assert.equal(firstResend.statusCode, 200);
+    assert.equal(secondResend.statusCode, 200);
+
+    // Lockout bypassed: repeated wrong passwords never lock (no 429), and the
+    // response is a plain 401 without attempt-counting noise.
+    const lockoutEmail = `devmode-lockout-${randomUUID()}@example.com`;
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const signIn = await ctx.app.inject({
+        method: 'POST',
+        url: '/auth/sign-in/email',
+        headers: { origin: TEST_ORIGIN },
+        payload: { email: lockoutEmail, password: 'WrongPassword1!' },
+      });
+      assert.equal(signIn.statusCode, 401, `attempt ${attempt + 1} should stay 401`);
+      assert.equal(signIn.json().message, 'Invalid email or password.');
+    }
+
+    // IP ban bypassed: a banned IP can still reach auth endpoints.
+    const { banIp } = await import('../lib/blocked-ips.js');
+    banIp('127.0.0.1');
+    const { sqlite } = await import('../db/client.js');
+    const banRow = sqlite
+      .prepare(`SELECT blocked_until FROM blocked_ips WHERE ip = '127.0.0.1'`)
+      .get() as { blocked_until: number } | undefined;
+    assert.ok(banRow, 'ban is recorded even in dev mode');
+    const bannedSignUp = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/sign-up/email',
+      headers: { origin: TEST_ORIGIN },
+      payload: {
+        email: `devmode-ban-${randomUUID()}@example.com`,
+        password: TEST_PASSWORD,
+        name: 'Dev Mode User',
+      },
+    });
+    assert.equal(bannedSignUp.statusCode, 200, 'banned IP is not blocked in dev mode');
+  } finally {
+    if (previousDevMode === undefined) {
+      delete process.env['DEV_MODE'];
+    } else {
+      process.env['DEV_MODE'] = previousDevMode;
+    }
+    // Remove the ban so it doesn't leak into other tests sharing the DB.
+    const { sqlite } = await import('../db/client.js');
+    sqlite.prepare(`DELETE FROM blocked_ips WHERE ip = '127.0.0.1'`).run();
+    await ctx.cleanup();
+  }
+});
+
 test('verification-required signup marks password setup as required', async () => {
   const { execFileSync } = await import('node:child_process');
   const { fileURLToPath } = await import('node:url');

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -280,7 +280,7 @@ test('verification-required signup marks password setup as required', async () =
   assert.ok(output.includes('PASSWORD_SETUP_REQUIRED:1'), `expected setup flag, got:\n${output}`);
 });
 
-test('unverified sign-in returns EMAIL_NOT_VERIFIED without burning lockout', async () => {
+test('unverified sign-in uses the generic response without burning lockout', async () => {
   // The verification gating is read at module load (env-at-boot contract), so
   // this scenario must run in a fresh process with the flag set before import.
   const { execFileSync } = await import('node:child_process');
@@ -293,12 +293,36 @@ test('unverified sign-in returns EMAIL_NOT_VERIFIED without burning lockout', as
       env: { ...process.env, REQUIRE_EMAIL_VERIFICATION: 'true', NODE_ENV: 'test' },
     });
     const lines = output.trim().split('\n');
-    assert.ok(lines.includes('SIGNIN_STATUS:403'), `expected 403, got:\n${output}`);
-    assert.ok(lines.includes('SIGNIN_CODE:EMAIL_NOT_VERIFIED'), `expected code, got:\n${output}`);
+    assert.ok(lines.includes('SIGNIN_STATUS:401'), `expected 401, got:\n${output}`);
+    assert.ok(
+      lines.includes('SIGNIN_BODY:{"message":"Invalid email or password."}'),
+      `expected generic body, got:\n${output}`,
+    );
     assert.ok(lines.includes('LOCKOUT_REMAINING:0'), `expected no lockout burn, got:\n${output}`);
   } catch (err) {
     assert.fail(`subprocess failed: ${(err as Error).message}`);
   }
+});
+
+test('unknown and unverified sign-ins have the same observable failure response', async () => {
+  const { execFileSync } = await import('node:child_process');
+  const { fileURLToPath } = await import('node:url');
+  const scriptPath = fileURLToPath(new URL('./unverified-signin.script.ts', import.meta.url));
+  const output = execFileSync(process.execPath, ['--import', 'tsx', scriptPath], {
+    encoding: 'utf8',
+    env: { ...process.env, REQUIRE_EMAIL_VERIFICATION: 'true', NODE_ENV: 'test' },
+  });
+  const lines = output.trim().split('\n');
+  assert.ok(lines.includes('SIGNIN_STATUS:401'), `expected unverified 401, got:\n${output}`);
+  assert.ok(lines.includes('UNKNOWN_SIGNIN_STATUS:401'), `expected unknown 401, got:\n${output}`);
+  assert.ok(
+    lines.includes('SIGNIN_BODY:{"message":"Invalid email or password."}'),
+    `expected generic unverified body, got:\n${output}`,
+  );
+  assert.ok(
+    lines.includes('UNKNOWN_SIGNIN_BODY:{"message":"Invalid email or password."}'),
+    `expected generic unknown body, got:\n${output}`,
+  );
 });
 
 test('pending password setup accounts cannot sign in with their temporary password', async () => {
@@ -647,7 +671,7 @@ test('password lockout locks account after repeated failed login attempts', asyn
     });
     assert.equal(registerResponse.statusCode, 200);
 
-    // First wrong password -> remainingAttempts: 1
+    // First wrong password -> generic 401 without account-dependent metadata
     const firstFail = await ctx.app.inject({
       method: 'POST',
       url: '/auth/sign-in/email',
@@ -655,9 +679,7 @@ test('password lockout locks account after repeated failed login attempts', asyn
       payload: { email, password: 'WrongPassword1!' },
     });
     assert.equal(firstFail.statusCode, 401);
-    const firstBody = firstFail.json();
-    assert.equal(firstBody.remainingAttempts, 1);
-    assert.equal(typeof firstBody.message, 'string');
+    assert.deepEqual(firstFail.json(), { message: 'Invalid email or password.' });
 
     // Second wrong password -> lockout, remainingAttempts: 0
     const secondFail = await ctx.app.inject({
@@ -795,7 +817,7 @@ test('locked account can log in after lockout window expires', { timeout: 60_000
     assert.ok(successResponse, 'Login should succeed after lockout expires');
     assert.equal(successResponse!.statusCode, 200);
 
-    // After successful login, a wrong password should start fresh (remainingAttempts: 1)
+    // After successful login, a wrong password should return the generic 401 response.
     const failAfterRecovery = await ctx.app.inject({
       method: 'POST',
       url: '/auth/sign-in/email',
@@ -803,8 +825,7 @@ test('locked account can log in after lockout window expires', { timeout: 60_000
       payload: { email, password: 'WrongAgain1!' },
     });
     assert.equal(failAfterRecovery.statusCode, 401);
-    const afterRecoveryBody = failAfterRecovery.json();
-    assert.equal(afterRecoveryBody.remainingAttempts, 1);
+    assert.deepEqual(failAfterRecovery.json(), { message: 'Invalid email or password.' });
   } finally {
     await ctx.cleanup();
   }

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -367,6 +367,7 @@ test('auth routes register and login with email/password', async () => {
     const registerBody = registerResponse.json();
     assert.equal(registerBody.user.email, TEST_EMAIL);
     assert.equal(registerBody.user.name, TEST_NAME);
+    assert.equal(registerBody.user.passwordSetupRequired, false);
     const registerCookie = readCookie(registerResponse);
 
     const meAfterRegister = await ctx.app.inject({

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -157,6 +157,17 @@ test('honeypot signup triggers IP ban and creates no user', async () => {
   }
 });
 
+test('verification-required signup marks password setup as required', async () => {
+  const { execFileSync } = await import('node:child_process');
+  const { fileURLToPath } = await import('node:url');
+  const scriptPath = fileURLToPath(new URL('./password-setup-signup.script.ts', import.meta.url));
+  const output = execFileSync(process.execPath, ['--import', 'tsx', scriptPath], {
+    encoding: 'utf8',
+    env: { ...process.env, REQUIRE_EMAIL_VERIFICATION: 'true', NODE_ENV: 'test' },
+  });
+  assert.ok(output.includes('PASSWORD_SETUP_REQUIRED:1'), `expected setup flag, got:\n${output}`);
+});
+
 test('unverified sign-in returns EMAIL_NOT_VERIFIED without burning lockout', async () => {
   // The verification gating is read at module load (env-at-boot contract), so
   // this scenario must run in a fresh process with the flag set before import.
@@ -183,7 +194,7 @@ test('set-password endpoint requires verified email and sets the password', asyn
   const email = `setpw-${randomUUID()}@example.com`;
 
   try {
-    // Register + login normally (verified in test env), then call the endpoint.
+    // Register + login normally; verified users without the setup flag are denied.
     const registerResponse = await ctx.app.inject({
       method: 'POST',
       url: '/auth/sign-up/email',
@@ -201,6 +212,19 @@ test('set-password endpoint requires verified email and sets the password', asyn
     });
     assert.equal(unauth.statusCode, 401);
 
+    const normalUserSetPw = await ctx.app.inject({
+      method: 'POST',
+      url: '/me/password/set',
+      headers: { origin: TEST_ORIGIN, cookie },
+      payload: { newPassword: 'NewPassword123!' },
+    });
+    assert.equal(normalUserSetPw.statusCode, 403);
+
+    const { sqlite } = await import('../db/client.js');
+    sqlite
+      .prepare('UPDATE user SET emailVerified = 1, passwordSetupRequired = 1 WHERE email = ?')
+      .run(email);
+
     const NEW_PW = 'NewPassword123!';
     const setPw = await ctx.app.inject({
       method: 'POST',
@@ -210,6 +234,14 @@ test('set-password endpoint requires verified email and sets the password', asyn
     });
     assert.equal(setPw.statusCode, 200);
     assert.equal(setPw.json().ok, true);
+
+    const secondSetPw = await ctx.app.inject({
+      method: 'POST',
+      url: '/me/password/set',
+      headers: { origin: TEST_ORIGIN, cookie },
+      payload: { newPassword: 'AnotherPassword123!' },
+    });
+    assert.equal(secondSetPw.statusCode, 403);
 
     // Old password no longer works; the new one does.
     const oldSignIn = await ctx.app.inject({

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -149,6 +149,60 @@ test('unverified sign-in returns EMAIL_NOT_VERIFIED without burning lockout', as
   }
 });
 
+test('set-password endpoint requires verified email and sets the password', async () => {
+  const ctx = await createTestApp();
+  const email = `setpw-${randomUUID()}@example.com`;
+
+  try {
+    // Register + login normally (verified in test env), then call the endpoint.
+    const registerResponse = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/sign-up/email',
+      headers: { origin: TEST_ORIGIN },
+      payload: { email, password: TEST_PASSWORD, name: 'Set PW User' },
+    });
+    assert.equal(registerResponse.statusCode, 200);
+    const cookie = readCookie(registerResponse);
+
+    // Unauthenticated → 401.
+    const unauth = await ctx.app.inject({
+      method: 'POST',
+      url: '/me/password/set',
+      payload: { newPassword: 'NewPassword123!' },
+    });
+    assert.equal(unauth.statusCode, 401);
+
+    const NEW_PW = 'NewPassword123!';
+    const setPw = await ctx.app.inject({
+      method: 'POST',
+      url: '/me/password/set',
+      headers: { origin: TEST_ORIGIN, cookie },
+      payload: { newPassword: NEW_PW },
+    });
+    assert.equal(setPw.statusCode, 200);
+    assert.equal(setPw.json().ok, true);
+
+    // Old password no longer works; the new one does.
+    const oldSignIn = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/sign-in/email',
+      headers: { origin: TEST_ORIGIN },
+      payload: { email, password: TEST_PASSWORD },
+    });
+    assert.notEqual(oldSignIn.statusCode, 200);
+
+    const newSignIn = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/sign-in/email',
+      headers: { origin: TEST_ORIGIN },
+      payload: { email, password: NEW_PW },
+    });
+    assert.equal(newSignIn.statusCode, 200);
+  } finally {
+    await ctx.cleanup();
+  }
+});
+
 test('auth routes register and login with email/password', async () => {
   const ctx = await createTestApp();
 

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -87,6 +87,68 @@ test('config endpoint exposes requireEmailVerification from env', async () => {
   }
 });
 
+test('honeypot signup triggers IP ban and creates no user', async () => {
+  const ctx = await createTestApp();
+
+  try {
+    const { isIpBanned } = await import('../lib/blocked-ips.js');
+
+    // Bot fills the hidden website field → fake success, no user created.
+    const honeypotResponse = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/sign-up/email',
+      headers: { origin: TEST_ORIGIN },
+      payload: {
+        email: `honeypot-${randomUUID()}@example.com`,
+        password: TEST_PASSWORD,
+        name: 'Bot',
+        website: 'http://spam.example.com',
+      },
+    });
+    assert.equal(honeypotResponse.statusCode, 200, 'fake success so bots cannot detect the trap');
+
+    // The IP is now banned → subsequent auth requests from it are 403.
+    const bannedResponse = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/sign-up/email',
+      headers: { origin: TEST_ORIGIN },
+      payload: {
+        email: `second-${randomUUID()}@example.com`,
+        password: TEST_PASSWORD,
+        name: 'Bot 2',
+      },
+    });
+    assert.equal(bannedResponse.statusCode, 403);
+    assert.equal(isIpBanned('127.0.0.1'), true);
+  } finally {
+    // Remove the ban so it doesn't leak into other tests sharing the DB.
+    const { sqlite } = await import('../db/client.js');
+    sqlite.prepare(`DELETE FROM blocked_ips WHERE ip = '127.0.0.1'`).run();
+    await ctx.cleanup();
+  }
+});
+
+test('unverified sign-in returns EMAIL_NOT_VERIFIED without burning lockout', async () => {
+  // The verification gating is read at module load (env-at-boot contract), so
+  // this scenario must run in a fresh process with the flag set before import.
+  const { execFileSync } = await import('node:child_process');
+  const { fileURLToPath } = await import('node:url');
+  const scriptPath = fileURLToPath(new URL('./unverified-signin.script.ts', import.meta.url));
+
+  try {
+    const output = execFileSync(process.execPath, ['--import', 'tsx', scriptPath], {
+      encoding: 'utf8',
+      env: { ...process.env, REQUIRE_EMAIL_VERIFICATION: 'true', NODE_ENV: 'test' },
+    });
+    const lines = output.trim().split('\n');
+    assert.ok(lines.includes('SIGNIN_STATUS:403'), `expected 403, got:\n${output}`);
+    assert.ok(lines.includes('SIGNIN_CODE:EMAIL_NOT_VERIFIED'), `expected code, got:\n${output}`);
+    assert.ok(lines.includes('LOCKOUT_REMAINING:0'), `expected no lockout burn, got:\n${output}`);
+  } catch (err) {
+    assert.fail(`subprocess failed: ${(err as Error).message}`);
+  }
+});
+
 test('auth routes register and login with email/password', async () => {
   const ctx = await createTestApp();
 

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -269,6 +269,42 @@ test('unverified sign-in returns EMAIL_NOT_VERIFIED without burning lockout', as
   }
 });
 
+test('pending password setup accounts cannot sign in with their temporary password', async () => {
+  const ctx = await createTestApp();
+  const email = `pending-password-${randomUUID()}@example.com`;
+
+  try {
+    const registerResponse = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/sign-up/email',
+      headers: { origin: TEST_ORIGIN },
+      payload: { email, password: TEST_PASSWORD, name: 'Pending Password User' },
+    });
+    assert.equal(registerResponse.statusCode, 200);
+
+    const { sqlite } = await import('../db/client.js');
+    sqlite
+      .prepare('UPDATE user SET emailVerified = 1, passwordSetupRequired = 1 WHERE email = ?')
+      .run(email);
+
+    const signIn = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/sign-in/email',
+      headers: { origin: TEST_ORIGIN },
+      payload: { email, password: TEST_PASSWORD },
+    });
+
+    assert.equal(signIn.statusCode, 401);
+    assert.deepEqual(signIn.json(), { message: 'Invalid email or password.' });
+    const lockout = sqlite
+      .prepare('SELECT attempts FROM login_attempts WHERE email = ?')
+      .get(email) as { attempts: number } | undefined;
+    assert.equal(lockout, undefined);
+  } finally {
+    await ctx.cleanup();
+  }
+});
+
 test('set-password endpoint requires verified email and sets the password', async () => {
   const ctx = await createTestApp();
   const email = `setpw-${randomUUID()}@example.com`;

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import assert from 'node:assert/strict';
+import { mock } from 'node:test';
 import test from 'node:test';
 
 // Ensure the SQLite singleton uses a shared temp DB before any module imports it.
@@ -695,16 +696,40 @@ test('sendResetPassword callback is wired correctly', async () => {
       payload: { email, password: TEST_PASSWORD, name: 'Reset CB User' },
     });
 
-    // Trigger the requestPasswordReset flow — this invokes the sendResetPassword
-    // callback configured in auth.ts, which dynamically imports email.js and
-    // calls sendPasswordResetEmail. Without RESEND_API_KEY, it logs to console.
-    const { auth } = await import('../lib/auth.js');
-    const result = await auth.api.requestPasswordReset({
-      body: { email },
+    // Capture the console-logged email body (test env logs instead of sending).
+    const logs: string[] = [];
+    mock.method(console, 'log', (msg: string) => {
+      if (typeof msg === 'string' && msg.startsWith('[email]')) logs.push(msg);
     });
 
-    // Better Auth returns { status: true } on success
-    assert.equal(result.status, true);
+    try {
+      // Trigger the requestPasswordReset flow — this invokes the sendResetPassword
+      // callback configured in auth.ts, which dynamically imports email.js and
+      // calls sendPasswordResetEmail. Without RESEND_API_KEY, it logs to console.
+      const { auth } = await import('../lib/auth.js');
+      const result = await auth.api.requestPasswordReset({
+        body: { email, redirectTo: 'http://localhost:4200/reset-password' },
+      });
+
+      // Better Auth returns { status: true } on success
+      assert.equal(result.status, true);
+
+      // The emailed link must point straight at the frontend with the token in
+      // the query — never at the API's redirect-based /auth/reset-password/<token>
+      // route (whose empty-callbackURL failure mode dead-ends on
+      // /auth/error?error=INVALID_TOKEN).
+      const body = logs.find((l) => l.includes('reset-password'));
+      assert.ok(body, 'reset email was logged: ' + JSON.stringify(logs));
+      const match = body!.match(/https?:\/\/[^\s]+/);
+      assert.ok(match, 'email body contains a URL');
+      const emailedUrl = new URL(match![0]);
+      assert.equal(emailedUrl.origin, 'http://localhost:4200');
+      assert.equal(emailedUrl.pathname, '/reset-password');
+      assert.ok(emailedUrl.searchParams.get('token'), 'token is in the query');
+      assert.equal(emailedUrl.searchParams.get('callbackURL'), null);
+    } finally {
+      mock.restoreAll();
+    }
   } finally {
     await ctx.cleanup();
   }

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -50,6 +50,43 @@ function readCookie(response: { headers: Record<string, unknown> }) {
   return Array.isArray(cookie) ? cookie[0] : cookie;
 }
 
+test('config endpoint exposes requireEmailVerification from env', async () => {
+  const ctx = await createTestApp();
+
+  try {
+    // createTestApp sets NODE_ENV=test; flag unset → false.
+    const response = await ctx.app.inject({
+      method: 'GET',
+      url: '/config',
+    });
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.json().requireEmailVerification, false);
+
+    // With the override flag, verification is required even in test env.
+    const previousFlag = process.env['REQUIRE_EMAIL_VERIFICATION'];
+    process.env['REQUIRE_EMAIL_VERIFICATION'] = 'true';
+    try {
+      const { buildApp } = await import('../server.js');
+      const overrideApp = await buildApp();
+      const overrideResponse = await overrideApp.inject({
+        method: 'GET',
+        url: '/config',
+      });
+      assert.equal(overrideResponse.statusCode, 200);
+      assert.equal(overrideResponse.json().requireEmailVerification, true);
+      await overrideApp.close();
+    } finally {
+      if (previousFlag === undefined) {
+        delete process.env['REQUIRE_EMAIL_VERIFICATION'];
+      } else {
+        process.env['REQUIRE_EMAIL_VERIFICATION'] = previousFlag;
+      }
+    }
+  } finally {
+    await ctx.cleanup();
+  }
+});
+
 test('auth routes register and login with email/password', async () => {
   const ctx = await createTestApp();
 

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -397,6 +397,17 @@ test('set-password endpoint requires verified email and sets the password', asyn
       .prepare('UPDATE user SET emailVerified = 1, passwordSetupRequired = 1 WHERE email = ?')
       .run(email);
 
+    const weakPasswords = ['abcdefgh1!', 'ABCDEFGH1!', 'Abcdefgh!', 'Abcdefgh1', 'short1!'];
+    for (const weakPassword of weakPasswords) {
+      const weakSetPw = await ctx.app.inject({
+        method: 'POST',
+        url: '/me/password/set',
+        headers: { origin: TEST_ORIGIN, cookie },
+        payload: { newPassword: weakPassword },
+      });
+      assert.equal(weakSetPw.statusCode, 400, `weak password should be rejected: ${weakPassword}`);
+    }
+
     const NEW_PW = 'NewPassword123!';
     const setPw = await ctx.app.inject({
       method: 'POST',

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -158,6 +158,38 @@ test('honeypot signup triggers IP ban and creates no user', async () => {
   }
 });
 
+test('direct clients cannot ban a spoofed forwarded IP', async () => {
+  const ctx = await createTestApp();
+  const spoofedIp = '203.0.113.99';
+
+  try {
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/sign-up/email',
+      remoteAddress: '198.51.100.10',
+      headers: {
+        origin: TEST_ORIGIN,
+        'x-forwarded-for': spoofedIp,
+      },
+      payload: {
+        email: `spoof-${randomUUID()}@example.com`,
+        password: TEST_PASSWORD,
+        name: 'Spoofed Bot',
+        website: 'http://spam.example.com',
+      },
+    });
+    assert.equal(response.statusCode, 200);
+
+    const { isIpBanned } = await import('../lib/blocked-ips.js');
+    assert.equal(isIpBanned(spoofedIp), false);
+    assert.equal(isIpBanned('198.51.100.10'), true);
+  } finally {
+    const { sqlite } = await import('../db/client.js');
+    sqlite.prepare(`DELETE FROM blocked_ips WHERE ip IN ('198.51.100.10', ?)`).run(spoofedIp);
+    await ctx.cleanup();
+  }
+});
+
 test('dev mode flips the require-email flag and bypasses rate limit, lockout, and IP ban', async () => {
   const ctx = await createTestApp();
   const previousDevMode = process.env['DEV_MODE'];

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -87,6 +87,35 @@ test('config endpoint exposes requireEmailVerification from env', async () => {
   }
 });
 
+test('verification resend is rate-limited without revealing account existence', async () => {
+  const ctx = await createTestApp();
+  const email = `resend-${randomUUID()}@example.com`;
+
+  try {
+    const firstResponse = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/send-verification-email',
+      headers: { origin: TEST_ORIGIN },
+      payload: { email },
+    });
+    assert.equal(firstResponse.statusCode, 200);
+    assert.equal(firstResponse.json().status, true);
+
+    const secondResponse = await ctx.app.inject({
+      method: 'POST',
+      url: '/auth/send-verification-email',
+      headers: { origin: TEST_ORIGIN },
+      payload: { email },
+    });
+    assert.equal(secondResponse.statusCode, 429);
+    assert.equal(secondResponse.headers['retry-after'] !== undefined, true);
+    assert.equal(secondResponse.json().retryAfterSeconds > 1500, true);
+    assert.match(secondResponse.json().message, /Too many verify requests/);
+  } finally {
+    await ctx.cleanup();
+  }
+});
+
 test('honeypot signup triggers IP ban and creates no user', async () => {
   const ctx = await createTestApp();
 

--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -1,0 +1,28 @@
+import type { FastifyInstance } from 'fastify';
+import { emailVerificationRequired } from '../lib/auth.js';
+
+export default async function configRoutes(fastify: FastifyInstance) {
+  fastify.get(
+    '/config',
+    {
+      schema: {
+        tags: ['meta'],
+        summary: 'Get public client configuration',
+        response: {
+          200: {
+            type: 'object',
+            required: ['requireEmailVerification'],
+            properties: {
+              requireEmailVerification: { type: 'boolean' },
+            },
+          },
+        },
+      },
+    },
+    async () => {
+      return {
+        requireEmailVerification: emailVerificationRequired(),
+      };
+    },
+  );
+}

--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { emailVerificationRequired } from '../lib/auth.js';
+import { devMode } from '../lib/dev-mode.js';
 
 export default async function configRoutes(fastify: FastifyInstance) {
   fastify.get(
@@ -11,9 +12,10 @@ export default async function configRoutes(fastify: FastifyInstance) {
         response: {
           200: {
             type: 'object',
-            required: ['requireEmailVerification'],
+            required: ['requireEmailVerification', 'devMode'],
             properties: {
               requireEmailVerification: { type: 'boolean' },
+              devMode: { type: 'boolean' },
             },
           },
         },
@@ -22,6 +24,7 @@ export default async function configRoutes(fastify: FastifyInstance) {
     async () => {
       return {
         requireEmailVerification: emailVerificationRequired(),
+        devMode: devMode(),
       };
     },
   );

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -9,7 +9,6 @@ import { toPublicUser } from '../lib/public-user.js';
 import { seedDefaultLabelsForOwner } from '../services/label-service.js';
 import { seedDefaultProjectsForOwner } from '../services/project-service.js';
 import { deleteAccountForUser, setPasswordForUser } from '../services/user-service.js';
-import { emailVerificationRequired } from '../lib/auth.js';
 
 export default async function meRoutes(fastify: FastifyInstance) {
   fastify.addHook('preHandler', requireAuthenticatedUser);
@@ -197,21 +196,23 @@ export default async function meRoutes(fastify: FastifyInstance) {
         return sendUnauthorized(reply);
       }
 
-      // Only allow setting the initial password once the email is verified —
-      // this is the email-first signup completion step. In dev/test where
-      // verification is not required, any authenticated user may set it.
+      // Only allow the one-time initial password step for verified users marked
+      // by the verification-required email-first signup flow.
       const [user] = await db
-        .select({ emailVerified: users.emailVerified })
+        .select({
+          emailVerified: users.emailVerified,
+          passwordSetupRequired: users.passwordSetupRequired,
+        })
         .from(users)
         .where(eq(users.id, userId))
         .limit(1);
       if (!user) {
         return sendUnauthorized(reply);
       }
-      if (emailVerificationRequired() && !user.emailVerified) {
+      if (!user.emailVerified || !user.passwordSetupRequired) {
         return reply
           .code(403)
-          .send({ message: 'Email must be verified before setting a password.' });
+          .send({ message: 'Password setup is only available after email verification.' });
       }
 
       const ok = await setPasswordForUser(userId, request.body.newPassword);

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -8,7 +8,8 @@ import requireAuthenticatedUser from '../plugins/auth-required.js';
 import { toPublicUser } from '../lib/public-user.js';
 import { seedDefaultLabelsForOwner } from '../services/label-service.js';
 import { seedDefaultProjectsForOwner } from '../services/project-service.js';
-import { deleteAccountForUser } from '../services/user-service.js';
+import { deleteAccountForUser, setPasswordForUser } from '../services/user-service.js';
+import { emailVerificationRequired } from '../lib/auth.js';
 
 export default async function meRoutes(fastify: FastifyInstance) {
   fastify.addHook('preHandler', requireAuthenticatedUser);
@@ -158,6 +159,66 @@ export default async function meRoutes(fastify: FastifyInstance) {
       }
 
       return { user: toPublicUser(user) };
+    },
+  );
+
+  fastify.post<{
+    Body: { newPassword: string };
+    Reply: { ok: true } | { message: string };
+  }>(
+    '/me/password/set',
+    {
+      schema: withJsonResponse({
+        tags: ['auth'],
+        summary: 'Set a new password after email verification (no current password required)',
+        security: authCookieSecurity,
+        body: {
+          type: 'object',
+          required: ['newPassword'],
+          properties: {
+            newPassword: { type: 'string', minLength: 8, maxLength: 128 },
+          },
+        },
+        response: {
+          200: {
+            description: 'Password set',
+            type: 'object',
+            required: ['ok'],
+            properties: { ok: { type: 'boolean' } },
+          },
+          401: errorResponseSchema('Authentication required', 'Unauthorized'),
+          403: errorResponseSchema('Email must be verified first', 'Email not verified'),
+        },
+      }),
+    },
+    async (request, reply) => {
+      const userId = request.userId;
+      if (!userId) {
+        return sendUnauthorized(reply);
+      }
+
+      // Only allow setting the initial password once the email is verified —
+      // this is the email-first signup completion step. In dev/test where
+      // verification is not required, any authenticated user may set it.
+      const [user] = await db
+        .select({ emailVerified: users.emailVerified })
+        .from(users)
+        .where(eq(users.id, userId))
+        .limit(1);
+      if (!user) {
+        return sendUnauthorized(reply);
+      }
+      if (emailVerificationRequired() && !user.emailVerified) {
+        return reply
+          .code(403)
+          .send({ message: 'Email must be verified before setting a password.' });
+      }
+
+      const ok = await setPasswordForUser(userId, request.body.newPassword);
+      if (!ok) {
+        return sendUnauthorized(reply);
+      }
+      return { ok: true };
     },
   );
 

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -175,7 +175,12 @@ export default async function meRoutes(fastify: FastifyInstance) {
           type: 'object',
           required: ['newPassword'],
           properties: {
-            newPassword: { type: 'string', minLength: 8, maxLength: 128 },
+            newPassword: {
+              type: 'string',
+              minLength: 8,
+              maxLength: 128,
+              pattern: '^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*[^A-Za-z0-9]).{8,128}$',
+            },
           },
         },
         response: {

--- a/apps/api/src/routes/password-setup-signup.script.ts
+++ b/apps/api/src/routes/password-setup-signup.script.ts
@@ -1,0 +1,34 @@
+import { randomUUID } from 'node:crypto';
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const dbFile = join(tmpdir(), `yotara-password-setup-${randomUUID()}.db`);
+process.env['DATABASE_URL'] = dbFile;
+process.env['BETTER_AUTH_SECRET'] = 'test-secret-with-enough-entropy-1234567890';
+process.env['APP_BASE_URL'] = 'http://localhost:3000';
+
+try {
+  const { buildApp } = await import('../server.js');
+  const { sqlite } = await import('../db/client.js');
+  const app = await buildApp();
+  const email = `password-setup-${randomUUID()}@example.com`;
+
+  await app.inject({
+    method: 'POST',
+    url: '/auth/sign-up/email',
+    headers: { origin: 'http://localhost:4200' },
+    payload: { email, password: 'Password123!', name: 'Password Setup User' },
+  });
+
+  const row = sqlite
+    .prepare('SELECT passwordSetupRequired FROM user WHERE email = ?')
+    .get(email) as { passwordSetupRequired: number } | undefined;
+  console.log(`PASSWORD_SETUP_REQUIRED:${row?.passwordSetupRequired ?? 'missing'}`);
+  await app.close();
+} finally {
+  delete process.env['DATABASE_URL'];
+  delete process.env['BETTER_AUTH_SECRET'];
+  delete process.env['APP_BASE_URL'];
+  rmSync(dbFile, { force: true });
+}

--- a/apps/api/src/routes/unverified-signin.script.ts
+++ b/apps/api/src/routes/unverified-signin.script.ts
@@ -30,8 +30,16 @@ try {
   });
 
   console.log(`SIGNIN_STATUS:${signIn.statusCode}`);
-  const body = signIn.json() as { code?: string };
-  console.log(`SIGNIN_CODE:${body.code ?? 'none'}`);
+  console.log(`SIGNIN_BODY:${JSON.stringify(signIn.json())}`);
+
+  const unknownSignIn = await app.inject({
+    method: 'POST',
+    url: '/auth/sign-in/email',
+    headers: { origin: 'http://localhost:4200' },
+    payload: { email: `unknown-${randomUUID()}@example.com`, password: 'Password123!' },
+  });
+  console.log(`UNKNOWN_SIGNIN_STATUS:${unknownSignIn.statusCode}`);
+  console.log(`UNKNOWN_SIGNIN_BODY:${JSON.stringify(unknownSignIn.json())}`);
 
   const { getRemainingLockoutSeconds } = await import('../lib/login-lockout.js');
   console.log(`LOCKOUT_REMAINING:${getRemainingLockoutSeconds('127.0.0.1', email)}`);

--- a/apps/api/src/routes/unverified-signin.script.ts
+++ b/apps/api/src/routes/unverified-signin.script.ts
@@ -1,0 +1,45 @@
+// Spawned by auth.test.ts with REQUIRE_EMAIL_VERIFICATION=true to exercise the
+// unverified-sign-in path in a fresh process (gating is read at module load).
+import { randomUUID } from 'node:crypto';
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const dbFile = join(tmpdir(), `yotara-unverified-${randomUUID()}.db`);
+process.env['DATABASE_URL'] = dbFile;
+process.env['BETTER_AUTH_SECRET'] = 'test-secret-with-enough-entropy-1234567890';
+process.env['APP_BASE_URL'] = 'http://localhost:3000';
+
+try {
+  const { buildApp } = await import('../server.js');
+  const app = await buildApp();
+
+  const email = `unverified-${randomUUID()}@example.com`;
+  await app.inject({
+    method: 'POST',
+    url: '/auth/sign-up/email',
+    headers: { origin: 'http://localhost:4200' },
+    payload: { email, password: 'Password123!', name: 'Unverified User' },
+  });
+
+  const signIn = await app.inject({
+    method: 'POST',
+    url: '/auth/sign-in/email',
+    headers: { origin: 'http://localhost:4200' },
+    payload: { email, password: 'Password123!' },
+  });
+
+  console.log(`SIGNIN_STATUS:${signIn.statusCode}`);
+  const body = signIn.json() as { code?: string };
+  console.log(`SIGNIN_CODE:${body.code ?? 'none'}`);
+
+  const { getRemainingLockoutSeconds } = await import('../lib/login-lockout.js');
+  console.log(`LOCKOUT_REMAINING:${getRemainingLockoutSeconds('127.0.0.1', email)}`);
+
+  await app.close();
+} finally {
+  delete process.env['DATABASE_URL'];
+  delete process.env['BETTER_AUTH_SECRET'];
+  delete process.env['APP_BASE_URL'];
+  rmSync(dbFile, { force: true });
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -6,6 +6,7 @@ import { AppError } from './lib/app-error.js';
 import corsPlugin from './plugins/cors.js';
 import authBridgePlugin, { applyCorsHeaders } from './plugins/auth-bridge.js';
 import { registerOpenApi } from './docs/openapi.js';
+import { startUnverifiedCleanupJob } from './lib/email-cleanup.js';
 import healthRoutes from './routes/health.js';
 import meRoutes from './routes/me.js';
 import configRoutes from './routes/config.js';
@@ -120,6 +121,9 @@ export async function startServer() {
   const app = await buildApp();
   const port = Number(process.env['PORT'] ?? 3000);
   const host = process.env['HOST'] ?? '0.0.0.0';
+
+  // Delete unverified accounts older than 24h (production or dev override).
+  startUnverifiedCleanupJob();
 
   try {
     await app.listen({ port, host });

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -8,6 +8,7 @@ import corsPlugin from './plugins/cors.js';
 import authBridgePlugin, { applyCorsHeaders } from './plugins/auth-bridge.js';
 import { registerOpenApi } from './docs/openapi.js';
 import { startUnverifiedCleanupJob } from './lib/email-cleanup.js';
+import { getTrustedProxy } from './lib/trusted-proxy.js';
 import healthRoutes from './routes/health.js';
 import meRoutes from './routes/me.js';
 import configRoutes from './routes/config.js';
@@ -46,17 +47,17 @@ export async function buildApp() {
   // in case auth.ts is not imported first.
   assertAuthSecretConfigured();
 
-  // trustProxy: 1 — nginx sits in front and appends the real client IP as the
-  // last entry in X-Forwarded-For ($proxy_add_x_forwarded_for). Fastify reads
-  // the last entry as request.ip, which is the authoritative client address.
-  const app = Fastify({ logger: true, trustProxy: 1 });
+  // Trust forwarded client IPs only from explicitly configured proxy addresses.
+  // Direct API deployments default to no proxy trust, so client-supplied
+  // X-Forwarded-For headers cannot control rate-limit or auth-abuse keys.
+  const app = Fastify({ logger: true, trustProxy: getTrustedProxy() });
 
   await registerOpenApi(app);
   await app.register(corsPlugin);
 
   // Global rate limiting (read at registration time so tests can configure via env).
-  // Relies on trustProxy: 1 (set above) so request.ip is the real client IP
-  // from the last X-Forwarded-For entry, not the client-controlled first entry.
+  // request.ip is derived from the socket address unless it comes through a
+  // configured trusted proxy.
   const rateLimitMax = Number(process.env['RATE_LIMIT_MAX'] ?? 200);
   const rateLimitWindowMs = Number(process.env['RATE_LIMIT_WINDOW_MINUTES'] ?? 1) * 60 * 1000;
   await app.register(rateLimit, {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -8,6 +8,7 @@ import authBridgePlugin, { applyCorsHeaders } from './plugins/auth-bridge.js';
 import { registerOpenApi } from './docs/openapi.js';
 import healthRoutes from './routes/health.js';
 import meRoutes from './routes/me.js';
+import configRoutes from './routes/config.js';
 import labelRoutes from './routes/labels.js';
 import notificationRoutes from './routes/notifications.js';
 import projectRoutes from './routes/projects.js';
@@ -103,6 +104,7 @@ export async function buildApp() {
   });
 
   await app.register(healthRoutes);
+  await app.register(configRoutes);
   await app.register(meRoutes);
   await app.register(labelRoutes);
   await app.register(notificationRoutes);

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import rateLimit from '@fastify/rate-limit';
 import { AppError } from './lib/app-error.js';
+import { assertAuthSecretConfigured } from './lib/auth-secret.js';
 import corsPlugin from './plugins/cors.js';
 import authBridgePlugin, { applyCorsHeaders } from './plugins/auth-bridge.js';
 import { registerOpenApi } from './docs/openapi.js';
@@ -38,19 +39,12 @@ const SECURITY_HEADERS: Record<string, string> = {
 };
 
 export async function buildApp() {
-  // Fail fast if Better Auth has no real secret in production. Session tokens are
-  // HMAC-signed with this secret, so a default/placeholder value lets anyone forge
-  // sessions for any account. Better Auth reads BETTER_AUTH_SECRET from the env by
-  // default; this guard is defense-in-depth in case auth.ts is not imported first.
-  const nodeEnv = process.env['NODE_ENV'] ?? 'development';
-  if (
-    nodeEnv !== 'development' &&
-    nodeEnv !== 'test' &&
-    (!process.env['BETTER_AUTH_SECRET'] ||
-      process.env['BETTER_AUTH_SECRET'] === 'local-dev-secret-change-me')
-  ) {
-    throw new Error('BETTER_AUTH_SECRET must be set to a unique value in production.');
-  }
+  // Fail fast if Better Auth has no strong secret in production. Session
+  // tokens are HMAC-signed with this secret, so a missing/weak value lets
+  // anyone forge sessions for any account. Better Auth reads
+  // BETTER_AUTH_SECRET from the env by default; this guard is defense-in-depth
+  // in case auth.ts is not imported first.
+  assertAuthSecretConfigured();
 
   // trustProxy: 1 — nginx sits in front and appends the real client IP as the
   // last entry in X-Forwarded-For ($proxy_add_x_forwarded_for). Fastify reads

--- a/apps/api/src/services/user-service.test.ts
+++ b/apps/api/src/services/user-service.test.ts
@@ -298,6 +298,39 @@ test('User Service — deleteAccountForUser', async (t) => {
       );
     });
 
+    await t.test('sets password once for a flagged verified account', async () => {
+      const email = `${randomUUID()}@test.com`;
+      const userId = await seedUser(ctx, email, 'initial-password');
+      await ctx.db
+        .update(ctx.schema.users)
+        .set({ passwordSetupRequired: true })
+        .where(eq(ctx.schema.users.id, userId));
+
+      const first = await ctx.userService.setPasswordForUser(
+        userId,
+        'new-password',
+        async () => 'hashed-new-password',
+      );
+      assert.equal(first, true);
+      const second = await ctx.userService.setPasswordForUser(
+        userId,
+        'another-password',
+        async () => 'hashed-another-password',
+      );
+      assert.equal(second, false);
+
+      const [user] = await ctx.db
+        .select({ passwordSetupRequired: ctx.schema.users.passwordSetupRequired })
+        .from(ctx.schema.users)
+        .where(eq(ctx.schema.users.id, userId));
+      assert.equal(user.passwordSetupRequired, false);
+      const [account] = await ctx.db
+        .select({ password: ctx.schema.accounts.password })
+        .from(ctx.schema.accounts)
+        .where(eq(ctx.schema.accounts.userId, userId));
+      assert.equal(account.password, 'hashed-new-password');
+    });
+
     await t.test('returns user_not_found for non-existent user', async () => {
       const result = await ctx.userService.deleteAccountForUser(randomUUID(), 'any-password');
       assert.deepEqual(result, { ok: false, reason: 'user_not_found' });

--- a/apps/api/src/services/user-service.ts
+++ b/apps/api/src/services/user-service.ts
@@ -1,5 +1,8 @@
 import { and, eq, sql } from 'drizzle-orm';
-import { verifyPassword as betterAuthVerifyPassword } from 'better-auth/crypto';
+import {
+  hashPassword as betterAuthHashPassword,
+  verifyPassword as betterAuthVerifyPassword,
+} from 'better-auth/crypto';
 import { db } from '../db/client.js';
 import { accounts, labels, projects, sessions, tasks, users, verifications } from '../db/schema.js';
 
@@ -7,6 +10,29 @@ export type DeleteAccountResult =
   | { ok: true }
   | { ok: false; reason: 'invalid_password' }
   | { ok: false; reason: 'user_not_found' };
+
+/**
+ * Set a new password for a user without verifying the current one.
+ *
+ * Used by the email-first signup flow: the account is created with a throwaway
+ * placeholder password that the user never knows, so after email verification
+ * they must be able to set a real password without proving the placeholder.
+ * The caller (the /auth/set-password route) is responsible for ensuring the
+ * user is authenticated AND email-verified.
+ */
+export async function setPasswordForUser(
+  userId: string,
+  newPassword: string,
+  hash: (password: string) => Promise<string> = (password) => betterAuthHashPassword(password),
+): Promise<boolean> {
+  const passwordHash = await hash(newPassword);
+  const result = await db
+    .update(accounts)
+    .set({ password: passwordHash, updatedAt: new Date() })
+    .where(and(eq(accounts.userId, userId), eq(accounts.providerId, 'credential')));
+
+  return result.changes > 0;
+}
 
 /**
  * Permanently delete a user account and all associated data.

--- a/apps/api/src/services/user-service.ts
+++ b/apps/api/src/services/user-service.ts
@@ -4,6 +4,7 @@ import {
   verifyPassword as betterAuthVerifyPassword,
 } from 'better-auth/crypto';
 import { db } from '../db/client.js';
+import { AppError } from '../lib/app-error.js';
 import { accounts, labels, projects, sessions, tasks, users, verifications } from '../db/schema.js';
 
 export type DeleteAccountResult =
@@ -17,8 +18,8 @@ export type DeleteAccountResult =
  * Used by the email-first signup flow: the account is created with a throwaway
  * placeholder password that the user never knows, so after email verification
  * they must be able to set a real password without proving the placeholder.
- * The caller (the /auth/set-password route) is responsible for ensuring the
- * user is authenticated AND email-verified.
+ * The caller is responsible for ensuring the user is authenticated, verified,
+ * and marked for initial password setup.
  */
 export async function setPasswordForUser(
   userId: string,
@@ -26,12 +27,29 @@ export async function setPasswordForUser(
   hash: (password: string) => Promise<string> = (password) => betterAuthHashPassword(password),
 ): Promise<boolean> {
   const passwordHash = await hash(newPassword);
-  const result = await db
-    .update(accounts)
-    .set({ password: passwordHash, updatedAt: new Date() })
-    .where(and(eq(accounts.userId, userId), eq(accounts.providerId, 'credential')));
+  return db.transaction(
+    (tx) => {
+      const flag = tx
+        .update(users)
+        .set({ passwordSetupRequired: false, updatedAt: new Date() })
+        .where(and(eq(users.id, userId), eq(users.passwordSetupRequired, true)))
+        .run();
+      if (flag.changes === 0) {
+        return false;
+      }
 
-  return result.changes > 0;
+      const result = tx
+        .update(accounts)
+        .set({ password: passwordHash, updatedAt: new Date() })
+        .where(and(eq(accounts.userId, userId), eq(accounts.providerId, 'credential')))
+        .run();
+      if (result.changes === 0) {
+        throw new AppError(500, 'Credential account not found while setting password.');
+      }
+      return true;
+    },
+    { behavior: 'immediate' },
+  );
 }
 
 /**

--- a/apps/frontend/e2e/PLAN.md
+++ b/apps/frontend/e2e/PLAN.md
@@ -158,12 +158,12 @@ Separate Playwright project with empty `storageState` so it creates a fresh user
 |------|--------|-------|
 | `RATE_LIMIT_MAX` dev default | 1000 | 55 tests make ~250-500 API calls — well under limit |
 | Login spec `test.use` | Redundant | `storageState` is already set at project level; no impact on correctness |
-| CI integration | In progress | Pipeline runs but fails on `wait-on`/`@types/node` — fixes applied, awaiting next run |
+| CI integration | Configured | CI starts both services with explicit logs/PIDs, runs mode-aware E2E, uploads diagnostics, and always cleans up; verify on the next CI run |
 | Test run duration | ~2 min | Full suite runs in ~2 minutes locally; CI may be slower |
 
 ### Next steps
 
-1. **Re-run CI pipeline**: Latest commit fixes `wait-on` invocation (via npm script) and `@types/node` typecheck errors. Push and verify green.
+1. **Run CI verification**: Confirm the configured service cleanup and diagnostics steps pass on the next CI run.
 2. **Monitor flakiness**: The 5s confirm-dialog timeout is generous but may need adjustment on slower CI runners.
 3. **Clean up redundant config**: The login spec's `test.use({ storageState: { cookies: [], origins: [] } })` is duplicative of the project-level config.
 4. **Add more edge cases**: Data export in settings, pagination (10/25/page nav), search sort (Date/A-Z), #tag label resolution in capture bar.

--- a/apps/frontend/e2e/fixtures/auth.ts
+++ b/apps/frontend/e2e/fixtures/auth.ts
@@ -1,5 +1,46 @@
 import { test as base, expect, type Page } from '@playwright/test';
 
+export interface RuntimeConfig {
+  requireEmailVerification: boolean;
+  devMode: boolean;
+}
+
+function isRuntimeConfig(value: unknown): value is RuntimeConfig {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  if (!('requireEmailVerification' in value) || !('devMode' in value)) {
+    return false;
+  }
+  return typeof value.requireEmailVerification === 'boolean' && typeof value.devMode === 'boolean';
+}
+
+export async function getRuntimeConfig(): Promise<RuntimeConfig> {
+  const apiUrl = process.env['E2E_API_URL'] ?? 'http://localhost:3000';
+  const response = await fetch(`${apiUrl.replace(/\/$/, '')}/config`);
+  if (!response.ok) {
+    throw new Error(`Runtime config request failed with status ${response.status}`);
+  }
+
+  const config: unknown = await response.json();
+  if (!isRuntimeConfig(config)) {
+    throw new Error(`Runtime config response has an invalid shape from ${response.url}`);
+  }
+  return config;
+}
+
+const e2eTest = base.extend({
+  page: async ({ page }, use) => {
+    const apiUrl = process.env['E2E_API_URL'];
+    if (apiUrl) {
+      await page.addInitScript((url) => {
+        (window as Window & { __YOTARA_E2E_API_URL__?: string }).__YOTARA_E2E_API_URL__ = url;
+      }, apiUrl);
+    }
+    await use(page);
+  },
+});
+
 export async function dismissTip(page: Page) {
   const tip = page.locator('.tip-backdrop');
   if (await tip.isVisible({ timeout: 1000 }).catch(() => false)) {
@@ -8,6 +49,6 @@ export async function dismissTip(page: Page) {
   }
 }
 
-export const test = base;
+export const test = e2eTest;
 
 export { expect };

--- a/apps/frontend/e2e/global-setup.ts
+++ b/apps/frontend/e2e/global-setup.ts
@@ -1,15 +1,15 @@
 import { chromium } from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
+import { getRuntimeConfig } from './fixtures/auth';
 
-const BASE_URL = 'http://localhost:4200';
+const BASE_URL = process.env['E2E_BASE_URL'] ?? 'http://localhost:4200';
 const AUTH_DIR = path.resolve('e2e/.auth');
 const AUTH_FILE = path.join(AUTH_DIR, 'user.json');
 const TEST_EMAIL = `e2e-${Date.now()}@yotara.test`;
 const TEST_PASSWORD = 'E2eTestPass123!';
 const TEST_NAME = 'E2E Tester';
 const LOG_FILE = path.resolve('e2e/.auth/setup-log.txt');
-const EMAIL_FIRST = process.env['REQUIRE_EMAIL_VERIFICATION'] === 'true';
 
 function log(msg: string) {
   try {
@@ -57,16 +57,29 @@ async function setup() {
   log('Starting setup...');
   await waitForServer(BASE_URL, 'Frontend');
   log('Frontend ready');
-  await waitForServer('http://localhost:3000/health', 'API');
+  const apiUrl = process.env['E2E_API_URL'] ?? 'http://localhost:3000';
+  await waitForServer(`${apiUrl}/health`, 'API');
   log('API ready');
+  const { requireEmailVerification } = await getRuntimeConfig();
+  log(`Runtime config: requireEmailVerification=${requireEmailVerification}`);
 
   if (!fs.existsSync(AUTH_DIR)) {
     fs.mkdirSync(AUTH_DIR, { recursive: true });
+  }
+  const apiLogFile = process.env['E2E_API_LOG'] ?? process.env['API_LOG_FILE'];
+  if (apiLogFile && !fs.existsSync(apiLogFile)) {
+    fs.writeFileSync(apiLogFile, '');
   }
 
   log('Launching browser...');
   const browser = await chromium.launch();
   const context = await browser.newContext();
+  const browserApiUrl = process.env['E2E_API_URL'];
+  if (browserApiUrl) {
+    await context.addInitScript((url) => {
+      (window as Window & { __YOTARA_E2E_API_URL__?: string }).__YOTARA_E2E_API_URL__ = url;
+    }, browserApiUrl);
+  }
   const page = await context.newPage();
 
   try {
@@ -81,7 +94,7 @@ async function setup() {
     await page.getByLabel('Name').fill(TEST_NAME);
     await page.getByLabel('Email').fill(TEST_EMAIL);
 
-    if (EMAIL_FIRST) {
+    if (requireEmailVerification) {
       // Email-first: no password field at signup; use the exact verification
       // link emitted in the API console fallback.
       await page.getByRole('button', { name: 'Create account' }).click();

--- a/apps/frontend/e2e/global-setup.ts
+++ b/apps/frontend/e2e/global-setup.ts
@@ -33,9 +33,7 @@ async function waitForServer(url: string, label: string, maxRetries = 30) {
 }
 
 /** Read the most recent verification URL from the API log (console fallback). */
-function getVerificationToken(): string {
-  // Better Auth emails a JWT link and does not persist the token in the DB;
-  // in dev/test the email body (with the link) is logged to the API console.
+function getVerificationUrl(): string {
   const logFile = process.env['E2E_API_LOG'] ?? process.env['API_LOG_FILE'];
   if (!logFile) {
     throw new Error(
@@ -43,17 +41,16 @@ function getVerificationToken(): string {
     );
   }
   const log = fs.readFileSync(logFile, 'utf8');
-  // The setup just created the account, so the most recent verify link is ours.
   const lines = log.split('\n').reverse();
-  const linkLine = lines.find((l) => l.includes('verify-email?token='));
+  const linkLine = lines.find((l) => l.includes('/verify-email?token='));
   if (!linkLine) {
     throw new Error(`No verification link found in ${logFile}`);
   }
-  const match = linkLine.match(/verify-email\?token=([^&\s]+)/);
+  const match = linkLine.match(/https?:\/\/[^\s]+\/verify-email\?token=[^&\s]+/);
   if (!match) {
-    throw new Error(`Could not extract token from: ${linkLine}`);
+    throw new Error(`Could not extract verification URL from: ${linkLine}`);
   }
-  return decodeURIComponent(match[1]);
+  return match[0];
 }
 
 async function setup() {
@@ -85,12 +82,12 @@ async function setup() {
     await page.getByLabel('Email').fill(TEST_EMAIL);
 
     if (EMAIL_FIRST) {
-      // Email-first: no password field at signup; the verification link is
-      // emailed (logged to the API console / stored in the verification table).
+      // Email-first: no password field at signup; use the exact verification
+      // link emitted in the API console fallback.
       await page.getByRole('button', { name: 'Create account' }).click();
       await page.getByRole('heading', { name: 'Check your email' }).waitFor();
-      const token = getVerificationToken();
-      await page.goto(`${BASE_URL}/verify-email?token=${token}`);
+      const verificationUrl = getVerificationUrl();
+      await page.goto(verificationUrl);
       await page.getByLabel('Password').fill(TEST_PASSWORD);
       await page.getByRole('button', { name: 'Set password and continue' }).click();
     } else {

--- a/apps/frontend/e2e/global-setup.ts
+++ b/apps/frontend/e2e/global-setup.ts
@@ -9,6 +9,7 @@ const TEST_EMAIL = `e2e-${Date.now()}@yotara.test`;
 const TEST_PASSWORD = 'E2eTestPass123!';
 const TEST_NAME = 'E2E Tester';
 const LOG_FILE = path.resolve('e2e/.auth/setup-log.txt');
+const EMAIL_FIRST = process.env['REQUIRE_EMAIL_VERIFICATION'] === 'true';
 
 function log(msg: string) {
   try {
@@ -29,6 +30,30 @@ async function waitForServer(url: string, label: string, maxRetries = 30) {
     await new Promise((r) => setTimeout(r, 1000));
   }
   throw new Error(`${label} at ${url} did not become available`);
+}
+
+/** Read the most recent verification URL from the API log (console fallback). */
+function getVerificationToken(): string {
+  // Better Auth emails a JWT link and does not persist the token in the DB;
+  // in dev/test the email body (with the link) is logged to the API console.
+  const logFile = process.env['E2E_API_LOG'] ?? process.env['API_LOG_FILE'];
+  if (!logFile) {
+    throw new Error(
+      'E2E_API_LOG must point at the API log file (it contains the console-printed verification link).',
+    );
+  }
+  const log = fs.readFileSync(logFile, 'utf8');
+  // The setup just created the account, so the most recent verify link is ours.
+  const lines = log.split('\n').reverse();
+  const linkLine = lines.find((l) => l.includes('verify-email?token='));
+  if (!linkLine) {
+    throw new Error(`No verification link found in ${logFile}`);
+  }
+  const match = linkLine.match(/verify-email\?token=([^&\s]+)/);
+  if (!match) {
+    throw new Error(`Could not extract token from: ${linkLine}`);
+  }
+  return decodeURIComponent(match[1]);
 }
 
 async function setup() {
@@ -58,10 +83,20 @@ async function setup() {
     log('Filling form...');
     await page.getByLabel('Name').fill(TEST_NAME);
     await page.getByLabel('Email').fill(TEST_EMAIL);
-    await page.getByLabel('Password').fill(TEST_PASSWORD);
 
-    log('Submitting...');
-    await page.getByRole('button', { name: 'Create account' }).click();
+    if (EMAIL_FIRST) {
+      // Email-first: no password field at signup; the verification link is
+      // emailed (logged to the API console / stored in the verification table).
+      await page.getByRole('button', { name: 'Create account' }).click();
+      await page.getByRole('heading', { name: 'Check your email' }).waitFor();
+      const token = getVerificationToken();
+      await page.goto(`${BASE_URL}/verify-email?token=${token}`);
+      await page.getByLabel('Password').fill(TEST_PASSWORD);
+      await page.getByRole('button', { name: 'Set password and continue' }).click();
+    } else {
+      await page.getByLabel('Password').fill(TEST_PASSWORD);
+      await page.getByRole('button', { name: 'Create account' }).click();
+    }
 
     log('Waiting for onboarding...');
     await page.waitForURL(/\/onboarding/);

--- a/apps/frontend/e2e/specs/authenticated/notifications.spec.ts
+++ b/apps/frontend/e2e/specs/authenticated/notifications.spec.ts
@@ -8,7 +8,6 @@ test.describe('Notifications', () => {
     await page.waitForLoadState('networkidle');
     await dismissTip(page);
 
-    const today = new Date().toISOString().slice(0, 10);
     const name = taskName('notif');
 
     // Create a task via the capture bar

--- a/apps/frontend/e2e/specs/authenticated/onboarding.spec.ts
+++ b/apps/frontend/e2e/specs/authenticated/onboarding.spec.ts
@@ -5,23 +5,23 @@ test.use({ storageState: { cookies: [], origins: [] } });
 
 const EMAIL_FIRST = process.env['REQUIRE_EMAIL_VERIFICATION'] === 'true';
 
-/** Read the most recent verification URL from the API log (console fallback). */
-function getVerificationToken(): string {
+/** Read the exact frontend verification URL emitted in the email log. */
+function getVerificationUrl(): string {
   const logFile = process.env['E2E_API_LOG'] ?? process.env['API_LOG_FILE'];
   if (!logFile) {
     throw new Error('E2E_API_LOG must point at the API log file');
   }
   const log = fs.readFileSync(logFile, 'utf8');
   const lines = log.split('\n').reverse();
-  const linkLine = lines.find((l) => l.includes('verify-email?token='));
+  const linkLine = lines.find((l) => l.includes('/verify-email?token='));
   if (!linkLine) {
     throw new Error(`No verification link found in ${logFile}`);
   }
-  const match = linkLine.match(/verify-email\?token=([^&\s]+)/);
+  const match = linkLine.match(/https?:\/\/[^\s]+\/verify-email\?token=[^&\s]+/);
   if (!match) {
-    throw new Error(`Could not extract token from: ${linkLine}`);
+    throw new Error(`Could not extract verification URL from: ${linkLine}`);
   }
-  return decodeURIComponent(match[1]);
+  return match[0];
 }
 
 /** Complete signup in either mode (legacy password form, or email-first). */
@@ -41,8 +41,8 @@ async function signUp(
   if (EMAIL_FIRST) {
     await page.getByRole('button', { name: 'Create account' }).click();
     await page.getByRole('heading', { name: 'Check your email' }).waitFor();
-    const token = getVerificationToken();
-    await page.goto(`/verify-email?token=${token}`);
+    const verificationUrl = getVerificationUrl();
+    await page.goto(verificationUrl);
     await page.getByLabel('Password').fill(password);
     await page.getByRole('button', { name: 'Set password and continue' }).click();
   } else {

--- a/apps/frontend/e2e/specs/authenticated/onboarding.spec.ts
+++ b/apps/frontend/e2e/specs/authenticated/onboarding.spec.ts
@@ -1,6 +1,55 @@
 import { test, expect } from '../../fixtures/auth';
+import fs from 'node:fs';
 
 test.use({ storageState: { cookies: [], origins: [] } });
+
+const EMAIL_FIRST = process.env['REQUIRE_EMAIL_VERIFICATION'] === 'true';
+
+/** Read the most recent verification URL from the API log (console fallback). */
+function getVerificationToken(): string {
+  const logFile = process.env['E2E_API_LOG'] ?? process.env['API_LOG_FILE'];
+  if (!logFile) {
+    throw new Error('E2E_API_LOG must point at the API log file');
+  }
+  const log = fs.readFileSync(logFile, 'utf8');
+  const lines = log.split('\n').reverse();
+  const linkLine = lines.find((l) => l.includes('verify-email?token='));
+  if (!linkLine) {
+    throw new Error(`No verification link found in ${logFile}`);
+  }
+  const match = linkLine.match(/verify-email\?token=([^&\s]+)/);
+  if (!match) {
+    throw new Error(`Could not extract token from: ${linkLine}`);
+  }
+  return decodeURIComponent(match[1]);
+}
+
+/** Complete signup in either mode (legacy password form, or email-first). */
+async function signUp(
+  page: import('@playwright/test').Page,
+  name: string,
+  email: string,
+  password: string,
+) {
+  await page.goto('/login');
+  await page.waitForLoadState('networkidle');
+
+  await page.getByRole('button', { name: 'Create an account' }).click();
+  await page.getByLabel('Name').fill(name);
+  await page.getByLabel('Email').fill(email);
+
+  if (EMAIL_FIRST) {
+    await page.getByRole('button', { name: 'Create account' }).click();
+    await page.getByRole('heading', { name: 'Check your email' }).waitFor();
+    const token = getVerificationToken();
+    await page.goto(`/verify-email?token=${token}`);
+    await page.getByLabel('Password').fill(password);
+    await page.getByRole('button', { name: 'Set password and continue' }).click();
+  } else {
+    await page.getByLabel('Password').fill(password);
+    await page.getByRole('button', { name: 'Create account' }).click();
+  }
+}
 
 test.describe.configure({ mode: 'serial' });
 
@@ -23,14 +72,7 @@ test.describe('Onboarding', () => {
 
   test('shows workspace selection options after sign-up', async ({ page }) => {
     // Sign up as a new user
-    await page.goto('/login');
-    await page.waitForLoadState('networkidle');
-
-    await page.getByRole('button', { name: 'Create an account' }).click();
-    await page.getByLabel('Name').fill(TEST_NAME);
-    await page.getByLabel('Email').fill(TEST_EMAIL);
-    await page.getByLabel('Password').fill(TEST_PASSWORD);
-    await page.getByRole('button', { name: 'Create account' }).click();
+    await signUp(page, TEST_NAME, TEST_EMAIL, TEST_PASSWORD);
 
     // Wait for onboarding page
     await page.waitForURL(/\/onboarding/, { timeout: 15_000 });
@@ -43,14 +85,7 @@ test.describe('Onboarding', () => {
     const email = `onboarding-flow-${Date.now()}@yotara.test`;
 
     // Sign up as a new user
-    await page.goto('/login');
-    await page.waitForLoadState('networkidle');
-
-    await page.getByRole('button', { name: 'Create an account' }).click();
-    await page.getByLabel('Name').fill('Flow Tester');
-    await page.getByLabel('Email').fill(email);
-    await page.getByLabel('Password').fill('FlowTest123!');
-    await page.getByRole('button', { name: 'Create account' }).click();
+    await signUp(page, 'Flow Tester', email, 'FlowTest123!');
 
     // Wait for onboarding page
     await page.waitForURL(/\/onboarding/, { timeout: 15_000 });

--- a/apps/frontend/e2e/specs/authenticated/onboarding.spec.ts
+++ b/apps/frontend/e2e/specs/authenticated/onboarding.spec.ts
@@ -1,9 +1,7 @@
-import { test, expect } from '../../fixtures/auth';
+import { test, expect, getRuntimeConfig } from '../../fixtures/auth';
 import fs from 'node:fs';
 
 test.use({ storageState: { cookies: [], origins: [] } });
-
-const EMAIL_FIRST = process.env['REQUIRE_EMAIL_VERIFICATION'] === 'true';
 
 /** Read the exact frontend verification URL emitted in the email log. */
 function getVerificationUrl(): string {
@@ -38,7 +36,8 @@ async function signUp(
   await page.getByLabel('Name').fill(name);
   await page.getByLabel('Email').fill(email);
 
-  if (EMAIL_FIRST) {
+  const { requireEmailVerification } = await getRuntimeConfig();
+  if (requireEmailVerification) {
     await page.getByRole('button', { name: 'Create account' }).click();
     await page.getByRole('heading', { name: 'Check your email' }).waitFor();
     const verificationUrl = getVerificationUrl();

--- a/apps/frontend/e2e/specs/login/email-first.spec.ts
+++ b/apps/frontend/e2e/specs/login/email-first.spec.ts
@@ -9,24 +9,23 @@ const emailFirst = process.env['REQUIRE_EMAIL_VERIFICATION'] === 'true';
 
 test.use({ storageState: { cookies: [], origins: [] } });
 
-// Better Auth emails a JWT link (console fallback in dev) and does not persist
-// the token in the DB, so read the most recent verification URL from the API log.
-function getVerificationToken(): string {
+// Read the exact frontend verification URL emitted in the email log.
+function getVerificationUrl(): string {
   const logFile = process.env['E2E_API_LOG'] ?? process.env['API_LOG_FILE'];
   if (!logFile) {
     throw new Error('E2E_API_LOG must point at the API log file');
   }
   const log = fs.readFileSync(logFile, 'utf8');
   const lines = log.split('\n').reverse();
-  const linkLine = lines.find((l) => l.includes('verify-email?token='));
+  const linkLine = lines.find((l) => l.includes('/verify-email?token='));
   if (!linkLine) {
     throw new Error(`No verification link found in ${logFile}`);
   }
-  const match = linkLine.match(/verify-email\?token=([^&\s]+)/);
+  const match = linkLine.match(/https?:\/\/[^\s]+\/verify-email\?token=[^&\s]+/);
   if (!match) {
-    throw new Error(`Could not extract token from: ${linkLine}`);
+    throw new Error(`Could not extract verification URL from: ${linkLine}`);
   }
-  return decodeURIComponent(match[1]);
+  return match[0];
 }
 
 test.describe('Email-first signup', () => {
@@ -51,9 +50,9 @@ test.describe('Email-first signup', () => {
     // Check-your-inbox screen.
     await expect(page.getByRole('heading', { name: 'Check your email' })).toBeVisible();
 
-    // Grab the verification token and open the emailed link.
-    const token = getVerificationToken();
-    await page.goto(`/verify-email?token=${token}`);
+    // Open the exact verification link emitted in the email.
+    const verificationUrl = getVerificationUrl();
+    await page.goto(verificationUrl);
 
     // Set-password step.
     await expect(page.getByText('Your email is verified')).toBeVisible();

--- a/apps/frontend/e2e/specs/login/email-first.spec.ts
+++ b/apps/frontend/e2e/specs/login/email-first.spec.ts
@@ -1,11 +1,11 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, getRuntimeConfig } from '../../fixtures/auth';
 import fs from 'node:fs';
 
 // This spec exercises the email-first signup flow (verification required).
 // It only runs when REQUIRE_EMAIL_VERIFICATION=true (dev/test override or
 // production), because the signup form differs in that mode. In the default
 // dev/test CI run the flag is off, so the legacy flow is what runs.
-const emailFirst = process.env['REQUIRE_EMAIL_VERIFICATION'] === 'true';
+let emailFirst = false;
 
 test.use({ storageState: { cookies: [], origins: [] } });
 
@@ -29,11 +29,14 @@ function getVerificationUrl(): string {
 }
 
 test.describe('Email-first signup', () => {
-  test.skip(!emailFirst, 'REQUIRE_EMAIL_VERIFICATION=true is not set');
+  test.beforeAll(async () => {
+    emailFirst = (await getRuntimeConfig()).requireEmailVerification;
+  });
 
   test('signs up with email only, verifies, sets password, and reaches onboarding', async ({
     page,
   }) => {
+    test.skip(!emailFirst, 'Email verification is not required by the running API');
     const email = `e2e-email-first-${Date.now()}@yotara.test`;
 
     await page.goto('/login');

--- a/apps/frontend/e2e/specs/login/email-first.spec.ts
+++ b/apps/frontend/e2e/specs/login/email-first.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+import fs from 'node:fs';
+
+// This spec exercises the email-first signup flow (verification required).
+// It only runs when REQUIRE_EMAIL_VERIFICATION=true (dev/test override or
+// production), because the signup form differs in that mode. In the default
+// dev/test CI run the flag is off, so the legacy flow is what runs.
+const emailFirst = process.env['REQUIRE_EMAIL_VERIFICATION'] === 'true';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+// Better Auth emails a JWT link (console fallback in dev) and does not persist
+// the token in the DB, so read the most recent verification URL from the API log.
+function getVerificationToken(): string {
+  const logFile = process.env['E2E_API_LOG'] ?? process.env['API_LOG_FILE'];
+  if (!logFile) {
+    throw new Error('E2E_API_LOG must point at the API log file');
+  }
+  const log = fs.readFileSync(logFile, 'utf8');
+  const lines = log.split('\n').reverse();
+  const linkLine = lines.find((l) => l.includes('verify-email?token='));
+  if (!linkLine) {
+    throw new Error(`No verification link found in ${logFile}`);
+  }
+  const match = linkLine.match(/verify-email\?token=([^&\s]+)/);
+  if (!match) {
+    throw new Error(`Could not extract token from: ${linkLine}`);
+  }
+  return decodeURIComponent(match[1]);
+}
+
+test.describe('Email-first signup', () => {
+  test.skip(!emailFirst, 'REQUIRE_EMAIL_VERIFICATION=true is not set');
+
+  test('signs up with email only, verifies, sets password, and reaches onboarding', async ({
+    page,
+  }) => {
+    const email = `e2e-email-first-${Date.now()}@yotara.test`;
+
+    await page.goto('/login');
+    await page.getByRole('button', { name: 'Create an account' }).click();
+
+    // Email-first form: no password field.
+    await expect(page.getByRole('heading', { name: 'Create your Yotara account' })).toBeVisible();
+    await expect(page.getByLabel('Password')).toHaveCount(0);
+
+    await page.getByLabel('Name').fill('Email First User');
+    await page.getByLabel('Email').fill(email);
+    await page.getByRole('button', { name: 'Create account' }).click();
+
+    // Check-your-inbox screen.
+    await expect(page.getByRole('heading', { name: 'Check your email' })).toBeVisible();
+
+    // Grab the verification token and open the emailed link.
+    const token = getVerificationToken();
+    await page.goto(`/verify-email?token=${token}`);
+
+    // Set-password step.
+    await expect(page.getByText('Your email is verified')).toBeVisible();
+    await page.getByLabel('Password').fill('NewPassword123!');
+    await page.getByRole('button', { name: 'Set password and continue' }).click();
+
+    // Lands in onboarding (session created via autoSignInAfterVerification).
+    await page.waitForURL(/\/onboarding/, { timeout: 15_000 });
+  });
+});

--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     ? [['html', { outputFolder: './e2e/playwright-report' }], ['github']]
     : 'list',
   use: {
-    baseURL: 'http://localhost:4200',
+    baseURL: process.env['E2E_BASE_URL'] ?? 'http://localhost:4200',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },

--- a/apps/frontend/src/app/app.config.ts
+++ b/apps/frontend/src/app/app.config.ts
@@ -17,6 +17,8 @@ import { loadingInterceptor } from './core/interceptors/loading.interceptor';
 import { errorInterceptor } from './core/interceptors/error.interceptor';
 import { AuthStateService } from './core/services/auth-state.service';
 
+type E2EWindow = Window & { __YOTARA_E2E_API_URL__?: string };
+
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
@@ -33,7 +35,8 @@ export const appConfig: ApplicationConfig = {
       useFactory: () => {
         const authState = inject(AuthStateService);
         return () => {
-          configureAuthClient(`${environment.apiBaseUrl}/auth`);
+          const apiBaseUrl = (window as E2EWindow).__YOTARA_E2E_API_URL__ ?? environment.apiBaseUrl;
+          configureAuthClient(`${apiBaseUrl}/auth`);
           return authState.initialize();
         };
       },

--- a/apps/frontend/src/app/app.routes.ts
+++ b/apps/frontend/src/app/app.routes.ts
@@ -31,6 +31,12 @@ export const routes: Routes = [
     loadComponent: () => import('./features/auth/login.component').then((m) => m.LoginComponent),
   },
   {
+    path: 'verify-email',
+    // No auth guard: the emailed link is clicked before the user has a session.
+    loadComponent: () =>
+      import('./features/auth/verify-email.component').then((m) => m.VerifyEmailComponent),
+  },
+  {
     path: 'forgot-password',
     canActivate: [loginRedirectGuard],
     loadComponent: () =>

--- a/apps/frontend/src/app/core/services/auth-state.service.spec.ts
+++ b/apps/frontend/src/app/core/services/auth-state.service.spec.ts
@@ -233,7 +233,12 @@ describe('AuthStateService', () => {
     const service = TestBed.inject(AuthStateService);
     const result = await service.signUp('test@example.com', 'password', 'Test User');
 
-    expect(AuthService.signUp).toHaveBeenCalledWith('test@example.com', 'password', 'Test User');
+    expect(AuthService.signUp).toHaveBeenCalledWith(
+      'test@example.com',
+      'password',
+      'Test User',
+      '',
+    );
     expect(result.error).toBeNull();
     expect(service.loading()).toBeFalse();
   });

--- a/apps/frontend/src/app/core/services/auth-state.service.spec.ts
+++ b/apps/frontend/src/app/core/services/auth-state.service.spec.ts
@@ -333,4 +333,45 @@ describe('AuthStateService', () => {
     await expectAsync(service.updateProfile({ captureBehavior: 'capture' })).toBeRejected();
     expect(service.loading()).toBeFalse();
   });
+
+  it('does not refresh session when signUp succeeds with requireEmailVerification', async () => {
+    spyOn(AuthService, 'signUp').and.resolveTo({ error: null } as any);
+    spyOn(AuthService, 'getSession');
+
+    const service = TestBed.inject(AuthStateService);
+    // Mimic the runtime config flag
+    (service as any).requireEmailVerificationState.set(true);
+    const result = await service.signUp('test@example.com', 'placeholder', 'Test User');
+
+    expect(result.error).toBeNull();
+    expect(AuthService.getSession).not.toHaveBeenCalled();
+    expect(service.loading()).toBeFalse();
+  });
+
+  it('delegates sendVerificationEmail to AuthService', async () => {
+    spyOn(AuthService, 'sendVerificationEmail').and.resolveTo(undefined as any);
+
+    const service = TestBed.inject(AuthStateService);
+    await service.sendVerificationEmail('test@example.com');
+
+    expect(AuthService.sendVerificationEmail).toHaveBeenCalledWith('test@example.com');
+  });
+
+  it('delegates setPassword to AuthService', async () => {
+    spyOn(AuthService, 'setPassword').and.resolveTo(undefined);
+
+    const service = TestBed.inject(AuthStateService);
+    await service.setPassword('newPass123!');
+
+    expect(AuthService.setPassword).toHaveBeenCalledWith('newPass123!');
+    expect(service.loading()).toBeFalse();
+  });
+
+  it('sets loading false even when setPassword throws', async () => {
+    spyOn(AuthService, 'setPassword').and.rejectWith(new Error('expired token'));
+
+    const service = TestBed.inject(AuthStateService);
+    await expectAsync(service.setPassword('newPass123!')).toBeRejected();
+    expect(service.loading()).toBeFalse();
+  });
 });

--- a/apps/frontend/src/app/core/services/auth-state.service.spec.ts
+++ b/apps/frontend/src/app/core/services/auth-state.service.spec.ts
@@ -199,6 +199,21 @@ describe('AuthStateService', () => {
     expect(AuthService.getSession).toHaveBeenCalledTimes(1);
   });
 
+  it('exposes the runtime config flags from getConfig', async () => {
+    spyOn(AuthService, 'getConfig').and.resolveTo({
+      requireEmailVerification: true,
+      devMode: true,
+    });
+    spyOn(AuthService, 'getSession').and.resolveTo({ data: { session: null, user: null } } as any);
+    spyOn(AuthService, 'getProfile');
+
+    const service = TestBed.inject(AuthStateService);
+    await service.initialize();
+
+    expect(service.requireEmailVerification()).toBeTrue();
+    expect(service.devMode()).toBeTrue();
+  });
+
   it('delegates signIn to AuthService and refreshes session on success', async () => {
     spyOn(AuthService, 'signIn').and.resolveTo({ error: null } as any);
     spyOn(AuthService, 'getSession').and.resolveTo({ data: { session: null, user: null } } as any);

--- a/apps/frontend/src/app/core/services/auth-state.service.ts
+++ b/apps/frontend/src/app/core/services/auth-state.service.ts
@@ -13,6 +13,7 @@ export class AuthStateService {
   private initializedState = signal(false);
   private loadingState = signal(false);
   private requireEmailVerificationState = signal(false);
+  private devModeState = signal(false);
   private logService = inject(LogService);
   private initPromise: Promise<SessionResponse> | null = null;
 
@@ -21,6 +22,7 @@ export class AuthStateService {
   readonly initialized = this.initializedState.asReadonly();
   readonly loading = this.loadingState.asReadonly();
   readonly requireEmailVerification = this.requireEmailVerificationState.asReadonly();
+  readonly devMode = this.devModeState.asReadonly();
   readonly isAuthenticated = computed(() => !!this.sessionState());
   readonly currentUserId = computed(
     () => this.userState()?.id ?? this.sessionState()?.userId ?? null,
@@ -39,11 +41,13 @@ export class AuthStateService {
     }
 
     this.initPromise = (async () => {
-      // Best-effort: the runtime flag decides which signup form to render.
-      // If it fails, default to the legacy form; the flag is not fatal.
+      // Best-effort: the runtime flags decide which signup form to render and
+      // whether the dev-mode badge is shown. If this fails, default to the
+      // legacy form; the flags are not fatal.
       try {
         const config = await AuthService.getConfig();
         this.requireEmailVerificationState.set(config.requireEmailVerification);
+        this.devModeState.set(config.devMode);
       } catch (error) {
         this.logService.error('Failed to load client config', error, 'AuthStateService');
       }

--- a/apps/frontend/src/app/core/services/auth-state.service.ts
+++ b/apps/frontend/src/app/core/services/auth-state.service.ts
@@ -12,6 +12,7 @@ export class AuthStateService {
   private userState = signal<ProfileUser | null>(null);
   private initializedState = signal(false);
   private loadingState = signal(false);
+  private requireEmailVerificationState = signal(false);
   private logService = inject(LogService);
   private initPromise: Promise<SessionResponse> | null = null;
 
@@ -19,6 +20,7 @@ export class AuthStateService {
   readonly user = this.userState.asReadonly();
   readonly initialized = this.initializedState.asReadonly();
   readonly loading = this.loadingState.asReadonly();
+  readonly requireEmailVerification = this.requireEmailVerificationState.asReadonly();
   readonly isAuthenticated = computed(() => !!this.sessionState());
   readonly currentUserId = computed(
     () => this.userState()?.id ?? this.sessionState()?.userId ?? null,
@@ -36,7 +38,17 @@ export class AuthStateService {
       return this.initPromise;
     }
 
-    this.initPromise = this.refreshSession().finally(() => {
+    this.initPromise = (async () => {
+      // Best-effort: the runtime flag decides which signup form to render.
+      // If it fails, default to the legacy form; the flag is not fatal.
+      try {
+        const config = await AuthService.getConfig();
+        this.requireEmailVerificationState.set(config.requireEmailVerification);
+      } catch (error) {
+        this.logService.error('Failed to load client config', error, 'AuthStateService');
+      }
+      return await this.refreshSession();
+    })().finally(() => {
       this.initPromise = null;
     });
 

--- a/apps/frontend/src/app/core/services/auth-state.service.ts
+++ b/apps/frontend/src/app/core/services/auth-state.service.ts
@@ -97,10 +97,9 @@ export class AuthStateService {
     this.loadingState.set(true);
 
     try {
-      // When email verification is required, the "password" is a throwaway
-      // placeholder (email + 5 random letters) — the user sets a real one
-      // after clicking the verification link. Never auto-login for an
-      // unverified account.
+      // When email verification is required, the "password" is a cryptographically
+      // random throwaway value — the user sets a real one after clicking the
+      // verification link. Never auto-login for an unverified account.
       const result = await AuthService.signUp(email, password, name, website);
       if (!result.error && !this.requireEmailVerificationState()) {
         await this.refreshSession();

--- a/apps/frontend/src/app/core/services/auth-state.service.ts
+++ b/apps/frontend/src/app/core/services/auth-state.service.ts
@@ -89,15 +89,48 @@ export class AuthStateService {
     }
   }
 
-  async signUp(email: string, password: string, name: string) {
+  async signUp(email: string, password: string, name: string, website = '') {
     this.loadingState.set(true);
 
     try {
-      const result = await AuthService.signUp(email, password, name);
+      // When email verification is required, the "password" is a throwaway
+      // placeholder (email + 5 random letters) — the user sets a real one
+      // after clicking the verification link. Never auto-login for an
+      // unverified account.
+      const result = await AuthService.signUp(email, password, name, website);
+      if (!result.error && !this.requireEmailVerificationState()) {
+        await this.refreshSession();
+      }
+      return result;
+    } finally {
+      this.loadingState.set(false);
+    }
+  }
+
+  /** Verify the email token from the emailed link (auto-signs-in if enabled). */
+  async verifyEmail(token: string) {
+    this.loadingState.set(true);
+    try {
+      const result = await AuthService.verifyEmail(token);
       if (!result.error) {
         await this.refreshSession();
       }
       return result;
+    } finally {
+      this.loadingState.set(false);
+    }
+  }
+
+  /** Resend the verification email (rate-limited server-side). */
+  async sendVerificationEmail(email: string) {
+    return await AuthService.sendVerificationEmail(email);
+  }
+
+  /** Set the real password after email verification (no current password needed). */
+  async setPassword(newPassword: string) {
+    this.loadingState.set(true);
+    try {
+      await AuthService.setPassword(newPassword);
     } finally {
       this.loadingState.set(false);
     }

--- a/apps/frontend/src/app/features/auth/login.component.html
+++ b/apps/frontend/src/app/features/auth/login.component.html
@@ -36,6 +36,9 @@
             Resend email
           </button>
         </p>
+        @if (error()) {
+          <div class="error-msg" role="alert">{{ error() }}</div>
+        }
       </div>
     } @else {
       <form (ngSubmit)="onSubmit()">

--- a/apps/frontend/src/app/features/auth/login.component.html
+++ b/apps/frontend/src/app/features/auth/login.component.html
@@ -17,104 +17,143 @@
       {{ isLogin() ? 'A calm space for your tasks' : 'Set up your workspace in under a minute' }}
     </p>
 
-    <form (ngSubmit)="onSubmit()">
-      @if (!isLogin()) {
+    @if (emailSubmitted()) {
+      <div class="check-email">
+        <div class="hero-icon" aria-hidden="true">
+          <fa-icon [icon]="faEnvelope" size="2x"></fa-icon>
+        </div>
+        <h2>Check your email</h2>
+        <p>
+          We sent a verification link to <strong>{{ email() }}</strong
+          >. Click it within 15 minutes, then choose a password to finish setting up your account.
+        </p>
+        <p class="check-email-resend">
+          Didn't get it?
+          <button type="button" class="link-button accent-link" (click)="resendVerification()">
+            Resend email
+          </button>
+        </p>
+      </div>
+    } @else {
+      <form (ngSubmit)="onSubmit()">
+        @if (!isLogin()) {
+          <div class="field-group">
+            <label for="name">Name</label>
+            <div class="input-wrap" [class.input-wrap-invalid]="shouldShowFieldError('name')">
+              <input
+                id="name"
+                type="text"
+                [ngModel]="name()"
+                (ngModelChange)="name.set($event)"
+                (blur)="markTouched('name')"
+                name="name"
+                placeholder="Your name"
+                autocomplete="name"
+                required
+              />
+            </div>
+            @if (shouldShowFieldError('name')) {
+              <div class="field-error">{{ getFieldError('name') }}</div>
+            }
+          </div>
+        }
+
         <div class="field-group">
-          <label for="name">Name</label>
-          <div class="input-wrap" [class.input-wrap-invalid]="shouldShowFieldError('name')">
+          <label for="email">Email</label>
+          <div class="input-wrap" [class.input-wrap-invalid]="shouldShowFieldError('email')">
+            <fa-icon class="input-icon" [icon]="faEnvelope" aria-hidden="true"></fa-icon>
             <input
-              id="name"
-              type="text"
-              [ngModel]="name()"
-              (ngModelChange)="name.set($event)"
-              (blur)="markTouched('name')"
-              name="name"
-              placeholder="Your name"
-              autocomplete="name"
+              id="email"
+              type="email"
+              [ngModel]="email()"
+              (ngModelChange)="email.set($event)"
+              (blur)="markTouched('email')"
+              name="email"
+              placeholder="your@email.com"
+              autocomplete="email"
               required
             />
           </div>
-          @if (shouldShowFieldError('name')) {
-            <div class="field-error">{{ getFieldError('name') }}</div>
+          @if (shouldShowFieldError('email')) {
+            <div class="field-error">{{ getFieldError('email') }}</div>
           }
         </div>
-      }
 
-      <div class="field-group">
-        <label for="email">Email</label>
-        <div class="input-wrap" [class.input-wrap-invalid]="shouldShowFieldError('email')">
-          <fa-icon class="input-icon" [icon]="faEnvelope" aria-hidden="true"></fa-icon>
-          <input
-            id="email"
-            type="email"
-            [ngModel]="email()"
-            (ngModelChange)="email.set($event)"
-            (blur)="markTouched('email')"
-            name="email"
-            placeholder="your@email.com"
-            autocomplete="email"
-            required
-          />
-        </div>
-        @if (shouldShowFieldError('email')) {
-          <div class="field-error">{{ getFieldError('email') }}</div>
-        }
-      </div>
+        <div class="field-group">
+          <div class="password-label">
+            <label for="password">Password</label>
+            @if (isLogin()) {
+              <button type="button" class="link-button" (click)="goToForgotPassword()">
+                Forgot password?
+              </button>
+            }
+          </div>
+          @if (!emailFirstSignup) {
+            <div class="input-wrap" [class.input-wrap-invalid]="shouldShowFieldError('password')">
+              <fa-icon class="input-icon" [icon]="faLock" aria-hidden="true"></fa-icon>
+              <input
+                id="password"
+                type="password"
+                [ngModel]="password()"
+                (ngModelChange)="password.set($event)"
+                (blur)="markTouched('password')"
+                name="password"
+                placeholder="••••••••"
+                [attr.minlength]="!isLogin() ? 8 : null"
+                [attr.autocomplete]="isLogin() ? 'current-password' : 'new-password'"
+                required
+              />
+            </div>
+            @if (shouldShowFieldError('password')) {
+              <div class="field-error">{{ getFieldError('password') }}</div>
+            }
 
-      <div class="field-group">
-        <div class="password-label">
-          <label for="password">Password</label>
-          @if (isLogin()) {
-            <button type="button" class="link-button" (click)="goToForgotPassword()">
-              Forgot password?
-            </button>
+            @if (!isLogin()) {
+              <app-strength-meter [password]="password()" />
+            }
+          } @else {
+            <p class="email-first-note">
+              We'll email you a verification link (valid 15 minutes) before you choose a password.
+            </p>
           }
         </div>
-        <div class="input-wrap" [class.input-wrap-invalid]="shouldShowFieldError('password')">
-          <fa-icon class="input-icon" [icon]="faLock" aria-hidden="true"></fa-icon>
-          <input
-            id="password"
-            type="password"
-            [ngModel]="password()"
-            (ngModelChange)="password.set($event)"
-            (blur)="markTouched('password')"
-            name="password"
-            placeholder="••••••••"
-            [attr.minlength]="!isLogin() ? 8 : null"
-            [attr.autocomplete]="isLogin() ? 'current-password' : 'new-password'"
-            required
-          />
-        </div>
-        @if (shouldShowFieldError('password')) {
-          <div class="field-error">{{ getFieldError('password') }}</div>
-        }
 
         @if (!isLogin()) {
-          <app-strength-meter [password]="password()" />
+          <!-- Honeypot: hidden from humans, bots will fill it. -->
+          <input
+            class="honeypot"
+            type="text"
+            name="website"
+            tabindex="-1"
+            autocomplete="off"
+            aria-hidden="true"
+            [ngModel]="website()"
+            (ngModelChange)="website.set($event)"
+          />
         }
-      </div>
 
-      @if (error()) {
-        <div class="error-msg">{{ error() }}</div>
-      }
+        @if (error()) {
+          <div class="error-msg">{{ error() }}</div>
+        }
 
-      <app-password-trial
-        [remainingAttempts]="remainingAttempts()"
-        [retryAfterSeconds]="retryAfterSeconds()"
-      />
+        <app-password-trial
+          [remainingAttempts]="remainingAttempts()"
+          [retryAfterSeconds]="retryAfterSeconds()"
+        />
 
-      <button type="submit" [disabled]="loading() || locked()" class="submit-button">
-        {{ loading() ? 'Loading...' : isLogin() ? 'Sign In' : 'Create account' }}
-      </button>
-    </form>
+        <button type="submit" [disabled]="loading() || locked()" class="submit-button">
+          {{ loading() ? 'Loading...' : isLogin() ? 'Sign In' : 'Create account' }}
+        </button>
+      </form>
 
-    <div class="divider"></div>
-    <p class="toggle-mode">
-      {{ isLogin() ? 'New to Yotara?' : 'Already have an account?' }}
-      <button type="button" (click)="toggleMode()" class="link-button accent-link">
-        {{ isLogin() ? 'Create an account' : 'Sign in' }}
-      </button>
-    </p>
+      <div class="divider"></div>
+      <p class="toggle-mode">
+        {{ isLogin() ? 'New to Yotara?' : 'Already have an account?' }}
+        <button type="button" (click)="toggleMode()" class="link-button accent-link">
+          {{ isLogin() ? 'Create an account' : 'Sign in' }}
+        </button>
+      </p>
+    }
   </div>
   <p class="footer-note">© 2026 Yotara. Designed for focused productivity.</p>
 </div>

--- a/apps/frontend/src/app/features/auth/login.component.html
+++ b/apps/frontend/src/app/features/auth/login.component.html
@@ -12,6 +12,9 @@
         />
       </svg>
     </div>
+    @if (showDevBadge()) {
+      <div class="dev-badge">DEV MODE</div>
+    }
     <h1>{{ isLogin() ? 'Welcome to Yotara' : 'Create your Yotara account' }}</h1>
     <p class="subtitle">
       {{ isLogin() ? 'A calm space for your tasks' : 'Set up your workspace in under a minute' }}

--- a/apps/frontend/src/app/features/auth/login.component.scss
+++ b/apps/frontend/src/app/features/auth/login.component.scss
@@ -39,6 +39,20 @@
   display: block;
 }
 
+.dev-badge {
+  width: fit-content;
+  margin: 0 auto 1rem;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  background: var(--status-overdue);
+  color: var(--surface-container-lowest);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  user-select: none;
+}
+
 .hero-leaf {
   fill: currentcolor;
 }

--- a/apps/frontend/src/app/features/auth/login.component.scss
+++ b/apps/frontend/src/app/features/auth/login.component.scss
@@ -189,6 +189,47 @@ input::placeholder {
   text-align: center;
 }
 
+/* Email-first signup: hidden honeypot field (bots fill it, humans never see it) */
+.honeypot {
+  position: absolute;
+  left: -9999px;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.email-first-note {
+  margin: 0.25rem 0 0;
+  color: var(--on-surface-subtle);
+  font-size: 0.88rem;
+}
+
+.check-email {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+  text-align: center;
+  padding: 0.5rem 0 0.25rem;
+
+  h2 {
+    margin: 0;
+    font-size: 1.35rem;
+  }
+
+  p {
+    margin: 0;
+    color: var(--on-surface-subtle);
+    font-size: 0.95rem;
+    line-height: 1.5;
+  }
+}
+
+.check-email-resend {
+  margin-top: 0.4rem;
+}
+
 @media (width <= 640px) {
   .login-screen {
     justify-content: flex-start;

--- a/apps/frontend/src/app/features/auth/login.component.spec.ts
+++ b/apps/frontend/src/app/features/auth/login.component.spec.ts
@@ -136,6 +136,24 @@ describe('LoginComponent', () => {
     expect(fixture.nativeElement.textContent).toContain('Check your email');
   });
 
+  it('email-first signup shows the error instead of check-email on failure', async () => {
+    authState.requireEmailVerification = () => true;
+    authState.signUp.and.resolveTo({ error: { message: 'Email already in use' } });
+    fixture.detectChanges();
+    component.toggleMode();
+
+    component.name.set('Alex Rivers');
+    component.email.set('alex@example.com');
+
+    await component.onSubmit();
+    fixture.detectChanges();
+
+    expect(component.error()).toBe('Email already in use');
+    expect(component.emailSubmitted()).toBeFalse();
+    expect(fixture.nativeElement.textContent).toContain('Email already in use');
+    expect(fixture.nativeElement.textContent).not.toContain('Check your email');
+  });
+
   it('email-first signup sends the honeypot website value when a bot fills it', async () => {
     authState.requireEmailVerification = () => true;
     fixture.detectChanges();

--- a/apps/frontend/src/app/features/auth/login.component.spec.ts
+++ b/apps/frontend/src/app/features/auth/login.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { LoginComponent } from './login.component';
+import { LoginComponent, isLocalhostHostname } from './login.component';
 import { AuthStateService } from '../../core/services/auth-state.service';
 import { Router } from '@angular/router';
 
@@ -12,6 +12,7 @@ describe('LoginComponent', () => {
     signUp: jasmine.Spy;
     getPostAuthRedirectUrl: jasmine.Spy;
     requireEmailVerification: () => boolean;
+    devMode: () => boolean;
     sendVerificationEmail: jasmine.Spy;
   };
 
@@ -26,6 +27,7 @@ describe('LoginComponent', () => {
       signUp: jasmine.createSpy('signUp').and.resolveTo({ error: null }),
       getPostAuthRedirectUrl: jasmine.createSpy('getPostAuthRedirectUrl').and.returnValue('/inbox'),
       requireEmailVerification: () => false,
+      devMode: () => false,
       sendVerificationEmail: jasmine.createSpy('sendVerificationEmail').and.resolveTo(undefined),
     };
 
@@ -341,5 +343,29 @@ describe('LoginComponent', () => {
     forgotBtn.click();
 
     expect(router.navigate).toHaveBeenCalledWith(['/forgot-password']);
+  });
+
+  it('shows the DEV MODE badge on localhost when dev mode is on', () => {
+    authState.devMode = () => true;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('DEV MODE');
+  });
+
+  it('hides the DEV MODE badge when dev mode is off', () => {
+    authState.devMode = () => false;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).not.toContain('DEV MODE');
+  });
+
+  it('hides the DEV MODE badge on non-localhost hosts even when dev mode is on', () => {
+    // The test URL must not advertise dev mode on screen — the hostname gate
+    // is a pure function so it can be tested without touching window.location.
+    expect(isLocalhostHostname('localhost')).toBeTrue();
+    expect(isLocalhostHostname('127.0.0.1')).toBeTrue();
+    expect(isLocalhostHostname('::1')).toBeTrue();
+    expect(isLocalhostHostname('test.yotara.website')).toBeFalse();
+    expect(isLocalhostHostname('yotara.website')).toBeFalse();
   });
 });

--- a/apps/frontend/src/app/features/auth/login.component.spec.ts
+++ b/apps/frontend/src/app/features/auth/login.component.spec.ts
@@ -126,11 +126,11 @@ describe('LoginComponent', () => {
     await component.onSubmit();
     fixture.detectChanges();
 
-    // Signup called with a throwaway placeholder (email + 5 letters) and the
-    // empty honeypot website value; no auto-login redirect.
+    // Signup receives a cryptographically random placeholder and the empty
+    // honeypot website value; no auto-login redirect.
     expect(authState.signUp).toHaveBeenCalledWith(
       'alex@example.com',
-      jasmine.stringMatching(/^alex@example\.com[a-z]{5}$/),
+      jasmine.stringMatching(/^[0-9a-f]{64}$/),
       'Alex Rivers',
       '',
     );
@@ -169,7 +169,7 @@ describe('LoginComponent', () => {
 
     expect(authState.signUp).toHaveBeenCalledWith(
       'bot@example.com',
-      jasmine.stringMatching(/^bot@example\.com[a-z]{5}$/),
+      jasmine.stringMatching(/^[0-9a-f]{64}$/),
       'Bot',
       'http://spam.example.com',
     );

--- a/apps/frontend/src/app/features/auth/login.component.spec.ts
+++ b/apps/frontend/src/app/features/auth/login.component.spec.ts
@@ -175,6 +175,56 @@ describe('LoginComponent', () => {
     );
   });
 
+  it('email-first signup shows resend error on check-email screen', async () => {
+    authState.requireEmailVerification = () => true;
+    authState.sendVerificationEmail.and.rejectWith(new Error('Rate limited'));
+    fixture.detectChanges();
+    component.toggleMode();
+
+    component.name.set('Alex Rivers');
+    component.email.set('alex@example.com');
+    await component.onSubmit();
+    fixture.detectChanges();
+
+    expect(component.emailSubmitted()).toBeTrue();
+    expect(fixture.nativeElement.textContent).toContain('Check your email');
+
+    // Resend fails; the error must be visible on the check-email screen.
+    const resendBtn: HTMLButtonElement = fixture.nativeElement.querySelector(
+      '.check-email .link-button',
+    );
+    resendBtn.click();
+    await Promise.resolve();
+    fixture.detectChanges();
+
+    expect(component.error()).toContain('Rate limited');
+    expect(fixture.nativeElement.querySelector('.error-msg')).not.toBeNull();
+  });
+
+  it('email-first signup shows resend success message on check-email screen', async () => {
+    authState.requireEmailVerification = () => true;
+    fixture.detectChanges();
+    component.toggleMode();
+
+    component.name.set('Alex Rivers');
+    component.email.set('alex@example.com');
+    await component.onSubmit();
+    fixture.detectChanges();
+
+    expect(component.emailSubmitted()).toBeTrue();
+
+    // Resend succeeds; the success message must be visible.
+    const resendBtn: HTMLButtonElement = fixture.nativeElement.querySelector(
+      '.check-email .link-button',
+    );
+    resendBtn.click();
+    await Promise.resolve();
+    fixture.detectChanges();
+
+    expect(component.error()).toContain('Verification email resent');
+    expect(fixture.nativeElement.querySelector('.error-msg')).not.toBeNull();
+  });
+
   it('shows field error for empty name in sign-up mode', () => {
     fixture.detectChanges();
     component.toggleMode();

--- a/apps/frontend/src/app/features/auth/login.component.spec.ts
+++ b/apps/frontend/src/app/features/auth/login.component.spec.ts
@@ -175,6 +175,17 @@ describe('LoginComponent', () => {
     );
   });
 
+  it('email-first signup clears error and remainingAttempts when toggling mode', () => {
+    fixture.detectChanges();
+    component.error.set('previous error');
+    component.remainingAttempts.set(2);
+
+    component.toggleMode();
+
+    expect(component.error()).toBe('');
+    expect(component.remainingAttempts()).toBeNull();
+  });
+
   it('email-first signup shows resend error on check-email screen', async () => {
     authState.requireEmailVerification = () => true;
     authState.sendVerificationEmail.and.rejectWith(new Error('Rate limited'));

--- a/apps/frontend/src/app/features/auth/login.component.spec.ts
+++ b/apps/frontend/src/app/features/auth/login.component.spec.ts
@@ -11,6 +11,8 @@ describe('LoginComponent', () => {
     signIn: jasmine.Spy;
     signUp: jasmine.Spy;
     getPostAuthRedirectUrl: jasmine.Spy;
+    requireEmailVerification: () => boolean;
+    sendVerificationEmail: jasmine.Spy;
   };
 
   beforeEach(async () => {
@@ -23,6 +25,8 @@ describe('LoginComponent', () => {
       signIn: jasmine.createSpy('signIn').and.resolveTo({ error: null }),
       signUp: jasmine.createSpy('signUp').and.resolveTo({ error: null }),
       getPostAuthRedirectUrl: jasmine.createSpy('getPostAuthRedirectUrl').and.returnValue('/inbox'),
+      requireEmailVerification: () => false,
+      sendVerificationEmail: jasmine.createSpy('sendVerificationEmail').and.resolveTo(undefined),
     };
 
     await TestBed.configureTestingModule({
@@ -97,10 +101,58 @@ describe('LoginComponent', () => {
       'alex@example.com',
       'LongEn0ugh!Pass',
       'Alex Rivers',
+      '',
     );
     expect(router.navigate).toHaveBeenCalledWith(['/onboarding'], {
       queryParams: { created: '1' },
     });
+  });
+
+  it('email-first signup shows no password field and a check-email screen', async () => {
+    authState.requireEmailVerification = () => true;
+    fixture.detectChanges();
+    component.toggleMode();
+    fixture.detectChanges();
+
+    // No password field when verification is required.
+    expect(fixture.nativeElement.querySelector('input[name="password"]')).toBeNull();
+    expect(fixture.nativeElement.textContent).toContain('verification link');
+
+    component.name.set('Alex Rivers');
+    component.email.set('alex@example.com');
+
+    await component.onSubmit();
+    fixture.detectChanges();
+
+    // Signup called with a throwaway placeholder (email + 5 letters) and the
+    // empty honeypot website value; no auto-login redirect.
+    expect(authState.signUp).toHaveBeenCalledWith(
+      'alex@example.com',
+      jasmine.stringMatching(/^alex@example\.com[a-z]{5}$/),
+      'Alex Rivers',
+      '',
+    );
+    expect(router.navigateByUrl).not.toHaveBeenCalled();
+    expect(fixture.nativeElement.textContent).toContain('Check your email');
+  });
+
+  it('email-first signup sends the honeypot website value when a bot fills it', async () => {
+    authState.requireEmailVerification = () => true;
+    fixture.detectChanges();
+    component.toggleMode();
+
+    component.name.set('Bot');
+    component.email.set('bot@example.com');
+    component.website.set('http://spam.example.com');
+
+    await component.onSubmit();
+
+    expect(authState.signUp).toHaveBeenCalledWith(
+      'bot@example.com',
+      jasmine.stringMatching(/^bot@example\.com[a-z]{5}$/),
+      'Bot',
+      'http://spam.example.com',
+    );
   });
 
   it('shows field error for empty name in sign-up mode', () => {

--- a/apps/frontend/src/app/features/auth/login.component.ts
+++ b/apps/frontend/src/app/features/auth/login.component.ts
@@ -225,8 +225,12 @@ export class LoginComponent implements OnDestroy {
           this.name().trim(),
           this.website(),
         );
-        // Email-first: never auto-login; show the check-your-inbox screen even
-        // when the signup succeeded (fake success for honeypot or real).
+        if (res.error) {
+          this.error.set(res.error.message || 'Authentication failed');
+          return;
+        }
+        // Email-first: never auto-login; show the check-your-inbox screen only
+        // on success (including the honeypot fake-success).
         this.emailSubmitted.set(true);
         return;
       } else {

--- a/apps/frontend/src/app/features/auth/login.component.ts
+++ b/apps/frontend/src/app/features/auth/login.component.ts
@@ -204,15 +204,11 @@ export class LoginComponent implements OnDestroy {
     );
   }
 
-  /** Generate the throwaway placeholder password (email + 5 random letters). */
-  private generatePlaceholderPassword(email: string): string {
-    const letters = 'abcdefghijklmnopqrstuvwxyz';
-    let suffix = '';
-    for (let i = 0; i < 5; i++) {
-      suffix += letters[Math.floor(Math.random() * letters.length)];
-    }
-    // email is always >= 8 chars; truncate to stay under Better Auth's max.
-    return `${email}${suffix}`.slice(0, 128);
+  /** Generate a cryptographically random throwaway password. */
+  private generatePlaceholderPassword(): string {
+    const bytes = new Uint8Array(32);
+    crypto.getRandomValues(bytes);
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
   }
 
   async onSubmit() {
@@ -231,7 +227,7 @@ export class LoginComponent implements OnDestroy {
       if (this.isLogin()) {
         res = await this.authState.signIn(this.email().trim(), this.password());
       } else if (this.emailFirstSignup) {
-        const placeholder = this.generatePlaceholderPassword(this.email().trim());
+        const placeholder = this.generatePlaceholderPassword();
         this.placeholderPassword.set(placeholder);
         res = await this.authState.signUp(
           this.email().trim(),

--- a/apps/frontend/src/app/features/auth/login.component.ts
+++ b/apps/frontend/src/app/features/auth/login.component.ts
@@ -10,6 +10,11 @@ import { Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faEnvelope, faLock } from '@fortawesome/free-solid-svg-icons';
+
+/** Localhost hostnames that may show the dev-mode badge on screen. */
+export function isLocalhostHostname(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+}
 import { PasswordTrialComponent } from './password-trial.component';
 import { StrengthMeterComponent } from '../../shared/ui/strength-meter/strength-meter.component';
 import { passwordPolicyMessage } from './password-policy';
@@ -56,6 +61,15 @@ export class LoginComponent implements OnDestroy {
   protected get emailFirstSignup(): boolean {
     return !this.isLogin() && this.authState.requireEmailVerification();
   }
+
+  /**
+   * Dev-mode badge: only when the server reports dev mode AND the app is
+   * served from localhost — a test deployment running dev mode must not
+   * advertise it on screen.
+   */
+  protected readonly showDevBadge = computed(() => {
+    return this.authState.devMode() && isLocalhostHostname(window.location.hostname);
+  });
 
   goToForgotPassword() {
     this.router.navigate(['/forgot-password']);

--- a/apps/frontend/src/app/features/auth/login.component.ts
+++ b/apps/frontend/src/app/features/auth/login.component.ts
@@ -1,4 +1,11 @@
-import { Component, OnDestroy, computed, signal, ChangeDetectionStrategy } from '@angular/core';
+import {
+  Component,
+  OnDestroy,
+  computed,
+  inject,
+  signal,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import { Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
@@ -30,16 +37,40 @@ export class LoginComponent implements OnDestroy {
   error = signal('');
   remainingAttempts = signal<number | null>(null);
   retryAfterSeconds = signal<number | null>(null);
+  /** Email-first signup state: email submitted → check-your-inbox screen. */
+  emailSubmitted = signal(false);
+  /** Hidden honeypot field — bots fill it, humans never see it. */
+  website = signal('');
+  /** The placeholder password used for the unverified signup, kept so the user
+   *  can set a real password after verification (changePassword needs it). */
+  placeholderPassword = signal('');
   protected locked = computed(() => (this.retryAfterSeconds() ?? 0) > 0);
   private countdownInterval: ReturnType<typeof setInterval> | null = null;
+  private authState = inject(AuthStateService);
+  private router = inject(Router);
 
-  constructor(
-    private router: Router,
-    private authState: AuthStateService,
-  ) {}
+  constructor() {}
+
+  /** Whether the signup form should collect a password (false when email
+   *  verification is required — email-first flow). */
+  protected get emailFirstSignup(): boolean {
+    return !this.isLogin() && this.authState.requireEmailVerification();
+  }
 
   goToForgotPassword() {
     this.router.navigate(['/forgot-password']);
+  }
+
+  /** Resend the verification email from the check-your-inbox screen. */
+  async resendVerification() {
+    this.error.set('');
+    try {
+      await this.authState.sendVerificationEmail(this.email().trim());
+      this.error.set('Verification email resent. Check your inbox.');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Could not resend the email.';
+      this.error.set(message);
+    }
   }
 
   ngOnDestroy() {
@@ -128,6 +159,11 @@ export class LoginComponent implements OnDestroy {
       return null;
     }
 
+    // Email-first signup collects no password.
+    if (this.emailFirstSignup) {
+      return null;
+    }
+
     if (!password) {
       return 'Password is required';
     }
@@ -154,6 +190,17 @@ export class LoginComponent implements OnDestroy {
     );
   }
 
+  /** Generate the throwaway placeholder password (email + 5 random letters). */
+  private generatePlaceholderPassword(email: string): string {
+    const letters = 'abcdefghijklmnopqrstuvwxyz';
+    let suffix = '';
+    for (let i = 0; i < 5; i++) {
+      suffix += letters[Math.floor(Math.random() * letters.length)];
+    }
+    // email is always >= 8 chars; truncate to stay under Better Auth's max.
+    return `${email}${suffix}`.slice(0, 128);
+  }
+
   async onSubmit() {
     this.markAllTouched();
     this.error.set('');
@@ -169,8 +216,26 @@ export class LoginComponent implements OnDestroy {
       let res;
       if (this.isLogin()) {
         res = await this.authState.signIn(this.email().trim(), this.password());
+      } else if (this.emailFirstSignup) {
+        const placeholder = this.generatePlaceholderPassword(this.email().trim());
+        this.placeholderPassword.set(placeholder);
+        res = await this.authState.signUp(
+          this.email().trim(),
+          placeholder,
+          this.name().trim(),
+          this.website(),
+        );
+        // Email-first: never auto-login; show the check-your-inbox screen even
+        // when the signup succeeded (fake success for honeypot or real).
+        this.emailSubmitted.set(true);
+        return;
       } else {
-        res = await this.authState.signUp(this.email().trim(), this.password(), this.name().trim());
+        res = await this.authState.signUp(
+          this.email().trim(),
+          this.password(),
+          this.name().trim(),
+          this.website(),
+        );
       }
 
       if (res.error) {

--- a/apps/frontend/src/app/features/auth/verify-email.component.spec.ts
+++ b/apps/frontend/src/app/features/auth/verify-email.component.spec.ts
@@ -83,6 +83,28 @@ describe('VerifyEmailComponent', () => {
     expect(component.state()).toBe('invalid');
   });
 
+  it('shows an error state when verifyEmail throws instead of getting stuck', async () => {
+    authState.verifyEmail.and.rejectWith(new Error('network down'));
+    fixture.detectChanges();
+    await Promise.resolve();
+    fixture.detectChanges();
+
+    // The UI must not remain on "Verifying your email…" — it shows the error.
+    expect(component.state()).toBe('invalid');
+    expect(component.error()).toContain('network down');
+    expect(fixture.nativeElement.textContent).toContain('Back to login');
+  });
+
+  it('falls back to a generic message when the thrown error has no message', async () => {
+    authState.verifyEmail.and.rejectWith(new Error());
+    fixture.detectChanges();
+    await Promise.resolve();
+    fixture.detectChanges();
+
+    expect(component.state()).toBe('invalid');
+    expect(component.error()).toContain('Something went wrong verifying your email');
+  });
+
   it('skips password setup and goes to the workspace for an already set-up account', async () => {
     authState.user = () => ({ emailVerified: true, passwordSetupRequired: false });
     fixture.detectChanges();

--- a/apps/frontend/src/app/features/auth/verify-email.component.spec.ts
+++ b/apps/frontend/src/app/features/auth/verify-email.component.spec.ts
@@ -1,0 +1,104 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { VerifyEmailComponent } from './verify-email.component';
+import { AuthStateService } from '../../core/services/auth-state.service';
+import { StatusService } from '../../core/services/status.service';
+import { ActivatedRoute, Router } from '@angular/router';
+
+describe('VerifyEmailComponent', () => {
+  let fixture: ComponentFixture<VerifyEmailComponent>;
+  let component: VerifyEmailComponent;
+  let router: { navigate: jasmine.Spy };
+  let status: { success: jasmine.Spy };
+  let authState: {
+    verifyEmail: jasmine.Spy;
+    setPassword: jasmine.Spy;
+  };
+
+  beforeEach(async () => {
+    router = { navigate: jasmine.createSpy('navigate').and.resolveTo(true) };
+    status = { success: jasmine.createSpy('success') };
+    authState = {
+      verifyEmail: jasmine.createSpy('verifyEmail').and.resolveTo({ error: null }),
+      setPassword: jasmine.createSpy('setPassword').and.resolveTo(undefined),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [VerifyEmailComponent],
+      providers: [
+        { provide: Router, useValue: router },
+        { provide: StatusService, useValue: status },
+        { provide: AuthStateService, useValue: authState },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { queryParamMap: new Map([['token', 'abc123']]) } },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(VerifyEmailComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('verifies the token and shows the set-password step', async () => {
+    fixture.detectChanges();
+    await Promise.resolve();
+    fixture.detectChanges();
+
+    expect(authState.verifyEmail).toHaveBeenCalledWith('abc123');
+    expect(component.state()).toBe('set-password');
+  });
+
+  it('shows invalid state when the token is missing', async () => {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [VerifyEmailComponent],
+      providers: [
+        { provide: Router, useValue: router },
+        { provide: StatusService, useValue: status },
+        { provide: AuthStateService, useValue: authState },
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: new Map() } } },
+      ],
+    }).compileComponents();
+
+    const f = TestBed.createComponent(VerifyEmailComponent);
+    f.detectChanges();
+    await Promise.resolve();
+    f.detectChanges();
+
+    expect(f.componentInstance.state()).toBe('invalid');
+    expect(authState.verifyEmail).not.toHaveBeenCalled();
+  });
+
+  it('shows invalid state when verification fails', async () => {
+    authState.verifyEmail.and.resolveTo({ error: { message: 'expired' } });
+    fixture.detectChanges();
+    await Promise.resolve();
+    fixture.detectChanges();
+
+    expect(component.state()).toBe('invalid');
+  });
+
+  it('sets the password and navigates to onboarding with a toast', async () => {
+    fixture.detectChanges();
+    await Promise.resolve();
+    fixture.detectChanges();
+
+    component.newPassword = 'NewPassword123!';
+    await component.setPassword();
+
+    expect(authState.setPassword).toHaveBeenCalledWith('NewPassword123!');
+    expect(status.success).toHaveBeenCalledWith('Your email is verified.');
+    expect(router.navigate).toHaveBeenCalledWith(['/onboarding']);
+  });
+
+  it('does not call setPassword when the password is invalid', async () => {
+    fixture.detectChanges();
+    await Promise.resolve();
+    fixture.detectChanges();
+
+    component.newPassword = 'short';
+    await component.setPassword();
+
+    expect(authState.setPassword).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/app/features/auth/verify-email.component.spec.ts
+++ b/apps/frontend/src/app/features/auth/verify-email.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { VerifyEmailComponent } from './verify-email.component';
 import { AuthStateService } from '../../core/services/auth-state.service';
 import { StatusService } from '../../core/services/status.service';
+import { AuthService } from '@yotara/shared';
 import { ActivatedRoute, Router } from '@angular/router';
 
 describe('VerifyEmailComponent', () => {
@@ -12,6 +13,7 @@ describe('VerifyEmailComponent', () => {
   let authState: {
     verifyEmail: jasmine.Spy;
     setPassword: jasmine.Spy;
+    user: () => Record<string, unknown> | null;
   };
 
   beforeEach(async () => {
@@ -20,6 +22,7 @@ describe('VerifyEmailComponent', () => {
     authState = {
       verifyEmail: jasmine.createSpy('verifyEmail').and.resolveTo({ error: null }),
       setPassword: jasmine.createSpy('setPassword').and.resolveTo(undefined),
+      user: () => null,
     };
 
     await TestBed.configureTestingModule({
@@ -70,12 +73,40 @@ describe('VerifyEmailComponent', () => {
   });
 
   it('shows invalid state when verification fails', async () => {
+    const getProfileSpy = spyOn(AuthService, 'getProfile');
+    getProfileSpy.and.rejectWith(new Error('no session'));
     authState.verifyEmail.and.resolveTo({ error: { message: 'expired' } });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component.state()).toBe('invalid');
+  });
+
+  it('skips password setup and goes to the workspace for an already set-up account', async () => {
+    authState.user = () => ({ emailVerified: true, passwordSetupRequired: false });
     fixture.detectChanges();
     await Promise.resolve();
     fixture.detectChanges();
 
-    expect(component.state()).toBe('invalid');
+    expect(component.state()).toBe('done');
+    expect(component.doneMessage()).toContain('already have an account');
+    expect(router.navigate).toHaveBeenCalledWith(['/']);
+  });
+
+  it('treats a consumed link as success when the profile is already verified', async () => {
+    const getProfileSpy = spyOn(AuthService, 'getProfile');
+    getProfileSpy.and.resolveTo({
+      user: { id: 'u1', email: 'x@example.com', name: 'X', createdAt: 0, emailVerified: true },
+    });
+    authState.verifyEmail.and.resolveTo({ error: { message: 'Token already used' } });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component.state()).toBe('done');
+    expect(component.doneMessage()).toContain('already have an account');
+    expect(router.navigate).toHaveBeenCalledWith(['/']);
   });
 
   it('sets the password and navigates to onboarding with a toast', async () => {

--- a/apps/frontend/src/app/features/auth/verify-email.component.ts
+++ b/apps/frontend/src/app/features/auth/verify-email.component.ts
@@ -151,7 +151,21 @@ export class VerifyEmailComponent implements OnInit {
       return;
     }
 
-    const result = await this.authState.verifyEmail(this.token);
+    let result: Awaited<ReturnType<typeof this.authState.verifyEmail>>;
+    try {
+      result = await this.authState.verifyEmail(this.token);
+    } catch (error) {
+      // A thrown error (network failure, 5xx) must not leave the UI stuck on
+      // "Verifying your email…" — show a recoverable error state instead.
+      this.state.set('invalid');
+      this.error.set(
+        error instanceof Error && error.message
+          ? error.message
+          : 'Something went wrong verifying your email. Please try again.',
+      );
+      return;
+    }
+
     const user = this.authState.user();
     const alreadySetUp =
       !!user && user.emailVerified === true && user.passwordSetupRequired === false;

--- a/apps/frontend/src/app/features/auth/verify-email.component.ts
+++ b/apps/frontend/src/app/features/auth/verify-email.component.ts
@@ -1,0 +1,197 @@
+import { Component, OnInit, inject, signal } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+import { AuthStateService } from '../../core/services/auth-state.service';
+import { StatusService } from '../../core/services/status.service';
+import { passwordPolicyMessage } from './password-policy';
+
+@Component({
+  selector: 'app-verify-email',
+  standalone: true,
+  imports: [FormsModule],
+  template: `
+    <div class="verify-screen">
+      <div class="auth-card">
+        <h1>Verify your email</h1>
+
+        @if (state() === 'verifying') {
+          <p>Verifying your email…</p>
+        }
+
+        @if (state() === 'invalid') {
+          <p class="error-msg">{{ error() }}</p>
+          <button type="button" class="submit-button" (click)="goToLogin()">Back to login</button>
+        }
+
+        @if (state() === 'set-password') {
+          <p class="success-msg">Your email is verified. Choose a password to finish setup.</p>
+
+          <div class="field-group">
+            <label for="new-password">Password</label>
+            <input
+              id="new-password"
+              type="password"
+              [(ngModel)]="newPassword"
+              name="newPassword"
+              placeholder="At least 8 characters"
+              autocomplete="new-password"
+            />
+            @if (passwordError()) {
+              <div class="field-error">{{ passwordError() }}</div>
+            }
+          </div>
+
+          <button
+            type="button"
+            class="submit-button"
+            [disabled]="loading()"
+            (click)="setPassword()"
+          >
+            {{ loading() ? 'Saving…' : 'Set password and continue' }}
+          </button>
+          @if (error()) {
+            <div class="error-msg">{{ error() }}</div>
+          }
+        }
+
+        @if (state() === 'done') {
+          <p class="success-msg">Your email is verified. Taking you to your workspace…</p>
+        }
+      </div>
+    </div>
+  `,
+  styles: [
+    `
+      .verify-screen {
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--surface);
+      }
+      .auth-card {
+        max-width: 400px;
+        width: 100%;
+        padding: 2rem;
+        border-radius: 12px;
+        background: var(--surface-container);
+        box-shadow: 0 8px 30px var(--outline-variant);
+      }
+      h1 {
+        margin: 0 0 1rem;
+        font-size: 1.5rem;
+      }
+      p {
+        margin: 0 0 1rem;
+        color: var(--on-surface-subtle);
+        line-height: 1.5;
+      }
+      .success-msg {
+        color: var(--primary-solid);
+        font-weight: 500;
+      }
+      .error-msg {
+        color: var(--status-overdue);
+      }
+      .field-group {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+        margin-bottom: 1rem;
+      }
+      input {
+        padding: 0.65rem 0.8rem;
+        border: 1px solid var(--outline-variant);
+        border-radius: 8px;
+        background: var(--surface);
+        color: var(--on-surface);
+        font-size: 0.95rem;
+      }
+      .field-error {
+        color: var(--status-overdue);
+        font-size: 0.85rem;
+      }
+      .submit-button {
+        width: 100%;
+        padding: 0.7rem;
+        border: 0;
+        border-radius: 8px;
+        background: var(--primary-solid);
+        color: var(--on-primary);
+        font-size: 1rem;
+        font-weight: 600;
+        cursor: pointer;
+      }
+      .submit-button:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+    `,
+  ],
+})
+export class VerifyEmailComponent implements OnInit {
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private authState = inject(AuthStateService);
+  private status = inject(StatusService);
+
+  state = signal<'verifying' | 'invalid' | 'set-password' | 'done'>('verifying');
+  error = signal('');
+  loading = signal(false);
+  newPassword = '';
+  private token = '';
+
+  async ngOnInit() {
+    this.token = this.route.snapshot.queryParamMap.get('token') ?? '';
+    if (!this.token) {
+      this.state.set('invalid');
+      this.error.set('Missing verification token. The link may be malformed.');
+      return;
+    }
+
+    const result = await this.authState.verifyEmail(this.token);
+    if (result.error) {
+      this.state.set('invalid');
+      this.error.set(
+        (result.error as { message?: string })?.message ??
+          'This verification link is invalid or expired.',
+      );
+      return;
+    }
+
+    this.state.set('set-password');
+  }
+
+  passwordError(): string | null {
+    if (!this.newPassword) {
+      return 'Password is required';
+    }
+    return passwordPolicyMessage(this.newPassword);
+  }
+
+  async setPassword() {
+    const validation = this.passwordError();
+    if (validation) {
+      return;
+    }
+
+    this.loading.set(true);
+    this.error.set('');
+    try {
+      // The account was created with a throwaway placeholder password that the
+      // user never knows; the server sets the real one (verified session).
+      await this.authState.setPassword(this.newPassword);
+      this.state.set('done');
+      this.status.success('Your email is verified.');
+      await this.router.navigate(['/onboarding']);
+    } catch (err) {
+      this.error.set(err instanceof Error ? err.message : 'Failed to set password.');
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  goToLogin() {
+    void this.router.navigate(['/login']);
+  }
+}

--- a/apps/frontend/src/app/features/auth/verify-email.component.ts
+++ b/apps/frontend/src/app/features/auth/verify-email.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
+import { AuthService } from '@yotara/shared';
 import { AuthStateService } from '../../core/services/auth-state.service';
 import { StatusService } from '../../core/services/status.service';
 import { passwordPolicyMessage } from './password-policy';
@@ -55,7 +56,7 @@ import { passwordPolicyMessage } from './password-policy';
         }
 
         @if (state() === 'done') {
-          <p class="success-msg">Your email is verified. Taking you to your workspace…</p>
+          <p class="success-msg">{{ doneMessage() }}</p>
         }
       </div>
     </div>
@@ -74,8 +75,8 @@ import { passwordPolicyMessage } from './password-policy';
         width: 100%;
         padding: 2rem;
         border-radius: 12px;
-        background: var(--surface-container);
-        box-shadow: 0 8px 30px var(--outline-variant);
+        background: var(--surface-card);
+        box-shadow: inset 0 0 0 1px var(--outline-variant);
       }
       h1 {
         margin: 0 0 1rem;
@@ -116,8 +117,8 @@ import { passwordPolicyMessage } from './password-policy';
         padding: 0.7rem;
         border: 0;
         border-radius: 8px;
-        background: var(--primary-solid);
-        color: var(--on-primary);
+        background: var(--primary-gradient);
+        color: hsl(var(--primary-foreground));
         font-size: 1rem;
         font-weight: 600;
         cursor: pointer;
@@ -138,6 +139,7 @@ export class VerifyEmailComponent implements OnInit {
   state = signal<'verifying' | 'invalid' | 'set-password' | 'done'>('verifying');
   error = signal('');
   loading = signal(false);
+  doneMessage = signal('Your email is verified. Taking you to your workspace…');
   newPassword = '';
   private token = '';
 
@@ -150,7 +152,22 @@ export class VerifyEmailComponent implements OnInit {
     }
 
     const result = await this.authState.verifyEmail(this.token);
+    const user = this.authState.user();
+    const alreadySetUp =
+      !!user && user.emailVerified === true && user.passwordSetupRequired === false;
+
+    // A consumed or expired link is not an error for an account that is
+    // already verified and has a password — it means the link did its job.
+    if (alreadySetUp && !result.error) {
+      this.finishAsDone();
+      return;
+    }
+
     if (result.error) {
+      if (await this.hasVerifiedProfile()) {
+        this.finishAsDone();
+        return;
+      }
       this.state.set('invalid');
       this.error.set(
         (result.error as { message?: string })?.message ??
@@ -160,6 +177,28 @@ export class VerifyEmailComponent implements OnInit {
     }
 
     this.state.set('set-password');
+  }
+
+  /**
+   * Fallback check for stale/consumed links: if a session exists and the
+   * profile is verified, the link was already used successfully — never
+   * present that as an error.
+   */
+  private async hasVerifiedProfile(): Promise<boolean> {
+    try {
+      const profile = await AuthService.getProfile();
+      return profile.user.emailVerified === true;
+    } catch {
+      return false;
+    }
+  }
+
+  private finishAsDone() {
+    this.doneMessage.set(
+      'You already have an account with this email — it is verified. Taking you to your workspace…',
+    );
+    this.state.set('done');
+    void this.router.navigate(['/']);
   }
 
   passwordError(): string | null {

--- a/apps/frontend/src/app/features/personal/pages/labels-page.component.spec.ts
+++ b/apps/frontend/src/app/features/personal/pages/labels-page.component.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { signal } from '@angular/core';
 import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
-import { BehaviorSubject, of } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 import { LabelsPageComponent } from './labels-page.component';
 import { LabelService } from '../../../core/services/label.service';
 import { ProjectService } from '../../../core/services/project.service';

--- a/apps/frontend/src/app/features/personal/pages/settings-page.component.ts
+++ b/apps/frontend/src/app/features/personal/pages/settings-page.component.ts
@@ -205,6 +205,19 @@ import { Task, Project, Label, type DataCounts } from '@yotara/shared';
 
         <div class="settings-section">
           <h3 class="section-title">Account</h3>
+          <div class="settings-item">
+            <div class="settings-item-copy">
+              <strong>Email</strong>
+              <span>{{ userEmail() || '—' }}</span>
+            </div>
+            <span class="verified-badge" [class.unverified]="!emailVerified()">
+              @if (emailVerified()) {
+                ✓ Verified
+              } @else {
+                Unverified
+              }
+            </span>
+          </div>
           <button
             type="button"
             class="settings-item settings-link"
@@ -577,6 +590,23 @@ import { Task, Project, Label, type DataCounts } from '@yotara/shared';
         flex: 0 0 auto;
       }
 
+      .verified-badge {
+        font-size: 0.72rem;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--primary-solid);
+        background: var(--primary-soft);
+        padding: 0.3rem 0.6rem;
+        border-radius: 0.5rem;
+        flex: 0 0 auto;
+      }
+
+      .verified-badge.unverified {
+        color: var(--on-surface-subtle);
+        background: var(--surface-container-high);
+      }
+
       .settings-link {
         width: 100%;
         border: 0;
@@ -808,6 +838,7 @@ export class SettingsPageComponent {
   protected readonly projectCount = computed(() => this.dataCounts().projects);
   protected readonly labelCount = computed(() => this.dataCounts().labels);
   protected readonly userEmail = computed(() => this.authState.user()?.email ?? '');
+  protected readonly emailVerified = computed(() => this.authState.user()?.emailVerified ?? false);
 
   protected readonly skipCompleteConfirm = this.preferences.skipCompleteConfirm;
   protected readonly actionNotifications = this.preferences.actionNotifications;

--- a/apps/frontend/src/app/shared/utils/timestamps.spec.ts
+++ b/apps/frontend/src/app/shared/utils/timestamps.spec.ts
@@ -1,5 +1,5 @@
 import { parseCalendarDate, startOfToday } from './timestamps';
-import { DateTime, Settings } from 'luxon';
+import { DateTime } from 'luxon';
 
 describe('parseCalendarDate', () => {
   it('parses date-only strings as local calendar dates', () => {

--- a/docker-compose.hub.yml
+++ b/docker-compose.hub.yml
@@ -4,6 +4,7 @@ services:
     environment:
       DATABASE_URL: /app/apps/api/data/yotara.db
       APP_BASE_URL: ${APP_BASE_URL:-http://localhost:8080/api}
+      FRONTEND_BASE_URL: ${FRONTEND_BASE_URL:-http://localhost:8080}
       TRUSTED_ORIGINS: ${TRUSTED_ORIGINS:-http://localhost:8080}
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET?set a strong BETTER_AUTH_SECRET (openssl rand -base64 32)}
       HOST: 0.0.0.0

--- a/docker-compose.hub.yml
+++ b/docker-compose.hub.yml
@@ -3,13 +3,23 @@ services:
     image: apauldev2/yotara-api:latest
     environment:
       DATABASE_URL: /app/apps/api/data/yotara.db
-      APP_BASE_URL: ${APP_BASE_URL:-http://localhost:8080/api}
+      APP_BASE_URL: ${APP_BASE_URL:-http://localhost:8080}
       FRONTEND_BASE_URL: ${FRONTEND_BASE_URL:-http://localhost:8080}
       TRUSTED_ORIGINS: ${TRUSTED_ORIGINS:-http://localhost:8080}
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET?set a strong BETTER_AUTH_SECRET (openssl rand -base64 32)}
       HOST: 0.0.0.0
       PORT: ${PORT:-3000}
       NODE_ENV: ${NODE_ENV:-production}
+      # Dev mode for a test instance: DEV_MODE=true disables email
+      # verification, logs emails to console, and bypasses anti-abuse. With
+      # NODE_ENV=production it also requires ALLOW_DEV_MODE_IN_PRODUCTION=true
+      # (deliberate double opt-in — dev mode disables auth protections).
+      DEV_MODE: ${DEV_MODE:-}
+      ALLOW_DEV_MODE_IN_PRODUCTION: ${ALLOW_DEV_MODE_IN_PRODUCTION:-}
+      # REQUIRED for production mode: the API refuses to boot without it when
+      # NODE_ENV=production (fail-loud contract). Dev mode ignores it.
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      EMAIL_FROM: ${EMAIL_FROM:-noreply@email.yotara.website}
       CONTENT_SECURITY_POLICY: ${CONTENT_SECURITY_POLICY:-default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'}
     volumes:
       - yotara_api_data:/app/apps/api/data

--- a/docker-compose.hub.yml
+++ b/docker-compose.hub.yml
@@ -6,6 +6,7 @@ services:
       APP_BASE_URL: ${APP_BASE_URL:-http://localhost:8080}
       FRONTEND_BASE_URL: ${FRONTEND_BASE_URL:-http://localhost:8080}
       TRUSTED_ORIGINS: ${TRUSTED_ORIGINS:-http://localhost:8080}
+      TRUST_PROXY: ${TRUST_PROXY:-172.16.0.0/12}
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET?set a strong BETTER_AUTH_SECRET (openssl rand -base64 32)}
       HOST: 0.0.0.0
       PORT: ${PORT:-3000}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       APP_BASE_URL: ${APP_BASE_URL:-http://localhost:8080}
       FRONTEND_BASE_URL: ${FRONTEND_BASE_URL:-http://localhost:8080}
       TRUSTED_ORIGINS: ${TRUSTED_ORIGINS:-http://localhost:8080}
+      TRUST_PROXY: ${TRUST_PROXY:-172.16.0.0/12}
       # REQUIRED: a strong unique secret, e.g. `openssl rand -base64 32`.
       # No default — compose fails fast if BETTER_AUTH_SECRET is unset, and the
       # API also refuses to boot with the old placeholder value.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
       DATABASE_URL: ${DATABASE_URL:-./apps/api/data/yotara.db}
       APP_BASE_URL: ${APP_BASE_URL:-http://localhost:8080/api}
+      FRONTEND_BASE_URL: ${FRONTEND_BASE_URL:-http://localhost:8080}
       TRUSTED_ORIGINS: ${TRUSTED_ORIGINS:-http://localhost:8080}
       # REQUIRED: a strong unique secret, e.g. `openssl rand -base64 32`.
       # No default — compose fails fast if BETTER_AUTH_SECRET is unset, and the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: apps/api/Dockerfile
     environment:
       DATABASE_URL: ${DATABASE_URL:-./apps/api/data/yotara.db}
-      APP_BASE_URL: ${APP_BASE_URL:-http://localhost:8080/api}
+      APP_BASE_URL: ${APP_BASE_URL:-http://localhost:8080}
       FRONTEND_BASE_URL: ${FRONTEND_BASE_URL:-http://localhost:8080}
       TRUSTED_ORIGINS: ${TRUSTED_ORIGINS:-http://localhost:8080}
       # REQUIRED: a strong unique secret, e.g. `openssl rand -base64 32`.
@@ -15,6 +15,17 @@ services:
       HOST: 0.0.0.0
       PORT: ${PORT:-3000}
       NODE_ENV: ${NODE_ENV:-production}
+      # Dev mode for the test instance: set DEV_MODE=true here (or in the
+      # shell) to disable email verification, log emails to console, and
+      # bypass anti-abuse. Because NODE_ENV defaults to production here,
+      # enabling dev mode also requires ALLOW_DEV_MODE_IN_PRODUCTION=true
+      # (deliberate double opt-in — dev mode disables auth protections).
+      DEV_MODE: ${DEV_MODE:-}
+      ALLOW_DEV_MODE_IN_PRODUCTION: ${ALLOW_DEV_MODE_IN_PRODUCTION:-}
+      # REQUIRED for production mode: the API refuses to boot without it when
+      # NODE_ENV=production (fail-loud contract). Dev mode ignores it.
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      EMAIL_FROM: ${EMAIL_FROM:-noreply@email.yotara.website}
       CONTENT_SECURITY_POLICY: ${CONTENT_SECURITY_POLICY:-default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'}
     volumes:
       - yotara_api_data:/app/apps/api/data

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -27,7 +27,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $remote_addr;
     proxy_set_header X-Forwarded-Proto $scheme;
   }
 
@@ -45,7 +45,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $remote_addr;
     proxy_set_header X-Forwarded-Proto $scheme;
   }
 
@@ -60,7 +60,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $remote_addr;
     proxy_set_header X-Forwarded-Proto $scheme;
   }
 }

--- a/docs/email-verification-implementation-log.md
+++ b/docs/email-verification-implementation-log.md
@@ -1,0 +1,41 @@
+# Email verification implementation log
+
+Status: **Complete** — all checklist items from `docs/email-verification-design.md` implemented on `beta-release`, tests green.
+
+## Summary
+
+Implemented the email-first signup + verification + anti-bot flow:
+
+- Verification is required when `NODE_ENV=production` **or** `REQUIRE_EMAIL_VERIFICATION=true` (dev/test override). Default dev/test registration is unchanged.
+- Signup (verification required) collects name + email only; a throwaway placeholder password (`email + 5 random letters`) satisfies Better Auth's password requirement. Login is untouched.
+- Verification link expires in 15 min; clicking it auto-signs-in and lands on a set-password step (`/me/password/set`, no current password required), then onboarding with a "Your email is verified" toast.
+- Anti-bot: hidden `website` honeypot → fake success + 24h IP ban (`SIGNUP_IP_BAN_MS`); 1 resend per 30 min (`email-rate-limit.ts` `'verify'` type); unverified accounts deleted after 24h by a boot + hourly cleanup job (gated on verification being required).
+- Unverified sign-ins return `403 EMAIL_NOT_VERIFIED` without burning a lockout attempt.
+- Email safety: console fallback only in dev/test; production fails loudly without `RESEND_API_KEY`; HTML/attribute escaping in templates; `EMAIL_FROM` defaults to `noreply@email.yotara.website`.
+- Runtime flag: `GET /config` returns `requireEmailVerification`; the frontend renders the right signup form with one build.
+- Settings shows the email with a Verified/Unverified badge.
+
+## Commits
+
+| SHA | Message |
+|:---|:---|
+| `8604d7e` | feat(api): gate email verification by env and harden email sending |
+| `b036849` | feat(api): expose requireEmailVerification runtime flag |
+| `740bf73` | feat(api): verify-resend rate limit and unverified-account cleanup |
+| `ce0eb89` | feat(api): honeypot IP ban and unverified-sign-in handling |
+| `055be45` | feat(auth): email-first signup, verify landing, and set-password endpoint |
+| `d444231` | test(frontend): cover email-first signup and verify-email flow |
+| `cebe7ec` | feat(frontend): show email with a Verified badge in settings |
+
+## Test results
+
+- API: `NODE_ENV=test pnpm exec tsx --test src/**/*.test.ts` → **220/220 pass** (incl. new: /config env gating, honeypot ban, unverified sign-in 403 without lockout burn, verify-resend 30-min cooldown, cleanup gating/age cutoff, email escaping, prod fail-loud without RESEND_API_KEY, set-password endpoint).
+- Frontend: `ng test --no-watch --browsers ChromeHeadless` → **644/644 pass** (incl. new: email-first signup form + check-email screen, honeypot passthrough, verify-email component).
+- `pnpm --filter @yotara/api typecheck`, `@yotara/shared typecheck`, `@yotara/frontend typecheck` — all clean.
+
+## Notes / decisions applied
+
+- No new endpoint for set-password-after-verification beyond `/me/password/set` (the placeholder is random and unrecoverable, so the endpoint must not require the current password; it is gated on an authenticated + email-verified session, or any authenticated session when verification is not required).
+- The unverified-sign-in test runs in a subprocess because the gating is read at module load (env-at-boot contract).
+- `email_sends` CHECK constraint migration recreates the table (transient rate-limit data), matching the existing `login_attempts` migration pattern.
+- Docs (`email-verification-design.md` etc.) remain untracked per instruction.

--- a/docs/email-verification-implementation-log.md
+++ b/docs/email-verification-implementation-log.md
@@ -39,3 +39,20 @@ Implemented the email-first signup + verification + anti-bot flow:
 - The unverified-sign-in test runs in a subprocess because the gating is read at module load (env-at-boot contract).
 - `email_sends` CHECK constraint migration recreates the table (transient rate-limit data), matching the existing `login_attempts` migration pattern.
 - Docs (`email-verification-design.md` etc.) remain untracked per instruction.
+
+## E2E + coverage follow-up (2026-08-12)
+
+### E2E
+
+- The suite had **no coverage of the email-first flow** and the global-setup broke when `REQUIRE_EMAIL_VERIFICATION=true`. Fixed:
+  - `e2e/specs/login/email-first.spec.ts` (new): signs up with email only → check-email screen → reads the verification link from the API log → verify → set password → onboarding. **Skipped when the flag is off** (CI default).
+  - `e2e/global-setup.ts`: mode-aware — legacy password signup (flag off) or email-first verify+set-password (flag on).
+  - `e2e/specs/authenticated/onboarding.spec.ts`: shared mode-aware `signUp` helper.
+- **Key finding**: Better Auth emails a **JWT** verification link and does **not** persist the token in the `verification` table, so the E2E reads the token from the API's console log (`E2E_API_LOG` env).
+- Verified: **77/77 pass** with the flag on; **76 pass + 1 skip** in the default CI mode (the email-first spec correctly skips).
+
+### Unit coverage
+
+- Frontend (`ng test --code-coverage`): **84.16% stmts / 69.58% branch / 80.87% funcs / 85.12% lines**. New auth files: login.component 95.2%, verify-email 94.6%, auth-state.service 88.1%, settings-page 100%.
+- API (`c8`): **94.43% stmts / 79.44% branch / 90.05% funcs / 94.43% lines**. New files: auth-bridge 93.97%, config 100%, blocked-ips 89.47%, email-rate-limit 98.36%, email-cleanup 65.3% → raised to ~90% with lifecycle tests (start/stop/idempotent + orphan-row cleanup).
+

--- a/docs/email-verification-implementation-log.md
+++ b/docs/email-verification-implementation-log.md
@@ -26,12 +26,25 @@ Implemented the email-first signup + verification + anti-bot flow:
 | `055be45` | feat(auth): email-first signup, verify landing, and set-password endpoint |
 | `d444231` | test(frontend): cover email-first signup and verify-email flow |
 | `cebe7ec` | feat(frontend): show email with a Verified badge in settings |
+| `7d6edbd` | docs: note E2E coverage and unit coverage in implementation log |
+| `d89b9bf` | test(e2e): cover email-first signup and make setup mode-aware |
+| `638242a` | test(api): cover cleanup job lifecycle (start/stop/idempotent) |
+| `4052666` | fix(api): remove orphaned rows when cleaning up unverified accounts |
+| `935832b` | fix(frontend): show signup error instead of check-email on failure |
+| `9f12faf` | fix(auth): throttle verification email resends |
+| `087adb4` | fix(auth): route verification links to frontend |
+| `caa2fee` | fix(auth): restrict initial password setup |
+| `ccef0cf` | fix(auth): honor passwordSetupRequired in verify flow |
+| `53aedb0` | fix(auth): route password-reset links to the frontend |
+| pending | fix(auth): harden production secret validation and complete dev-mode/deployment batching |
 
 ## Test results
 
-- API: `NODE_ENV=test pnpm exec tsx --test src/**/*.test.ts` → **220/220 pass** (incl. new: /config env gating, honeypot ban, unverified sign-in 403 without lockout burn, verify-resend 30-min cooldown, cleanup gating/age cutoff, email escaping, prod fail-loud without RESEND_API_KEY, set-password endpoint).
-- Frontend: `ng test --no-watch --browsers ChromeHeadless` → **644/644 pass** (incl. new: email-first signup form + check-email screen, honeypot passthrough, verify-email component).
-- `pnpm --filter @yotara/api typecheck`, `@yotara/shared typecheck`, `@yotara/frontend typecheck` — all clean.
+- API: `pnpm --filter @yotara/api test` → **245/245 pass** (including dev-mode, secret validation, email safety, runtime config, verification, cleanup, and anti-abuse coverage).
+- Frontend: `pnpm --filter @yotara/frontend test` → **653/653 pass**.
+- Repository: `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` — all pass; lint emits existing warnings only.
+- Docker: isolated image build plus `pnpm smoke:docker` through the published nginx port — pass.
+- E2E: CI now passes explicit runtime-config and API-log environment variables and always cleans services; local email-first execution requires running the Angular dev server against the same API port because the default environment points at port 3000.
 
 ## Notes / decisions applied
 

--- a/docs/precheck-beta-release.md
+++ b/docs/precheck-beta-release.md
@@ -29,19 +29,19 @@ for production deployments; configure Resend and a verified `EMAIL_FROM` before 
 `apps/api/src/lib/email.ts` HTML-escapes display names and attribute-escapes URLs; the email
 tests cover special characters. No further code change is required before upload.
 
-### 1.3 Proxy trust assumes exactly one reverse proxy
+### 1.3 Proxy trust is explicitly configured
 
-- `apps/api/src/server.ts:56` sets `trustProxy: 1`; rate limiting keys off `request.ip` (`server.ts:69`).
-- The API binds `0.0.0.0` (`Dockerfile`), and nginx sets `X-Forwarded-For` from the real client IP (`docker/nginx.conf:30`).
+- `apps/api/src/server.ts` trusts only the addresses/CIDRs configured in `TRUST_PROXY`; it defaults to no proxy trust. Rate limiting keys off `request.ip`.
+- The API binds `0.0.0.0` (`Dockerfile`), and bundled nginx overwrites `X-Forwarded-For` with the address it observes (`docker/nginx.conf`).
 
-**For the beta EC2 instance:** only the bundled nginx container must be exposed; port 3000 must not be reachable from outside. If anything else terminates TLS/proxies in front (Caddy, Traefik, an ALB), the hop count changes and `request.ip` may become client-spoofable or the proxy IP.
+**For the beta EC2 instance:** only the bundled nginx container must be exposed; port 3000 must not be reachable from outside. If anything else terminates TLS/proxies in front (Caddy, Traefik, an ALB), configure that proxy's actual address or CIDR in `TRUST_PROXY`.
 
 **Fix before upload**
 
 - On EC2, publish only port 8080; keep the API container port private.
 - Document the exact topology in the deployment notes (one nginx hop, or N hops).
-- If the topology is not exactly "one trusted proxy", replace the blanket `trustProxy: 1` with a trusted-proxy IP range before upload.
-- Add a test with spoofed `X-Forwarded-For` headers to lock in the behavior.
+- Set `TRUST_PROXY` to the actual trusted proxy IP/CIDR for the deployment topology; do not use a blanket hop count.
+- Add or retain tests with spoofed `X-Forwarded-For` headers to lock in the behavior.
 
 ## 2. Strongly recommended before upload
 

--- a/docs/precheck-beta-release.md
+++ b/docs/precheck-beta-release.md
@@ -1,0 +1,129 @@
+# Precheck: beta release
+
+This document is the checklist to work through **before** building and pushing the Docker images that will run on the beta EC2 instance. It is derived from `docs/anti-patterns-audit.md` (findings were verified against the current source on 2026-08-12), plus deployment-specific items for a small single-node EC2 deployment.
+
+The bar for the beta is lower than for a public launch, but the items below are cheap to fix now and expensive to discover on a running instance. Items are grouped by **must fix before upload**, **strongly recommended before upload**, and **decide now** (product/ops policy choices that should not be made implicitly).
+
+## 0. Current baseline (what already holds)
+
+- CI installs with `pnpm install --frozen-lockfile`.
+- Production startup rejects missing, malformed, undersized, placeholder, and obvious structured `BETTER_AUTH_SECRET` values.
+- Protected routes use auth middleware and owner-scoped queries.
+- Search uses parameterized SQL and escapes wildcard characters.
+- API and nginx set security headers on every response.
+- Containers: read-only rootfs, `tmpfs /tmp`, all capabilities dropped, `no-new-privileges`, non-root user.
+- Smoke test (`pnpm smoke:docker`) covers `/`, `/api/health`, `/docs`, `/docs/openapi.json`, and unauthenticated `/api/tasks` → 401.
+
+These stay as the baseline; the list below only adds what is missing.
+
+## 1. Must fix before uploading images
+
+### 1.1 Production email fallback (implemented)
+
+`apps/api/src/lib/email.ts` fails closed outside development/test when `RESEND_API_KEY` is
+missing, and the email tests cover the production guard. Console fallback is not available
+for production deployments; configure Resend and a verified `EMAIL_FROM` before upload.
+
+### 1.2 HTML email templates (implemented)
+
+`apps/api/src/lib/email.ts` HTML-escapes display names and attribute-escapes URLs; the email
+tests cover special characters. No further code change is required before upload.
+
+### 1.3 Proxy trust assumes exactly one reverse proxy
+
+- `apps/api/src/server.ts:56` sets `trustProxy: 1`; rate limiting keys off `request.ip` (`server.ts:69`).
+- The API binds `0.0.0.0` (`Dockerfile`), and nginx sets `X-Forwarded-For` from the real client IP (`docker/nginx.conf:30`).
+
+**For the beta EC2 instance:** only the bundled nginx container must be exposed; port 3000 must not be reachable from outside. If anything else terminates TLS/proxies in front (Caddy, Traefik, an ALB), the hop count changes and `request.ip` may become client-spoofable or the proxy IP.
+
+**Fix before upload**
+
+- On EC2, publish only port 8080; keep the API container port private.
+- Document the exact topology in the deployment notes (one nginx hop, or N hops).
+- If the topology is not exactly "one trusted proxy", replace the blanket `trustProxy: 1` with a trusted-proxy IP range before upload.
+- Add a test with spoofed `X-Forwarded-For` headers to lock in the behavior.
+
+## 2. Strongly recommended before upload
+
+### 2.1 Task updates can self-parent
+
+- Creation rejects `parentId === taskId` (`apps/api/src/services/task-service.ts`); updates do not (`482-493`).
+
+**Fix:** reject `nextParentId === taskId` in the service layer (so every caller gets the invariant) and add a 400 regression test. Cheap to fix now, confusing to debug later.
+
+### 2.2 CI is not a reliable gate for the release
+
+- `.github/workflows/ci.yml`: `continue-on-error: true` on the audit step (46-48) and the whole coverage job (68-70); `fail_ci_if_error: false` on Codecov (86-90).
+
+**Fix before relying on CI to bless the release:** make the audit blocking, remove `continue-on-error` from coverage, and make Codecov fail the job if it is a required check. If coverage is advisory, move it to a separate non-gating workflow instead of silently passing.
+
+### 2.3 Docker smoke CI cleanup (implemented)
+
+The Docker smoke job now tears down its Compose stack with `if: always()` after collecting
+failure logs. The host-path smoke script was also exercised locally against built images.
+
+### 2.4 E2E diagnostics are thin
+
+- Playwright uses `retries: 0`, `trace: 'on-first-retry'`; CI uploads only the HTML report; background API/frontend processes are not cleaned up in an `always()` step.
+
+**Fix:** `retries: process.env['CI'] ? 1 : 0`, `trace: 'retain-on-failure'`, upload `test-results/`, preserve process logs as artifacts, and terminate both background processes in an `always()` step.
+
+## 3. Decide now (product/ops policy — do not leave implicit)
+
+### 3.1 Email verification policy (implemented)
+
+Verification is required in production and can be enabled in dev/test with
+`REQUIRE_EMAIL_VERIFICATION=true`; default dev/test mode remains frictionless. The runtime
+`/config` flag and API tests pin this behavior. Beta deployment still requires the operator
+to verify the intended production environment variables.
+
+### 3.2 Image tags for the beta deploy
+
+- The Hub compose file deploys `latest` tags.
+
+**Decision needed:** for the beta, pull a specific version tag (e.g. `0.72.3`) or the commit SHA, not `latest`, so the running instance is reproducible and rollback is unambiguous. Record which tag is deployed on the EC2 box.
+
+### 3.3 Backups before first deploy
+
+The SQLite DB lives in the `yotara_api_data` volume. **Decide before users exist** how the volume is backed up on a single EC2 instance (e.g. nightly `docker compose exec` sqlite backup or EBS snapshot), and confirm a restore actually works.
+
+## 4. Deferred (fix after beta, not blocking)
+
+These are real findings from the audit but are not needed for a small beta with a handful of users:
+
+- Schema evolution via startup `ALTER TABLE`s instead of Drizzle migrations (`apps/api/src/db/client.ts`) — affects future upgrades; fine for a fresh DB.
+- Cleanup writes on every task request — acceptable at beta scale.
+- Leading-wildcard search — acceptable until data grows; benchmark before switching to FTS5.
+- Missing `CHECK` constraints on domain fields — add with migrations later.
+- Unbounded `JSON.parse` of stored recurrence — legacy-data risk; add read-boundary validation with the migration work.
+- Fixed `sleep 5` before the Docker smoke script — small CI latency, not correctness.
+- `lint:fix` masking failures with `|| true` — developer ergonomics.
+- Broad `^` dependency ranges — keep `frozen-lockfile`; tighten only for high-risk/native deps.
+- Base images pinned to tags, not digests — move to digests with automation after beta.
+- Loading-state timer imbalance risk — concurrency test, not a release blocker.
+
+## 5. Pre-upload checklist (run on the release branch)
+
+- [x] 1.1 production email fallback gated to dev/test
+- [x] 1.2 email templates escape name and URL
+- [ ] 1.3 EC2 topology: only 8080 exposed; `trustProxy` matches reality
+- [ ] 2.1 self-parent update rejected + regression test
+- [ ] 2.2 CI audit/coverage blocking
+- [x] 2.3 Docker smoke CI teardown step
+- [x] 2.4 Playwright logs/artifacts/cleanup configured; run CI verification before upload
+- [x] 3.1 verification policy decided and documented
+- [ ] 3.2 beta image tag chosen (not `latest`)
+- [ ] 3.3 backup plan tested
+- [x] `pnpm format:check && pnpm lint && pnpm typecheck && pnpm test` green
+- [x] `pnpm smoke:docker` green locally
+- [ ] Version tag bumped for the beta release (release workflow) before push
+
+## 6. Post-upload verification on the EC2 instance
+
+- [ ] `BETTER_AUTH_SECRET` set to a fresh random value on the instance (never committed)
+- [ ] Sign up → verification/confirmation email arrives (or is deliberately disabled per 3.1)
+- [ ] Password reset flow works and the reset link is **not** present in `docker compose logs`
+- [ ] Sign in, create a task, complete it, archive it
+- [ ] `/api/health` returns ok; `/docs` reachable only from the LAN/SSH tunnel
+- [ ] DB file exists inside the volume after writes; backup script runs
+- [ ] Restart the stack (`docker compose down && up`) and confirm data persists

--- a/docs/security-hardening-plan.md
+++ b/docs/security-hardening-plan.md
@@ -239,6 +239,35 @@ the full API surface to anyone. Restrict it to local/LAN access by default.
   proxy with auth, not open it to the internet. (Alternative: drop the `/docs` proxy
   entirely and only serve Swagger when running the API container directly for dev.)
 
+## 5. BETTER_AUTH_SECRET hardening (implemented)
+
+The production secret contract is now explicit and format-agnostic within the two secure
+OpenSSL workflows documented by the project:
+
+- `NODE_ENV=production` and other non-exempt environments require `BETTER_AUTH_SECRET`.
+- The value must be canonical hexadecimal or standard padded Base64 representing at least
+  32 decoded bytes. `openssl rand -hex 32` and `openssl rand -base64 32` produce accepted
+  values.
+- Missing values, the development placeholder, plain-text passphrases, malformed
+  encodings, whitespace, undersized encodings, repeated values, and obvious sequential values are
+  rejected before the API serves traffic.
+- `development` and `test` intentionally allow a missing secret for local and CI flows.
+- Format and structural checks cannot prove that a value was generated randomly; deployment
+  operators must still use a cryptographically secure random generator and keep the value
+  unique and secret.
+
+Implementation and regression coverage:
+
+- `apps/api/src/lib/auth-secret.ts` is the shared validator used by both auth configuration
+  and server bootstrap.
+- `apps/api/src/lib/auth-secret.test.ts` covers accepted encodings, malformed/structured
+  values, environment exemptions, and production/staging behavior.
+- `apps/api/src/lib/security-audit.test.ts` executes the real server entry point in a child
+  process, verifies predictable values fail without hanging, and verifies a valid generated
+  secret reaches `/health`.
+- Deployment guidance is synchronized in `apps/api/.env.example`, `DOCKER.md`, `README.md`,
+  and `PROJECT_README.md`.
+
 ## Non-action (documented trade-offs, do not fix now)
 - **Account enumeration on signup** — Better Auth returns `USER_ALREADY_EXISTS` when an
   email is taken. Suppressing it cleanly requires a custom flow; the standard
@@ -265,5 +294,7 @@ the full API surface to anyone. Restrict it to local/LAN access by default.
 - `curl -X POST .../auth/sign-up/email -d '{"password":"short"}'` → 400 with a
   password-too-short error; `{"password":"alllower1"}` → 400 complexity error;
   a compliant password → 200.
-- Confirm `NODE_ENV=production` makes the api container refuse the default
-  `BETTER_AUTH_SECRET` (already covered by `security-audit.test.ts` boot test).
+- Confirm `NODE_ENV=production` makes the API refuse missing, placeholder, malformed,
+  undersized, repeated, and sequential `BETTER_AUTH_SECRET` values, while a canonical
+  generated secret reaches `/health` (covered by `auth-secret.test.ts` and
+  `security-audit.test.ts`).

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "prebuild": "pnpm version:gen",
     "pretest": "pnpm version:gen",
     "dev": "node scripts/dev.mjs",
+    "dev:email": "DEV_MODE=false REQUIRE_EMAIL_VERIFICATION=true node scripts/dev.mjs",
     "build": "pnpm -r build",
     "start": "pnpm -r start",
     "lint": "eslint . && pnpm -r lint",

--- a/packages/shared/src/auth.ts
+++ b/packages/shared/src/auth.ts
@@ -40,6 +40,7 @@ export interface ProfileResponse {
     name: string;
     image?: string | null;
     emailVerified?: boolean;
+    passwordSetupRequired?: boolean;
     createdAt: string | number;
     updatedAt?: string | number;
     workspaceMode?: WorkspaceMode | null;

--- a/packages/shared/src/auth.ts
+++ b/packages/shared/src/auth.ts
@@ -63,18 +63,35 @@ export const AuthService = {
   getConfig: async () => {
     return await request<ClientConfig>('/config');
   },
+  verifyEmail: async (token: string) => {
+    return await getAuthClient().verifyEmail({ query: { token } });
+  },
+  sendVerificationEmail: async (email: string) => {
+    return await getAuthClient().sendVerificationEmail({ email });
+  },
+  setPassword: async (newPassword: string) => {
+    return await request<{ ok: true }>('/me/password/set', {
+      method: 'POST',
+      body: JSON.stringify({ newPassword }),
+    });
+  },
   signIn: async (email: string, password: string) => {
     return await getAuthClient().signIn.email({
       email,
       password,
     });
   },
-  signUp: async (email: string, password: string, name: string) => {
-    return await getAuthClient().signUp.email({
+  signUp: async (email: string, password: string, name: string, website = '') => {
+    // The honeypot "website" field is sent so the auth bridge can detect bots.
+    // Better Auth's client type is strict; the server accepts and strips it.
+    const authClient = getAuthClient();
+    type SignUpBody = Parameters<typeof authClient.signUp.email>[0];
+    return await authClient.signUp.email({
       email,
       password,
       name,
-    });
+      website,
+    } as unknown as SignUpBody);
   },
   signOut: async () => {
     return await getAuthClient().signOut();

--- a/packages/shared/src/auth.ts
+++ b/packages/shared/src/auth.ts
@@ -55,7 +55,14 @@ export interface DataCounts {
   labels: number;
 }
 
+export interface ClientConfig {
+  requireEmailVerification: boolean;
+}
+
 export const AuthService = {
+  getConfig: async () => {
+    return await request<ClientConfig>('/config');
+  },
   signIn: async (email: string, password: string) => {
     return await getAuthClient().signIn.email({
       email,

--- a/packages/shared/src/auth.ts
+++ b/packages/shared/src/auth.ts
@@ -58,6 +58,7 @@ export interface DataCounts {
 
 export interface ClientConfig {
   requireEmailVerification: boolean;
+  devMode: boolean;
 }
 
 export const AuthService = {

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -27,6 +27,11 @@ function loadEnvFile(filePath) {
 
 loadEnvFile('apps/api/.env');
 
+// Local dev is frictionless by default: dev mode is on unless .env (or the
+// shell) explicitly sets DEV_MODE=false. Flip to the full email-first flow
+// with real Resend emails via `pnpm dev:email`.
+process.env['DEV_MODE'] ??= 'true';
+
 const processes = [
   { name: 'frontend', args: ['--filter', '@yotara/frontend', 'dev'] },
   { name: 'api', args: ['--filter', '@yotara/api', 'dev'] },

--- a/scripts/docker-smoke.sh
+++ b/scripts/docker-smoke.sh
@@ -1,51 +1,32 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Smoke test that runs against the published host port (via nginx), so the
+# real routing path — host -> nginx -> containers — is exercised. Previously
+# the checks fetched from INSIDE the containers with `docker compose exec`,
+# which never tested port publishing or the nginx proxy config.
 base_url="${DOCKER_SMOKE_BASE_URL:-http://localhost:8080}"
 attempts="${DOCKER_SMOKE_ATTEMPTS:-60}"
 delay_ms="${DOCKER_SMOKE_DELAY_MS:-1000}"
 sleep_seconds="$(awk "BEGIN { printf \"%.3f\", ${delay_ms} / 1000 }")"
 
-docker_request() {
-  local service="$1"
-  local url="$2"
-  local attempt output status body output_file
+# Fetch a URL from the host. Prints "STATUS" on the first line and the body
+# after it. Retries while the stack is still starting (curl errors / 502).
+host_request() {
+  local url="$1"
+  local attempt status output_file
   output_file="$(mktemp)"
 
   for ((attempt = 1; attempt <= attempts; attempt++)); do
-    if ! docker compose ps "$service" --format json | grep -q '"State":"running"'; then
-      if [[ "$attempt" -eq "$attempts" ]]; then
-        printf 'Service "%s" is not running. Logs:\n' "$service" >&2
-        docker compose logs "$service" >&2
-      fi
-      sleep "$sleep_seconds"
-      continue
-    fi
-
-    if docker compose exec -T "$service" node -e "
-        const url = process.argv[1];
-        fetch(url)
-          .then(async (response) => {
-            console.log('STATUS:' + response.status);
-            console.log('BODY:');
-            process.stdout.write(await response.text());
-          })
-          .catch((error) => {
-            console.error(error instanceof Error ? error.message : String(error));
-            process.exit(1);
-          });
-      " "$url" >"$output_file"; then
-      output="$(cat "$output_file")"
-      status="$(grep '^STATUS:' <<<"$output" | head -n1 | cut -d: -f2)"
-      body="$(tail -n +3 <<<"$output")"
-
+    if status="$(curl -sS -o "$output_file" -w '%{http_code}' "$url" 2>/dev/null)"; then
       if [[ "$status" == "502" && "$attempt" -lt "$attempts" ]]; then
         sleep "$sleep_seconds"
         continue
       fi
 
+      printf '%s\n' "$status"
+      cat "$output_file"
       rm -f "$output_file"
-      printf '%s\n%s' "$status" "$body"
       return 0
     fi
 
@@ -59,53 +40,43 @@ docker_request() {
   return 1
 }
 
-api_response() {
+check() {
   local path="$1"
-  docker_request api "http://localhost:3000${path}"
+  local expected_status="$2"
+  local url="${base_url}${path}"
+  local result status body
+
+  result="$(host_request "$url")"
+  status="$(head -n 1 <<<"$result")"
+  body="$(tail -n +2 <<<"$result")"
+
+  [[ "$status" == "$expected_status" ]] || {
+    printf 'Expected %s to return %s, got %s\n' "$url" "$expected_status" "$status" >&2
+    exit 1
+  }
+
+  printf '%s\n' "$body"
 }
 
-frontend_response() {
-  docker_request api 'http://frontend/'
-}
-
-result="$(frontend_response)"
-body="${result#*$'\n'}"
+body="$(check '/' 200)"
 grep -q '<app-root>' <<<"$body" || {
   printf 'Frontend root page did not include the app root placeholder\n' >&2
   exit 1
 }
 
-result="$(api_response '/health')"
-status="${result%%$'\n'*}"
-body="${result#*$'\n'}"
-[[ "$status" == "200" ]] || {
-  printf 'Expected /api/health to return 200, got %s\n' "$status" >&2
-  exit 1
-}
+body="$(check '/api/health' 200)"
 grep -q '"status":"ok"' <<<"$body" || {
   printf 'API health did not report ok\n' >&2
   exit 1
 }
 
-result="$(api_response '/docs')"
-status="${result%%$'\n'*}"
-body="${result#*$'\n'}"
-[[ "$status" == "200" ]] || {
-  printf 'Expected /docs to return 200, got %s\n' "$status" >&2
-  exit 1
-}
+body="$(check '/docs' 200)"
 grep -q 'Swagger UI' <<<"$body" || {
   printf 'Docs page did not look like Swagger UI\n' >&2
   exit 1
 }
 
-result="$(api_response '/docs/openapi.json')"
-status="${result%%$'\n'*}"
-body="${result#*$'\n'}"
-[[ "$status" == "200" ]] || {
-  printf 'Expected /docs/openapi.json to return 200, got %s\n' "$status" >&2
-  exit 1
-}
+body="$(check '/docs/openapi.json' 200)"
 grep -q '"openapi":"3.1.0"' <<<"$body" || {
   printf 'OpenAPI document did not report version 3.1.0\n' >&2
   exit 1
@@ -115,13 +86,7 @@ grep -q '"/tasks"' <<<"$body" || {
   exit 1
 }
 
-result="$(api_response '/tasks')"
-status="${result%%$'\n'*}"
-body="${result#*$'\n'}"
-[[ "$status" == "401" ]] || {
-  printf 'Expected /api/tasks to return 401, got %s\n' "$status" >&2
-  exit 1
-}
+body="$(check '/api/tasks' 401)"
 grep -q '"Unauthorized"' <<<"$body" || {
   printf 'Unauthorized task response did not match expected shape\n' >&2
   exit 1

--- a/scripts/generate-version.test.mjs
+++ b/scripts/generate-version.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import { readFileSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, '..');
@@ -12,7 +12,7 @@ const outputPath = join(rootDir, 'apps/frontend/src/app/core/constants/version.t
 
 test('Version Generator Script (Final Polish)', async (t) => {
   await t.test('should execute without error', () => {
-    const output = execSync(`node ${generatorPath}`).toString();
+    const output = execFileSync(process.execPath, [generatorPath]).toString();
     assert.match(output, /✅ Version generated:/);
   });
 


### PR DESCRIPTION
### **User description**
## Description

Pre-release hardening for the beta deployment (branch `beta-release` → `main`). This PR makes email verification mandatory in production with an email-first signup flow, adds layered anti-bot / anti-abuse controls, introduces a dev-mode switch for frictionless local and test-instance development, hardens deployment secrets and CI, and fixes several auth flows that dead-ended in production. See `docs/precheck-beta-release.md` for the derived checklist and `docs/email-verification-implementation-log.md` for the implementation history.

Key behavior change: in `NODE_ENV=production` (the Docker Compose default), signup is now email-only (name + email) and sign-in is blocked (`403 EMAIL_NOT_VERIFIED`) until the emailed verification link is used. Dev/test behavior is unchanged unless `REQUIRE_EMAIL_VERIFICATION=true`, and `DEV_MODE=true` re-enables a frictionless flow on the test instance (with an explicit double opt-in).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Test coverage improvement
- [ ] Performance improvement
- [ ] Refactoring (code improvement with no functional change)

## Related Issue

N/A — pre-release hardening item; no issue tracked. Work is derived from the security audit noted in `docs/precheck-beta-release.md`.

Closes: # (none)

## Roadmap Reference

Beta release prep (MVP roadmap, release polish). Image tags and backup procedures for the EC2 deployment are called out in the precheck doc (decisions still pending, see Additional Notes).

## Changes Made

**Email verification (production-required)**
- Verification gated by `NODE_ENV=production || REQUIRE_EMAIL_VERIFICATION=true` (single source of truth in `emailVerificationRequired()`, `apps/api/src/lib/auth.ts`)
- Email-first signup: name + email only, hidden `website` honeypot generated by the frontend, check-your-inbox screen with resend; throwaway placeholder password is never shown or auto-logged-in
- 15-minute verification token expiry, auto-sign-in after verification; new `/verify-email` frontend route (token → set-password → onboarding)
- `/me/password/set` sets the initial password once, guarded by the new `passwordSetupRequired` flag (set only at verified-email signup; second call is `403`)
- `GET /config` runtime flag so one frontend build renders the correct signup form

**Anti-bot / anti-abuse**
- Honeypot trigger → 24h IP ban (`SIGNUP_IP_BAN_MS`, `blocked_ips` table) with fake success so bots can't detect the trap; banned IPs get `403` on auth endpoints
- Unverified sign-in returns distinct `403 EMAIL_NOT_VERIFIED` without burning login-lockout attempts
- Verification resend throttled to once per 30 min (`'verify'` email type); hourly + boot cleanup job deletes unverified accounts >24h (gated on the policy, deletes all related rows in a transaction)
- `BETTER_AUTH_SECRET` boot validation: canonical hex/Base64 ≥32 bytes only — placeholders, plain passphrases, malformed or structured values refuse to boot in production
- Wildcard origins refused at boot (would disable origin/CSRF checks)

**Email safety**
- Console email fallback (with verification/reset links) confined to dev/test; production fails loudly without `RESEND_API_KEY` — links can never leak into container logs
- HTML-escaped names + attribute-escaped URLs in templates; `EMAIL_FROM` default `noreply@email.yotara.website`

**Dev mode (`docs` + code)**
- `DEV_MODE` env + `apps/api/dev-mode.json`: bypasses verification, logs emails to console, skips rate limits / lockout / IP bans; in production requires `ALLOW_DEV_MODE_IN_PRODUCTION=true` (deliberate double opt-in); frontend shows a DEV MODE badge on localhost only

**Link routing fixes**
- Verification and password-reset emails now point directly at the Angular app (`/verify-email?token=…`, `/reset-password?token=…` via `FRONTEND_BASE_URL`); token consumption unchanged — previously reset links dead-ended on the API redirect route with `INVALID_TOKEN`

**Frontend**
- Settings shows the email with a Verified/Unverified badge; verify-email component recovers from network/5xx errors instead of hanging; signup errors surface instead of showing the check-email screen

**CI / Docker**
- E2E: mode-aware global-setup, new email-first spec (76 pass + 1 skip; also verified 77/77 with the flag on), diagnostics artifacts (logs, traces, screenshots) uploaded on every run, background processes killed in an `always()` step
- Docker smoke rewritten to hit the published host port through nginx (real routing path); stack torn down via `if: always()`
- `docker-api-native` (amd64/arm64) now boots the API with the dev-mode double opt-in — production signup is email-first and returns no session cookie, so the smoke's authenticated flow needs dev mode; also proves the image boots with no email provider configured
- `APP_BASE_URL` no longer carries the `/api` suffix (nginx strips it before proxying); `dev-mode.json` baked into the image; `RESEND_API_KEY` / `EMAIL_FROM` passthrough in both compose files

**Docs**
- `docs/precheck-beta-release.md` (new), `docs/email-verification-implementation-log.md` (new), `docs/security-hardening-plan.md`, `DOCKER.md`, `PROJECT_README.md`, `.env.example` updates

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing completed

### Verification Steps

All run locally on this branch; details in `docs/email-verification-implementation-log.md`:

1. `pnpm format:check && pnpm lint && pnpm typecheck` — clean (0 errors; 281 pre-existing style warnings)
2. `pnpm test` — API 245/245 pass; frontend suite green
3. `pnpm test:coverage` — API 94.4% stmts, frontend 84.2% stmts
4. `pnpm build` — API + shared + frontend production bundles build clean
5. Playwright e2e (API + frontend on fresh ports, as CI does) — **76 passed, 1 skipped**
6. `pnpm smoke:docker` — host-level checks through nginx (`/`, `/api/health`, `/docs`, openapi, unauthenticated `/api/tasks` → 401) against `NODE_ENV=production` stack with the strong-secret + fail-loud boot contract
7. `pnpm smoke:docker:api` — native better-sqlite3 + signup → session → DB-backed task create/list, verified on **both linux/arm64 and linux/amd64 images**
8. Production boot rejection verified: missing/placeholder/plain-text `BETTER_AUTH_SECRET` and missing `RESEND_API_KEY` refuse to start (unit + subprocess tests)

### Known bug found & fixed during verification

The `docker-api-native` CI job would have failed: the smoke script expected signup to return a session cookie, but production signup is email-first. Fixed inside `e0696a2` by running that job with the dev-mode opt-in.

## Screenshots or Demo

No screenshots — the complete authenticated email-first flow (signup → verify email → set password → onboarding → task usage) is exercised by the Playwright e2e suite (76 tests).

## Contributor License Agreement

By submitting this PR, you agree to the [Yotara CLA](https://github.com/apauldev/Yotara/blob/main/CLA.md).

- [x] I have read and agree to the Yotara Contributor License Agreement
- [x] I have signed-off my commits (`git commit -s`) to certify the Developer Certificate of Origin

## Checklist

- [x] Code follows the project style and conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have verified that this PR is against the correct branch (`main`)

## Additional Notes

- **DCO**: commits before the DCO convention (the last six: `087adb4`→`e0696a2`) lack individual `Signed-off-by` trailers; `8b8459e chore: add DCO sign-off for Developer Certificate of Origin` (empty) was added per the repo precedent (`8eaac1a`). If branch protection requires a DCO bot to pass on every commit, those six need an interactive rebase with `-s` instead.
- **Known-open precheck items** (from `docs/precheck-beta-release.md`, intentionally not shipped): task update can still self-parent (creation rejects it; updates don't); CI audit/coverage jobs remain non-gating (`continue-on-error: true`); beta image tag and backup plan are ops decisions to make before deploy.
- **Verified keys in CI are test-only** (`903d44f7…f14214`): canonical 32-byte value used to pass the boot validator, never used for production signing; a fresh `openssl rand -base64 32` secret is required on the beta instance.
- Version tag not bumped (0.72.3 unchanged); bump + release workflow is expected on merge.


___

### **PR Type**
Enhancement, Bug fix, Tests, Documentation


___

### **Description**
- Email-first signup with mandatory verification
  - Gated by `NODE_ENV=production` or `REQUIRE_EMAIL_VERIFICATION=true`
  - 15-minute token expiry, auto-sign-in after verification

- Dev mode bypass for anti-abuse guards
  - Bypasses email rate limits, login lockout, IP bans
  - Console email fallback, forces email verification off

- Honeypot IP ban and response normalization
  - Hidden website field bans IP for 24h, returns fake success
  - Normalizes 403 `EMAIL_NOT_VERIFIED` to generic 401

- Harden secrets, email sending, and cleanup
  - Validate `BETTER_AUTH_SECRET`, fail on missing `RESEND_API_KEY` in production
  - Delete unverified accounts older than 24h, add verify-email component


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Frontend["Frontend: Login, VerifyEmail"] --> API["API: Auth Bridge, Rate Limit"]
  API --> Auth["Better Auth: Email Verification"]
  Auth --> Email["Email Service: Resend/Console"]
  DevMode["Dev Mode"] -->|bypass| Auth
  DevMode -->|bypass| Email
  DevMode -->|bypass| API
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>auth.ts</strong><dd><code>Configure email verification gating and password setup</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-194eed7921891a0d635a058cb06dcb6b74e812425b79dbb5395bbb98d6acd089">+62/-21</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>auth-bridge.ts</strong><dd><code>Add honeypot IP ban and normalize auth responses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-8a17065c4cd613a3fb9d864036ae8e213cbe597263a4ad1b0433bb54077c1c31">+71/-16</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>email.ts</strong><dd><code>Harden email sending with escaping and dev mode fallback</code>&nbsp; </dd></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-41ae9a064f2b70f40e0f9f63e48fb64f218b5c229917c88096762052bea1f617">+70/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dev-mode.ts</strong><dd><code>Implement dev mode bypass for anti-abuse guards</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-c70dba5d1d3f64d1874b1e34b3791b02f87011f96b5a853ae785ef3247ba9d81">+130/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>login.component.ts</strong><dd><code>Add email-first signup and dev mode badge</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-f5bdf590e4a8f351c8c862f83f1418b5d9f171cc3ea37880cccd963ca769d600">+85/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>verify-email.component.ts</strong><dd><code>Create verify email and set password component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-5dd64ccd5f57e22e39a933854ac784cc5002794e581e4d0d76f3b6bc139a121b">+250/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>auth-secret.ts</strong><dd><code>Implement strong auth secret validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-d249d14e5173fe4ed86c1228e65114b431fac17db020df9b7d91433f19e313f5">+88/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>email-cleanup.ts</strong><dd><code>Implement unverified account cleanup job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-0d059150c637c83d6997ccd5e02d7ed98615abb428959b2516baf65e6b04b113">+103/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>blocked-ips.ts</strong><dd><code>Implement IP ban for honeypot triggers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-cdbec94cac7d45f85d94938cd311822c383eb3d005c932dc9433f1e736bf6f56">+45/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.ts</strong><dd><code>Expose runtime config with email verification flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-b8e5bb71c1c3a4d36f40aee9c23f4ed0c1bf4b25eec96085d3fb4b0af5b918c1">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>auth.test.ts</strong><dd><code>Add tests for email verification and dev mode bypass</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-51cd3d380cfbeb5d8208155f5b810ac210f9c284163af853b840dceedc01d2f7">+434/-15</a></td>

</tr>

<tr>
  <td><strong>security-audit.test.ts</strong><dd><code>Add tests for auth secret validation and boot</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-93fd0348650816cfe1ff9e9cd3104d9624e81c1c6d5547ca7611ca0d924a8f2f">+130/-19</a></td>

</tr>

<tr>
  <td><strong>email.test.ts</strong><dd><code>Add tests for email rate limits and escaping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-ddf1f70df6da097d1d3ecf4af0fc1e5c3665be448103096b718971fc2f3163d5">+146/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dev-mode.test.ts</strong><dd><code>Add tests for dev mode configuration parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-9d851c16a99a3438e90cc32b4b6b9c062ed895945c911941e2bfb04d88453519">+157/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>auth-secret.test.ts</strong><dd><code>Add tests for auth secret validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-41c7511c0af67f1bd9423fe3c95e6c1c4b6c6b768bc9622c25e2d78714ffed82">+123/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>email-cleanup.test.ts</strong><dd><code>Add tests for unverified account cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-c68c645fcb0cfd2ef83097bb5b6f9cecdc3742fd977f661f9ab101ce383f2ead">+143/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>verify-email.component.spec.ts</strong><dd><code>Add component tests for verify email flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-4cb6884c34d29600a0cb49493ce5af7856803ae5e059d84ea4c7cafb60aa5e31">+157/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>login.component.spec.ts</strong><dd><code>Add tests for email-first signup and dev badge</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-2dcd9aba9f21d1417aed1e98c805d3d4fe4d44e8d97cff97bd830d2cd21038fb">+158/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>rate-limit.test.ts</strong><dd><code>Add tests for trusted proxy rate limiting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-50850bde35bfa1e8e28a599950f5fde57b9b39bb771e3c6d013fee7a72e1f02b">+86/-35</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>server.ts</strong><dd><code>Bootstrap with secret validation and trusted proxy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-3504cff00dc0b301e00da4235ed65736b5fd11064dd71e70f2cca2e4f00f77eb">+20/-19</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>53 files</summary><table>
<tr>
  <td><strong>ci.yml</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+51/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pr-agent.yml</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>.gitleaks.toml</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-f40ac94aac00bf364ae4ebef5689f7a2b61d63788030902c529d48d6d7d30ffc">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>commit-msg</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-292bac03df29207ee254ba91cfc30951b10c50c0a9fff3a0768778cebe5f4c4a">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DOCKER.md</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-972512ed94fce217ace10a2303390c321d822f967f2f008c353fb5f57152b7d0">+26/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PROJECT_README.md</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-f575c06961db4da985b0a1345eb9dac64043ce102659b06b00a9a7a79e68ecee">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>.env.example</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-0ab7147cd8ad1eddcd936d4014fc9778eb565a51aed784bbdd32ffcba52cf22b">+31/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-9ada278a9adf2846ef744063b304ed43826d904a8e1729669a1035ee26e036c6">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dev-mode.json</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-94f6faec89c9b194bf7245651f4dc9ee6e49cb2a77ac09b37da1d0ffde382eaf">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>client.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-c98bf92a63cb7e172c1366205c9796ec8ad5bf409fdc46120c707288194fb5f4">+50/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>login-attempts-migration.test.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-f3e7eef4d5aa929386359f4bcb8baeb85fc2d93a6e659086c9f865b625d2bfa2">+42/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>schema.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-cf118e957cab3dc2d4a6d93927c9d823ff500be7d29d635965fb390fb98f29e4">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>openapi.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-176b8ad6d77b4f95047f5887bbdb70e096be17e228129ecc7670f42b126f8f42">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>auth-origins.test.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-d549e24f601be07786b393724665416175b4aafb70c19d5c5c686a13f9a3a797">+70/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>auth-origins.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-38efece3ab66215a739fe070502749c182c8aa2e4da84d887a58f560e487fa10">+69/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>email-rate-limit.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-b91cb97461f7d63bab0dfb21da19368ecd32fd575e9acfa60881bc0bd4682011">+24/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>login-lockout.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-e7d87ba52860c1e2c1e503e5e654b4eb044e273ae0b0c14ad9c158ac98149387">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>public-user.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-4c22c2f071c691e66a49cb881bab8b26f15a237cefc2896ed3ae5110d42d9157">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>trusted-proxy.test.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-2f2db3379823a82468bb4e14b749f400554a56548d708507a4a61329d770e804">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>trusted-proxy.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-5007e9679356176db9bd12c8680230e9429ebfb964ec9bf07ca5cec2392a8ec8">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>me.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-c7df6b2b7baa5e943b8611bbe0f1b67c5b70601d86e297b04faaac24178503b8">+68/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>password-setup-signup.script.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-2b7f00c7147779a878048e26336542fa53d07ae5b9a9fb3435d06bb6f5a0d21a">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>unverified-signin.script.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-e0c8959bfa29ed8f7205329f19b53cf8e083b0724b46b05329cffce9a111e322">+53/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>user-service.test.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-3d1aadfaf6817495320c3ec15ad38d2d4b6d620bab844cdd90754ca98c78284c">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>user-service.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-1b3385178e84f73d3ace2eb6fb542f3931e19a9557fe82c74c4aef40d3560cab">+45/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PLAN.md</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-57f2757f8328cb6c0676a875d542be1653dec468e9d746d14759830804977d1e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>auth.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-86ed2bd53bc7b316dd19129b412cae8220b67c3df1ae3da46138bf5768c03a1a">+42/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>global-setup.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-a5aee0c76053bcda10d336b8ba5d2f3bf51574603eb0f00da43dc7297743f2ad">+50/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>notifications.spec.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-7cc18d09ed8e104fcf939bb57a0b04ec3282b604580e56ef28ec07dafd5ec39d">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>onboarding.spec.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-bb7a059424d9131585c01771fc0c61208cb34fb71125dc5eea99c791f275a323">+51/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>email-first.spec.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-943e81d5c37898ab71d5e3df9f8f3ef099e4a8258baba5a1e753da5fb82e13d4">+68/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>playwright.config.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-6334b404ba03d16543616b22a47d35cecfa41d3f6727f6f826c8ed415681482f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app.config.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-1f4f9dc4ade6cb753d3932ce8928674f4e706f73c1377d5fc78ad499f5cf514f">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app.routes.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-8ce2ae75854edcc086460c3a530084d4dd7f6259889413da8b67ba8705f8a9a5">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>auth-state.service.spec.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-b000ab1c32743227089a2fc374297479996fc3a1f2b4b51f246e91a35dcff3a1">+62/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>auth-state.service.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-67c976234350ce3a8e644ab9006ea3a3b0188f6240c4f38034996b7a1203e8b4">+51/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>login.component.html</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-89b2e85b6287a3ab5bd3894f322ae63070ea77d68109f88e4b91b148cb9019d2">+124/-79</a></td>

</tr>

<tr>
  <td><strong>login.component.scss</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-fc0df902f1ba3f87e3f75f33f7d4d27a7638bfe1725f7cb17ab022fb5fd04491">+55/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>labels-page.component.spec.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-c3c84a91678bb37c04b5584a8caa4c4916d5fccb02c63079fcf7013048e8d366">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>settings-page.component.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-c8c41f8b2bd0c8a02de9f97ffa3440d5feb7d527399de6737f01a99ed95bee2b">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>timestamps.spec.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-d7e4f580ca7effada3babee2d80146235ded2d0fe2d1fb7fa90eae9cbe3138e9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.hub.yml</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-832b611d39bcad2ee976eb8bbc3ace82a3364132d7b10cb1e775976e3a342d5c">+13/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.yml</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+14/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>nginx.conf</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-fe579aa58b5146f19eeb285be0d8f90e9498ef94194c7e62cf6fdc6c6cccaf2e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>email-verification-implementation-log.md</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-a5ba6a6deb61f24822b8bade2a9f2ff58f2f2b8fb9960096c4f51eef18512c0c">+71/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>precheck-beta-release.md</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-d707dda4257c459724ca96e41631c7f7b65968df9d0630ab39b42b2d5b7b8b3c">+129/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>security-hardening-plan.md</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-3110b315cd4cd90dbf2f1aec8f68f90fa3ebce17f05b7dc8f6112157877c3658">+33/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>package.json</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>auth.ts</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-c820f130a3bfe91eaf102453cac85e6586e10c2d2ee37d7f990bb8f9315b0982">+29/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dev.mjs</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-0559901a4c3b5be9b8257debd3cd795b0424df2de22427404d0c1c82beb8311b">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docker-smoke.sh</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-1b6740ecbc8e477fdd0a1a97700876e56da4d495c7002983fd2b49e26128f98e">+31/-66</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>generate-version.test.mjs</strong></td>
  <td><a href="https://github.com/apauldev/Yotara/pull/348/files#diff-77eb50bf3ae71fab29d8d82b06178dca8b804fdeabfa066ddf07836de89918df">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

